### PR TITLE
remove unused lines from bootstrap.ps1

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -14,6 +14,9 @@ param(
 
 Import-Module (Join-Path $PSScriptRoot "build" "conda-utils.psm1");
 
+# Enable conda hook
+Enable-Conda
+
 # Get default value for PackageDirs by searching for environment.yml files
 if ($null -eq $PackageDirs) {
   $PackageDirs = Get-ChildItem -Path $PSScriptRoot -Recurse -Filter "environment.yml" | Select-Object -ExpandProperty Directory | Split-Path -Leaf

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -32,7 +32,3 @@ foreach ($PackageDir in $PackageDirs) {
         & (Join-Path $PSScriptRoot build create-env.ps1) -PackageDirs $PackageDir
     }
 }
-
-Write-Host "##[info]Initializing and updating submodule."
-git submodule init
-git submodule update


### PR DESCRIPTION
Forgot to catch these lines in the previous PR (#11)
Fixes bug found in SDL pipeline (conda command not found in bootstrap.ps1 script), see https://ms-quantum.visualstudio.com/Solid/_build/results?buildId=125687&view=logs&j=489ffc9e-2a44-5d38-7ef9-84f9f1f89ead&t=72d21a86-428e-5245-9acf-871836e51db5&l=117