### PR TITLE
Fix build pipeline on release branch

### DIFF
--- a/azure-quantum/environment.yml
+++ b/azure-quantum/environment.yml
@@ -13,3 +13,4 @@ dependencies:
     - msrestazure
     - msal
     - azure-common
+    - azure-identity

--- a/azure-quantum/tests/integration/integration_test_util.py
+++ b/azure-quantum/tests/integration/integration_test_util.py
@@ -17,11 +17,11 @@ def create_workspace() -> Workspace:
     workspace_name = os.environ.get("WORKSPACE_NAME","")
 
     assert len(client_id)>0, "AZURE_CLIENT_ID not found in environment variables."
-    assert len(client_id)>0, "AZURE_CLIENT_SECRET not found in environment variables."
-    assert len(client_id)>0, "AZURE_TENANT_ID not found in environment variables."
-    assert len(client_id)>0, "RESOURCE_GROUP not found in environment variables."
-    assert len(client_id)>0, "SUBSCRIPTION_ID not found in environment variables."
-    assert len(client_id)>0, "WORKSPACE_NAME not found in environment variables."
+    assert len(client_secret)>0, "AZURE_CLIENT_SECRET not found in environment variables."
+    assert len(tenant_id)>0, "AZURE_TENANT_ID not found in environment variables."
+    assert len(resource_group)>0, "RESOURCE_GROUP not found in environment variables."
+    assert len(subscription_id)>0, "SUBSCRIPTION_ID not found in environment variables."
+    assert len(workspace_name)>0, "WORKSPACE_NAME not found in environment variables."
 
     if len(client_secret) > 0:
         workspace = Workspace(

--- a/azure-quantum/tests/integration/test_streaming_problem.py
+++ b/azure-quantum/tests/integration/test_streaming_problem.py
@@ -13,12 +13,12 @@
 import unittest
 import json
 import os
+import pytest
 from typing import List
 
 from azure.quantum import Workspace
 from azure.quantum.optimization import StreamingProblem, Problem, ProblemType, Term
 from azure.quantum.storage import download_blob
-from azure.identity import DefaultAzureCredential
 from integration_test_util import create_workspace
 
 class TestStreamingProblem(unittest.TestCase):
@@ -66,26 +66,45 @@ class TestStreamingProblem(unittest.TestCase):
 
         return default
 
+    @pytest.mark.skip(reason="No live-test infra available yet")
     def test_small_chunks(self):
         self.__test_upload_problem(4, 1, 1, False)
 
+    @pytest.mark.skip(reason="No live-test infra available yet")
     def test_large_chunks(self):
         self.__test_upload_problem(4, 1000, 10e6, False)
 
+    @pytest.mark.skip(reason="No live-test infra available yet")
     def test_small_chunks_compressed(self):
         self.__test_upload_problem(4, 1, 1, True)
 
+    @pytest.mark.skip(reason="No live-test infra available yet")
     def test_large_chunks_compressed(self):
         self.__test_upload_problem(4, 1000, 10e6, True)
 
+    @pytest.mark.skip(reason="No live-test infra available yet")
     def test_pubo(self):
         self.__test_upload_problem(4, 1, 1, False, ProblemType.pubo)
 
+    @pytest.mark.skip(reason="No live-test infra available yet")
     def test_initial_terms(self):
         self.__test_upload_problem(4, 1, 1, False, initial_terms=[
             Term(w=10, indices=[0, 1, 2]),
             Term(w=20, indices=[1, 2, 3])
         ], avg_coupling=(4*2 + 6)/6, max_coupling=3)
 
+    def check_all(self):
+        self.test_small_chunks();
+        self.test_large_chunks();
+        self.test_small_chunks_compressed();
+        self.test_large_chunks_compressed();
+        self.test_pubo();
+        self.test_initial_terms();
+
 if __name__ == "__main__":
-    unittest.main()
+    # Our test infra is not quite ready to run tests against a live service
+    # To run these tests follow the README.md from the integration tests folder
+    # unittest.main()
+
+    tests = TestStreamingProblem();
+    tests.check_all();


### PR DESCRIPTION
(This is the same as PR #36 but applied to the release branch)

This PR fixes the build pipeline that stopped working due to a new integration test for the azure-quantum package (introduced with #23) and the inclusion of running tests as part of the main build (introduced with #20).

PR #23 added some integration unit tests in the azure-quantum, but we don't have the infra yet to run them from ADO, so I disabled the unit tests for now.
For now, one needs to manually set some environment variables described in the integration tests README.md and manually run those tests.
In April the "integration tests" and "unit tests" will be consolidated and will be able to run against a live-service and also in playback mode.