### PR TITLE
Add Streaming Problem Interface

### DIFF
--- a/azure-quantum/azure/quantum/optimization/__init__.py
+++ b/azure-quantum/azure/quantum/optimization/__init__.py
@@ -7,5 +7,5 @@
 from .term    import *
 from .problem import *
 from .solvers import *
-
+from .streaming_problem import *
 

--- a/azure-quantum/azure/quantum/optimization/problem.py
+++ b/azure-quantum/azure/quantum/optimization/problem.py
@@ -55,6 +55,7 @@ class Problem:
         self.uploaded_blob_params = None
 
     def serialize(self) -> str:
+        """Serializes the problem to a JSON string"""
         result = {
             "cost_function": {
                 "version": "1.1" if self.init_config else "1.0",
@@ -69,7 +70,14 @@ class Problem:
         return json.dumps(result)
 
     @staticmethod
-    def deserialize(string, name):
+    def deserialize(string: str, name: str):
+        """Deserializes the problem from a JSON string
+
+        :param string: The string to be deserializes to a `Problem` instance
+        :type string: str
+        :param name: The name of the problem
+        :type name: str
+        """
         result = json.loads(string)
         problem = Problem(
             name = name,
@@ -83,10 +91,21 @@ class Problem:
         return problem
  
     def add_term(self, c: Union[int, float], indices: List[int]): 
+        """Adds a single term to the `Problem` representation
+
+        :param c: The cost or weight of this term
+        :type c: int, float
+        :param indices: The variable indices that are in this term
+        :type indices: List[int]
+        """
         self.terms.append(Term(indices=indices, c=c))
         self.uploaded_blob_uri = None
     
     def add_terms(self, terms: List[Term]): 
+        """Adds a list of terms to the `Problem` representation
+
+        :param terms: The list of terms to add to the problem
+        """
         self.terms += terms
         self.uploaded_blob_uri = None
 

--- a/azure-quantum/azure/quantum/optimization/problem.py
+++ b/azure-quantum/azure/quantum/optimization/problem.py
@@ -153,11 +153,11 @@ class Problem:
             # No storage account is passed, use the linked one
             container_uri = workspace._get_linked_storage_sas_uri(container_name)
             container_client = ContainerClient.from_container_url(container_uri)
-            self.uploaded_blob_uri = upload_blob(container_client, blob_name, content_type, encoding, data.getvalue(), returnSasToken=False)
+            self.uploaded_blob_uri = upload_blob(container_client, blob_name, content_type, encoding, data.getvalue(), return_sas_token=False)
         else:
             # Use the specified storage account
             container_client = ContainerClient.from_connection_string(workspace.storage, container_name)
-            self.uploaded_blob_uri = upload_blob(container_client, blob_name, content_type, encoding, data.getvalue(), returnSasToken=True)
+            self.uploaded_blob_uri = upload_blob(container_client, blob_name, content_type, encoding, data.getvalue(), return_sas_token=True)
 
         self.uploaded_blob_params = blob_params
         return self.uploaded_blob_uri

--- a/azure-quantum/azure/quantum/optimization/problem.py
+++ b/azure-quantum/azure/quantum/optimization/problem.py
@@ -48,9 +48,11 @@ class Problem:
         problem_type: ProblemType = ProblemType.ising
     ):
         self.name = name
-        self.terms = terms if terms is not None else []
+        self.terms = terms.copy() if terms is not None else []
         self.problem_type = problem_type
         self.init_config = init_config
+        self.uploaded_blob_uri = None
+        self.uploaded_blob_params = None
 
     def serialize(self) -> str:
         result = {
@@ -66,11 +68,27 @@ class Problem:
 
         return json.dumps(result)
 
-    def add_term(self, c: Union[int, float], indices: List[int]):
+    @staticmethod
+    def deserialize(string, name):
+        result = json.loads(string)
+        problem = Problem(
+            name = name,
+            terms = [Term.from_dict(t) for t in result['cost_function']['terms']],
+            problem_type = ProblemType[result['cost_function']['type']]
+        )
+        
+        if 'initial_configuration' in result['cost_function']:
+            problem.init_config = result['cost_function']['initial_configuration']
+
+        return problem
+ 
+    def add_term(self, c: Union[int, float], indices: List[int]): 
         self.terms.append(Term(indices=indices, c=c))
+        self.uploaded_blob_uri = None
     
-    def add_terms(self, terms: List[Term]):
+    def add_terms(self, terms: List[Term]): 
         self.terms += terms
+        self.uploaded_blob_uri = None
 
     def upload(
         self,
@@ -92,6 +110,10 @@ class Problem:
         :return: uri of the uploaded problem
         :rtype: [type]
         """
+        blob_params = [workspace, container_name, blob_name, compress]
+        if self.uploaded_blob_uri and self.uploaded_blob_params == blob_params:
+            return self.uploaded_blob_uri
+        
         if blob_name is None:
             blob_name = '{}-{}'.format(self.name, uuid.uuid1())
             
@@ -112,8 +134,11 @@ class Problem:
             # No storage account is passed, use the linked one
             container_uri = workspace._get_linked_storage_sas_uri(container_name)
             container_client = ContainerClient.from_container_url(container_uri)
-            return upload_blob(container_client, blob_name, content_type, encoding, data.getvalue(), return_sas_token=False)
+            self.uploaded_blob_uri = upload_blob(container_client, blob_name, content_type, encoding, data.getvalue(), returnSasToken=False)
         else:
             # Use the specified storage account
             container_client = ContainerClient.from_connection_string(workspace.storage, container_name)
-            return upload_blob(container_client, blob_name, content_type, encoding, data.getvalue(), return_sas_token=True)
+            self.uploaded_blob_uri = upload_blob(container_client, blob_name, content_type, encoding, data.getvalue(), returnSasToken=True)
+
+        self.uploaded_blob_params = blob_params
+        return self.uploaded_blob_uri

--- a/azure-quantum/azure/quantum/optimization/problem.py
+++ b/azure-quantum/azure/quantum/optimization/problem.py
@@ -80,9 +80,9 @@ class Problem:
         """
         result = json.loads(string)
         problem = Problem(
-            name = name,
-            terms = [Term.from_dict(t) for t in result['cost_function']['terms']],
-            problem_type = ProblemType[result['cost_function']['type']]
+            name=name,
+            terms=[Term.from_dict(t) for t in result['cost_function']['terms']],
+            problem_type=ProblemType[result['cost_function']['type']]
         )
         
         if 'initial_configuration' in result['cost_function']:

--- a/azure-quantum/azure/quantum/optimization/problem.py
+++ b/azure-quantum/azure/quantum/optimization/problem.py
@@ -69,16 +69,16 @@ class Problem:
 
         return json.dumps(result)
 
-    @staticmethod
-    def deserialize(string: str, name: str):
-        """Deserializes the problem from a JSON string
+    @classmethod
+    def deserialize(cls, problem_as_json: str, name: str):
+        """Deserializes the problem from a JSON string serialized with Problem.serialize()
 
-        :param string: The string to be deserializes to a `Problem` instance
-        :type string: str
+        :param problem_as_json: The string to be deserialized to a `Problem` instance
+        :type problem_as_json: str
         :param name: The name of the problem
         :type name: str
         """
-        result = json.loads(string)
+        result = json.loads(problem_as_json)
         problem = Problem(
             name=name,
             terms=[Term.from_dict(t) for t in result['cost_function']['terms']],

--- a/azure-quantum/azure/quantum/optimization/streaming_problem.py
+++ b/azure-quantum/azure/quantum/optimization/streaming_problem.py
@@ -9,8 +9,6 @@ import io
 import gzip
 import json
 import threading
-import gzip
-import io
 import sys
 
 from typing import List, Union, Dict, Optional

--- a/azure-quantum/azure/quantum/optimization/streaming_problem.py
+++ b/azure-quantum/azure/quantum/optimization/streaming_problem.py
@@ -130,6 +130,9 @@ class StreamingProblem(object):
             self.terms_queue.put(terms)
 
     def download(self):
+        if not self.uploaded_uri:
+            raise Exception('StreamingProblem may not be downloaded before it is uploaded')
+
         coords = self._get_upload_coords()
         blob = coords['container_client'].get_blob_client(coords['blob_name'])
         contents = download_blob(blob.url)

--- a/azure-quantum/azure/quantum/optimization/streaming_problem.py
+++ b/azure-quantum/azure/quantum/optimization/streaming_problem.py
@@ -25,7 +25,23 @@ logger = logging.getLogger(__name__)
 __all__ = ['StreamingProblem']
 
 class StreamingProblem(object):
+    """Problem to be streamed to the service.
 
+    Streaming problems are uploaded on the fly as terms are added,
+    meaning that the whole problem representation is not kept in memory. This
+    is very useful when constructing large problems.
+
+    :param workspace: Workspace to upload problem to
+    :type workspace: Workspace
+    :param name: Problem name
+    :type name: str
+    :param terms: Problem terms, depending on solver. Defaults to None
+    :type terms: Optional[List[Term]], optional
+    :param init_config: Optional configuration details, depending on solver. Defaults to None
+    :type init_config: Optional[Dict[str,int]], optional
+    :param problem_type: Problem type (ProblemType.pubo or ProblemType.ising), defaults to ProblemType.ising
+    :type problem_type: ProblemType, optional
+    """
     def __init__(
         self,
         workspace: Workspace,
@@ -139,6 +155,16 @@ class StreamingProblem(object):
         return self.uploaded_uri
             
 class JsonStreamingProblemUploader:
+    """Helper class for uploading json problem files in chunks.
+
+    :param problem: Back-ref to the problem being uploaded
+    :param container: Reference to the container client in which to store the problem
+    :param name: Name of the problem (added to blob metadata)
+    :param compress: Whether the problem should be compressed on the fly
+    :param upload_size_threshold: Chunking threshold (in bytes). Once the internal buffer reaches this size, the chunk will be uploaded.
+    :param upload_term_threshold: Chunking threshold (in terms). Once this many terms are ready to be uploaded, the chunk will be uploaded.
+    :param blob_properties: Properties to set on the blob.
+    """
     def __init__(
         self,
         problem: StreamingProblem,

--- a/azure-quantum/azure/quantum/optimization/streaming_problem.py
+++ b/azure-quantum/azure/quantum/optimization/streaming_problem.py
@@ -76,7 +76,7 @@ class StreamingProblem(object):
             self.add_terms(terms.copy())
 
     def add_term(self, c: Union[int, float], indices: List[int]) : 
-        """Adds a single term to the `Problem` representation
+        """Adds a single term to the `Problem` representation and queues it to be uploaded
 
         :param c: The cost or weight of this term
         :type c: int, float
@@ -103,8 +103,8 @@ class StreamingProblem(object):
         
         return { 'blob_name': blob_name, 'container_client': container_client }
 
-    def add_terms(self, terms: List[Term]) :
-        """Adds a list of terms to the `Problem` representation
+    def add_terms(self, terms: List[Term]):
+        """Adds a list of terms to the `Problem` representation and queues them to be uploaded
 
         :param terms: The list of terms to add to the problem
         """

--- a/azure-quantum/azure/quantum/optimization/streaming_problem.py
+++ b/azure-quantum/azure/quantum/optimization/streaming_problem.py
@@ -1,0 +1,277 @@
+##
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+##
+
+import logging
+import uuid
+import io
+import gzip
+import json
+import threading
+import gzip
+import io
+import sys
+
+from typing import List, Union, Dict, Optional
+from enum import Enum
+from azure.quantum import Workspace
+from azure.quantum.optimization import Term, Problem, ProblemType
+from azure.quantum.storage import StreamedBlob, ContainerClient, BlobClient, download_blob
+from queue import Queue, Empty
+
+logger = logging.getLogger(__name__)
+
+__all__ = ['StreamingProblem']
+
+class StreamingProblem(object):
+
+    def __init__(
+        self,
+        workspace: Workspace,
+        name: str = 'Optimization Problem',
+        terms: Optional[List[Term]] = None,
+        init_config: Optional[Dict[str,int]] = None,
+        problem_type: ProblemType = ProblemType.ising,
+        metadata: Dict[str, str] = {},
+        **kw
+    ):
+        super(StreamingProblem, self).__init__(**kw)
+        self.name = name
+        self.id = str(uuid.uuid1())
+        self.workspace = workspace
+        self.problem_type = problem_type
+        self.init_config = init_config
+        self.terms_queue = Queue()
+        self.uploaded_uri = None
+        self.upload_to_url = None
+        self.uploader = None
+        self.compress = True
+        self.__n_couplers = 0
+        self.stats = {
+            'type': problem_type.name,
+            'max_coupling': 0,
+            'avg_coupling': 0,
+            'min_coupling': sys.maxsize,
+            'num_terms': 0,
+        }
+        self.upload_size_threshold = 10e6
+        self.upload_terms_threshold = 1000
+        self.metadata = metadata
+        if terms is not None and len(terms) > 0:
+            self.add_terms(terms.copy())
+
+    def add_term(self, c: Union[int, float], indices: List[int]) : 
+        self.add_terms([Term(indices=indices, c=c)])
+    
+    def _get_upload_coords(self):
+        blob_name=self.id
+        if self.upload_to_url:
+            blob_client = BlobClient.from_blob_url(self.upload_to_url)
+            container_client = ContainerClient.from_container_url(
+                self.workspace._get_linked_storage_sas_uri(
+                    blob_client.container_name))
+            blob_name = blob_client.blob_name
+        elif not self.workspace.storage:
+            # No storage account is passed, use the linked one
+            container_uri = self.workspace._get_linked_storage_sas_uri(self.id)
+            container_client = ContainerClient.from_container_url(container_uri)
+        else:
+            # Use the specified storage account
+            container_client = ContainerClient.from_connection_string(self.workspace.storage, self.id)
+        
+        return { 'blob_name': blob_name, 'container_client': container_client }
+
+    def add_terms(self, terms: List[Term]) :
+        if self.uploaded_uri is not None:
+            raise Exception('Cannot add terms after problem has been uploaded')
+
+        if terms is not None:
+            if self.uploader is None:
+                upload_coords = self._get_upload_coords()
+                self.uploader = JsonStreamingProblemUploader(
+                    problem=self,
+                    container=upload_coords['container_client'],
+                    name=upload_coords['blob_name'],
+                    compress=self.compress,
+                    upload_size_threshold=self.upload_size_threshold,
+                    upload_term_threshold=self.upload_terms_threshold,
+                    )
+                self.uploader.start()
+            elif self.uploader.is_done():
+                raise Exception('Cannot add terms after problem has been uploaded')
+            
+            term_couplings = [len(term.ids) for term in terms]
+            max_coupling = max(term_couplings)
+            min_coupling = min(term_couplings)
+            self.__n_couplers += sum(term_couplings)
+            self.stats['num_terms'] += len(terms)
+            self.stats['avg_coupling'] = self.__n_couplers / self.stats['num_terms']
+            if self.stats['max_coupling'] < max_coupling:
+                self.stats['max_coupling'] = max_coupling
+            if self.stats['min_coupling'] > min_coupling:
+                self.stats['min_coupling'] = min_coupling
+            self.terms_queue.put(terms)
+
+    def download(self):
+        coords = self._get_upload_coords()
+        blob = coords['container_client'].get_blob_client(coords['blob_name'])
+        contents = download_blob(blob.url)
+        return Problem.deserialize(contents, self.name)
+
+    def upload(self, workspace, container_name:str="qio-problems", blob_name:str=None, compress:bool=True):
+        """Uploads an optimization problem instance to the cloud storage linked with the Workspace.
+
+        :param workspace: interaction terms of the problem.
+        :return: uri of the uploaded problem
+        """
+        if not self.uploaded_uri:
+            self.uploader.blob_properties = {k:str(v) for k,v in {
+                **self.stats,
+                **self.metadata
+            }.items()}
+            self.terms_queue.put(None)
+            blob = self.uploader.join()
+            self.uploaded_uri = blob.getUri(not not self.workspace.storage)
+            self.uploader = None
+            self.terms_queue = None
+            
+        return self.uploaded_uri
+            
+class JsonStreamingProblemUploader:
+    def __init__(
+        self,
+        problem: StreamingProblem,
+        container: ContainerClient,
+        name: str,
+        compress: bool,
+        upload_size_threshold: int,
+        upload_term_threshold: int,
+        blob_properties: Dict[str, str] = None
+    ):
+        self.problem = problem
+        self.started_upload = False
+        self.blob = StreamedBlob(container, name, 'application/json', self.get_content_type(compress))
+        self.compressedStream = io.BytesIO() if compress else None
+        self.compressor = gzip.GzipFile(mode='wb', fileobj=self.compressedStream) if compress else None
+        self.uploaded_terms = 0
+        self.blob_properties = blob_properties
+        self.__thread = None
+        self.__queue_wait_timeout=1
+        self.__upload_terms_threshold=upload_term_threshold
+        self.__upload_size_threshold=upload_size_threshold
+        self.__read_pos = 0
+
+    def get_content_type(self, compress: bool):
+        if compress:
+            return 'gzip'
+        
+        return 'identity'
+
+    def start(self):
+        if self.__thread is not None:
+            raise Exception('JsonStreamingProblemUploader thread already started')
+
+        self.__thread = threading.Thread(target=self._run_queue)
+        self.__thread.start()
+
+    def join(self, timeout : float = None) -> StreamedBlob:
+        if self.__thread is None:
+            raise Exception('JsonStreamingProblemUploader has not started')
+
+        self.__thread.join(timeout=timeout)
+        return self.blob
+
+    def is_done(self):
+        return not self.__thread.isAlive()
+
+    def _run_queue(self):
+        continue_processing = True
+        terms = []
+        while continue_processing:
+            try:
+                new_terms = self.problem.terms_queue.get(block=True, timeout=self.__queue_wait_timeout)
+                if new_terms is None:
+                    continue_processing = False
+                else:
+                    terms = terms + new_terms
+                    if len(terms) < self.__upload_terms_threshold:
+                        continue
+            except Empty:
+                pass
+            except Exception as e:
+                raise e
+
+            if len(terms) > 0:
+                self._upload_next(terms)
+                terms = []
+
+        self._finish_upload()
+
+    def _upload_start(self, terms):
+        self.started_upload = True
+        self._upload_chunk(
+            f'{{"cost_function":{{"version":"{self._get_version()}","type":"{self._scrub(self.problem.problem_type.name)}",'
+            + self._get_initial_config_string()
+            + '"terms":[' + self._get_terms_string(terms)
+        )
+
+    def _get_initial_config_string(self):
+        if self.problem.init_config:
+            return f'"initial_configuration":' + json.dumps(self.problem.init_config) + ','
+        return ''
+
+    def _get_version(self):
+        return "1.1" if self.problem.init_config else "1.0"
+
+    def _get_terms_string(self, terms):
+        result = ("," if self.uploaded_terms > 0 else "") + ",".join([json.dumps(term.to_dict()) for term in terms])
+        self.uploaded_terms += len(terms)
+        return result
+
+    def _scrub(self, s):
+        if '"' in s:
+            raise "string should not contain a literal double quote '\"'"
+
+        return s
+
+    def _upload_next(self, terms):
+        if not self.started_upload:
+            self._upload_start(terms)
+        else:
+            self._upload_chunk(self._get_terms_string(terms))
+
+    def _maybe_compress_bits(self, chunk: bytes, is_final: bool):
+        if self.compressor is None:
+            return chunk
+
+        if self.__read_pos > 0:
+            self.compressedStream.truncate(0)
+            self.compressedStream.seek(0)
+            
+        self.compressor.write(chunk)
+        if is_final:
+            self.compressor.flush()
+            self.compressor.close()
+        elif self.compressedStream.getbuffer().nbytes < self.__upload_size_threshold:
+            self.__read_pos = 0
+            return
+
+        self.compressedStream.seek(0)
+        compressed = self.compressedStream.read(-1)
+        self.__read_pos = 0 if compressed is None else len(compressed)
+        return compressed
+
+    def _upload_chunk(self, chunk: str, is_final: bool = False):
+        compressed = self._maybe_compress_bits(chunk.encode(), is_final)
+        if compressed is None:
+            return
+        if len(compressed) > 0:
+            self.blob.upload_data(compressed)
+
+    def _finish_upload(self):
+        if not self.started_upload:
+            self._upload_start([])
+
+        self._upload_chunk(f']}}}}', True)
+        self.blob.commit(metadata=self.blob_properties)

--- a/azure-quantum/azure/quantum/optimization/term.py
+++ b/azure-quantum/azure/quantum/optimization/term.py
@@ -29,6 +29,10 @@ class Term:
     def to_dict(self):
         return self.__dict__
 
+    @staticmethod
+    def from_dict(obj):
+        return Term(indices = obj['ids'], c = obj['c'])
+
     def __repr__(self):
         return str(self.__dict__)
 

--- a/azure-quantum/azure/quantum/storage.py
+++ b/azure-quantum/azure/quantum/storage.py
@@ -54,7 +54,7 @@ def get_container_uri(connection_string: str, container_name: str) -> str:
     return uri
 
 
-def upload_blob(container: ContainerClient, blob_name: str, content_type:str, content_encoding:str, data: Any, returnSasToken: bool=True) -> str:
+def upload_blob(container: ContainerClient, blob_name: str, content_type:str, content_encoding:str, data: Any, return_sas_token: bool=True) -> str:
     """
     Uploads the given data to a blob record. If a blob with the given name already exist, it throws an error.
 
@@ -68,7 +68,7 @@ def upload_blob(container: ContainerClient, blob_name: str, content_type:str, co
     blob.upload_blob(data, content_settings=content_settings)
     logger.debug(f"  - blob '{blob_name}' uploaded. generating sas token.")
 
-    if returnSasToken:
+    if return_sas_token:
         uri = get_blob_uri_with_sas_token(blob)
     else:
         uri = remove_sas_token(blob.url)
@@ -272,11 +272,11 @@ class StreamedBlob:
         self.state = StreamedBlobState.committed
         logger.debug(f"Committed {self.blob_name}")
 
-    def getUri(self, withSasToken : bool = False):
+    def getUri(self, with_sas_token : bool = False):
         """Gets the full Azure Storage URI for the uploaded blob after it has been committed"""
         if self.state != StreamedBlobState.committed:
             raise Exception('Can only retrieve sas token for committed blob')
-        if withSasToken:
+        if with_sas_token:
             return get_blob_uri_with_sas_token(self.blob)
 
         return remove_sas_token(self.blob.url)

--- a/azure-quantum/tests/README.md
+++ b/azure-quantum/tests/README.md
@@ -23,3 +23,5 @@ WORKSPACE_NAME
   - ParallelTempering
 - Jobs
 
+# Integration Tests
+- Streaming Problem

--- a/azure-quantum/tests/integration/integration_test_util.py
+++ b/azure-quantum/tests/integration/integration_test_util.py
@@ -1,0 +1,40 @@
+import os
+from azure.quantum import Workspace
+from azure.common.credentials import ServicePrincipalCredentials
+
+def create_workspace() -> Workspace:
+    """Create workspace using credentials stored in config file
+
+    :return: Workspace
+    :rtype: Workspace
+    """
+
+    client_id = os.environ.get("AZURE_CLIENT_ID","")
+    client_secret = os.environ.get("AZURE_CLIENT_SECRET","")
+    tenant_id = os.environ.get("AZURE_TENANT_ID","")
+    resource_group = os.environ.get("RESOURCE_GROUP","")
+    subscription_id = os.environ.get("SUBSCRIPTION_ID","")
+    workspace_name = os.environ.get("WORKSPACE_NAME","")
+
+    assert len(client_id)>0, "AZURE_CLIENT_ID not found in environment variables."
+    assert len(client_id)>0, "AZURE_CLIENT_SECRET not found in environment variables."
+    assert len(client_id)>0, "AZURE_TENANT_ID not found in environment variables."
+    assert len(client_id)>0, "RESOURCE_GROUP not found in environment variables."
+    assert len(client_id)>0, "SUBSCRIPTION_ID not found in environment variables."
+    assert len(client_id)>0, "WORKSPACE_NAME not found in environment variables."
+
+    if len(client_secret) > 0:
+        workspace = Workspace(
+            subscription_id=subscription_id,
+            resource_group=resource_group,
+            name=workspace_name,
+        )
+        workspace.credentials = ServicePrincipalCredentials(
+            tenant=tenant_id,
+            client_id=client_id,
+            secret=client_secret,
+            resource  = "https://quantum.microsoft.com"
+        )
+
+    workspace.login()
+    return workspace

--- a/azure-quantum/tests/integration/test_integration.py
+++ b/azure-quantum/tests/integration/test_integration.py
@@ -8,7 +8,7 @@
 import os
 import configparser
 import functools
-from azure.common.credentials import ServicePrincipalCredentials
+from integration_test_util import create_workspace
 
 from azure.quantum import Workspace
 from azure.quantum.optimization import (
@@ -30,45 +30,6 @@ from azure.quantum.optimization.toshiba import (
     SimulatedBifurcationMachine
 )
 
-def create_workspace() -> Workspace:
-    """Create workspace using credentials stored in config file
-
-    :return: Workspace
-    :rtype: Workspace
-    """
-
-    client_id = os.environ.get("AZURE_CLIENT_ID","")
-    client_secret = os.environ.get("AZURE_CLIENT_SECRET","")
-    tenant_id = os.environ.get("AZURE_TENANT_ID","")
-    resource_group = os.environ.get("RESOURCE_GROUP","")
-    subscription_id = os.environ.get("SUBSCRIPTION_ID","")
-    workspace_name = os.environ.get("WORKSPACE_NAME","")
-
-    assert len(client_id)>0, "AZURE_CLIENT_ID not found in environment variables."
-    assert len(client_id)>0, "AZURE_CLIENT_SECRET not found in environment variables."
-    assert len(client_id)>0, "AZURE_TENANT_ID not found in environment variables."
-    assert len(client_id)>0, "RESOURCE_GROUP not found in environment variables."
-    assert len(client_id)>0, "SUBSCRIPTION_ID not found in environment variables."
-    assert len(client_id)>0, "WORKSPACE_NAME not found in environment variables."
-
-    if len(client_secret) > 0:
-        workspace = Workspace(
-            
-            subscription_id=subscription_id,
-            resource_group=resource_group,
-            name=workspace_name,
-        )
-        workspace.credentials = ServicePrincipalCredentials(
-            tenant=tenant_id,
-            client_id=client_id,
-            secret=client_secret,
-            resource  = "https://quantum.microsoft.com"
-        )
-
-    workspace.login()
-    return workspace
-
-
 def create_problem(init: bool = False) -> Problem:
     """Create optimization problem with some default terms
 
@@ -88,9 +49,9 @@ def create_problem(init: bool = False) -> Problem:
 
     if init is True:
         initial_config = {
-            "1": -1,
+            "1": 0,
             "0": 1,
-            "2": -1,
+            "2": 0,
             "3": 1
         }
 

--- a/azure-quantum/tests/integration/test_streaming_problem.py
+++ b/azure-quantum/tests/integration/test_streaming_problem.py
@@ -18,26 +18,8 @@ from typing import List
 from azure.quantum import Workspace
 from azure.quantum.optimization import StreamingProblem, Problem, ProblemType, Term
 from azure.quantum.storage import download_blob
-from azure.common.credentials import ServicePrincipalCredentials
 from azure.identity import DefaultAzureCredential
-
-def _init_ws_():
-    workspace = Workspace(
-        subscription_id=os.environ.get('TEST_WORKSPACE_SUB'), 
-        resource_group=os.environ.get('TEST_WORKSPACE_RG'),
-        name=os.environ.get('TEST_WORKSPACE_NAME'),
-    )
-
-    if os.environ.get('AZURE_TENANT_ID') is not None:
-        workspace.credentials = ServicePrincipalCredentials(
-            tenant    = os.environ.get('AZURE_TENANT_ID'), # From service principal creation, your Directory (tenant) ID
-            client_id = os.environ.get('AZURE_CLIENT_ID'), # From service principal creation, your Application (client) ID
-            secret    = os.environ.get('AZURE_CLIENT_SECRET'), # From service principal creation, your secret
-            resource  = "https://quantum.microsoft.com/" # Do not change! This is the resource you want to authenticate against - the Azure Quantum service
-        )
-
-    workspace.login()
-    return workspace
+from integration_test_util import create_workspace
 
 class TestStreamingProblem(unittest.TestCase):
     def __test_upload_problem(
@@ -50,7 +32,7 @@ class TestStreamingProblem(unittest.TestCase):
         initial_terms: List[Term] = [],
         **kwargs
     ):
-        ws = _init_ws_()
+        ws = create_workspace()
         sProblem = StreamingProblem(
             ws,
             name="test",

--- a/azure-quantum/tests/integration/test_streaming_problem.py
+++ b/azure-quantum/tests/integration/test_streaming_problem.py
@@ -1,0 +1,109 @@
+
+#!/bin/env python
+# -*- coding: utf-8 -*-
+##
+# test_problem.py: Checks correctness of azure.quantum.optimization module.
+##
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+##
+
+## IMPORTS ##
+
+import unittest
+import json
+import os
+from typing import List
+
+from azure.quantum import Workspace
+from azure.quantum.optimization import StreamingProblem, Problem, ProblemType, Term
+from azure.quantum.storage import download_blob
+from azure.common.credentials import ServicePrincipalCredentials
+from azure.identity import DefaultAzureCredential
+
+def _init_ws_():
+    workspace = Workspace(
+        subscription_id=os.environ.get('TEST_WORKSPACE_SUB'), 
+        resource_group=os.environ.get('TEST_WORKSPACE_RG'),
+        name=os.environ.get('TEST_WORKSPACE_NAME'),
+    )
+
+    if os.environ.get('AZURE_TENANT_ID') is not None:
+        workspace.credentials = ServicePrincipalCredentials(
+            tenant    = os.environ.get('AZURE_TENANT_ID'), # From service principal creation, your Directory (tenant) ID
+            client_id = os.environ.get('AZURE_CLIENT_ID'), # From service principal creation, your Application (client) ID
+            secret    = os.environ.get('AZURE_CLIENT_SECRET'), # From service principal creation, your secret
+            resource  = "https://quantum.microsoft.com/" # Do not change! This is the resource you want to authenticate against - the Azure Quantum service
+        )
+
+    workspace.login()
+    return workspace
+
+class TestStreamingProblem(unittest.TestCase):
+    def __test_upload_problem(
+        self,
+        count: int,
+        terms_thresh: int,
+        size_thresh: int,
+        compress: bool,
+        problem_type: ProblemType = ProblemType.ising,
+        initial_terms: List[Term] = [],
+        **kwargs
+    ):
+        ws = _init_ws_()
+        sProblem = StreamingProblem(
+            ws,
+            name = "test",
+            problem_type=problem_type,
+            terms=initial_terms
+        )
+        rProblem = Problem('test', problem_type=problem_type, terms=initial_terms)
+        sProblem.upload_terms_threshold = terms_thresh
+        sProblem.upload_size_threshold = size_thresh
+        sProblem.compress = compress
+
+        for i in range(count):
+            sProblem.add_term(c = i, indices = [i, i+1])
+            rProblem.add_term(c = i, indices = [i, i+1])
+        
+        self.assertEqual(problem_type, sProblem.problem_type)
+        self.assertEqual(problem_type.name, sProblem.stats['type'])
+        self.assertEqual(count + len(initial_terms), sProblem.stats['num_terms'])
+        self.assertEqual(self.__kwarg_or_value(kwargs, 'avg_coupling', 2), sProblem.stats['avg_coupling'])
+        self.assertEqual(self.__kwarg_or_value(kwargs, 'max_coupling', 2), sProblem.stats['max_coupling'])
+        self.assertEqual(self.__kwarg_or_value(kwargs, 'min_coupling', 2), sProblem.stats['min_coupling'])
+
+        uri = sProblem.upload(ws)
+        uploaded = json.loads(sProblem.download().serialize())
+        local = json.loads(rProblem.serialize())
+        self.assertEqual(uploaded, local)
+
+    def __kwarg_or_value(self, kwarg, name, default):
+        if name in kwarg:
+            return kwarg[name]
+
+        return default
+
+    def test_small_chunks(self):
+        self.__test_upload_problem(4, 1, 1, False)
+
+    def test_large_chunks(self):
+        self.__test_upload_problem(4, 1000, 10e6, False)
+
+    def test_small_chunks_compressed(self):
+        self.__test_upload_problem(4, 1, 1, True)
+
+    def test_large_chunks_compressed(self):
+        self.__test_upload_problem(4, 1000, 10e6, True)
+
+    def test_pubo(self):
+        self.__test_upload_problem(4, 1, 1, False, ProblemType.pubo)
+
+    def test_initial_terms(self):
+        self.__test_upload_problem(4, 1, 1, False, initial_terms=[
+            Term(w=10, indices=[0, 1, 2]),
+            Term(w=20, indices=[1, 2, 3])
+        ], avg_coupling=(4*2 + 6)/6, max_coupling=3)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/azure-quantum/tests/integration/test_streaming_problem.py
+++ b/azure-quantum/tests/integration/test_streaming_problem.py
@@ -53,7 +53,7 @@ class TestStreamingProblem(unittest.TestCase):
         ws = _init_ws_()
         sProblem = StreamingProblem(
             ws,
-            name = "test",
+            name="test",
             problem_type=problem_type,
             terms=initial_terms
         )

--- a/azure-quantum/tests/unit/test_optimization.py
+++ b/azure-quantum/tests/unit/test_optimization.py
@@ -115,6 +115,35 @@ class TestProblem(QuantumTestBase):
         actual = problem.serialize()
         self.assertEqual(expected, actual)
 
+    def test_deserialize(self):
+        count = 2
+        terms = []
+        for i in range(count):
+            terms.append(Term(c = i, indices = [i, i+1]))
+        problem = Problem(name = "test", terms=terms)
+        deserialized = Problem.deserialize(problem.serialize(), problem.name)
+        self.assertEqual(problem.name, deserialized.name)
+        self.assertEqual(problem.problem_type, deserialized.problem_type)
+        self.assertEqual(count, len(deserialized.terms))
+        self.assertEqual(problem.init_config, deserialized.init_config)
+        self.assertEqual(Term(c = 0, indices = [0, 1]), problem.terms[0])
+        self.assertEqual(Term(c = 1, indices = [1, 2]), problem.terms[1])
+
+    def test_deserialize_init_config(self):
+        count = 2
+        terms = []
+        for i in range(count):
+            terms.append(Term(c = i, indices = [i, i+1]))
+        init_config = {"0":-1 , "1": 1, "2": -1}
+        problem = Problem(name = "test", terms=terms, init_config=init_config)
+        deserialized = Problem.deserialize(problem.serialize(), problem.name)
+        self.assertEqual(problem.name, deserialized.name)
+        self.assertEqual(problem.problem_type, deserialized.problem_type)
+        self.assertEqual(count, len(deserialized.terms))
+        self.assertEqual(problem.init_config, deserialized.init_config)
+        self.assertEqual(Term(c = 0, indices = [0, 1]), problem.terms[0])
+        self.assertEqual(Term(c = 1, indices = [1, 2]), problem.terms[1])
+
 
 def _init_ws_():
     return Workspace(


### PR DESCRIPTION
**Summary**
Adds a new `StreamingProblem` class, which allows users to construct a problem without having to hold the whole problem definition in memory at one time, which may be a significant problem when constructing large problems or when constructing many problems in parallel.

Sample Usage:
```python
import StreamingProblem from azure.quantum.optimization
workspace = Workspace(...)
problem = StreamingProblem(workspace = workspace, name="My Problem", problem_type=ProblemType.ising)
for terms in generate_problem_terms():
    problem.add_terms(terms)
results = solver.optimize(problem)
```

Under the hood, the `StreamingProblem` uploads the problem in chunks as terms are added using [Block Blobs](https://docs.microsoft.com/rest/api/storageservices/understanding-block-blobs--append-blobs--and-page-blobs). The problem representation is committed in Azure storage when the user calls problem.upload(). If the user never finalizes the problem by submitting it or calling `problem.upload()` Azure will automatically clean up the uncommitted blocks.

StreamingProblem is otherwise used in the exact same way as the existing `Problem` class, with the exception that you cannot read back terms after they have been added. However, after you have called `upload` you may call `download` to download the complete problem definition back to  the client.

**Open Issues**
This is a somewhat large PR - very open to feedback on the approach and structure!

I've added integration tests for `StreamingProblem`, however the format is using the unittest framework which differs from the existing integration tests. I also encountered #22 which, once resolved, will allow us to automate integration tests in builds. I'd appreciate maintainer feedback on how these are structured.