### PR TITLE
add MANIFEST file to include image for readme

### DIFF
--- a/qdk/MANIFEST.in
+++ b/qdk/MANIFEST.in
@@ -1,0 +1,2 @@
+include caffeine.png
+include README.md


### PR DESCRIPTION
Currently, the PyPI page for the qdk package has a broken image; this MANIFEST file makes sure the png file of the molecule is added to the package and uploaded properly.