### PR TITLE
Add repo status badges, trigger build on main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![PyPI version](https://badge.fury.io/py/azure-quantum.svg)](https://badge.fury.io/py/azure-quantum)
 [![Build Status](https://dev.azure.com/ms-quantum-public/Microsoft%20Quantum%20(public)/_apis/build/status/microsoft.qdk-python?branchName=main)](https://dev.azure.com/ms-quantum-public/Microsoft%20Quantum%20(public)/_build/latest?definitionId=32&branchName=main)
 
 # QDK-Python
@@ -7,8 +6,8 @@
 
 QDK-Python is the repository for Python packages of the Quantum Development Kit (QDK). Currently, this consists of the following packages:
 
-- qdk
-- azure-quantum
+- `qdk` [![PyPI version](https://badge.fury.io/py/qdk.svg)](https://badge.fury.io/py/qdk)
+- `azure-quantum` [![PyPI version](https://badge.fury.io/py/azure-quantum.svg)](https://badge.fury.io/py/azure-quantum)
 
 Coming soom:
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![PyPI version](https://badge.fury.io/py/azure-quantum.svg)](https://badge.fury.io/py/azure-quantum)
+[![Build Status](https://dev.azure.com/ms-quantum-public/Microsoft%20Quantum%20(public)/_apis/build/status/microsoft.qdk-python?branchName=main)](https://dev.azure.com/ms-quantum-public/Microsoft%20Quantum%20(public)/_build/latest?definitionId=32&branchName=main)
+
 # QDK-Python
 
 ## Introduction

--- a/build/ci.yml
+++ b/build/ci.yml
@@ -1,6 +1,7 @@
 name: $(Build.Major).$(Build.Minor).$(date:yyMM).$(DayOfMonth)$(rev:rr)
 
-trigger: none
+trigger:
+- main
 
 pr:
 - main


### PR DESCRIPTION
Add status badges to indicate the latest PyPI version as well as the latest build on `main`.
This also adds a trigger to the build pipeline for `main`.