### PR TITLE
Add numpy as dependency for Azure.Quantum conda environment

### DIFF
--- a/azure-quantum/environment.yml
+++ b/azure-quantum/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - pip
   - jupyter
   - pytest
+  - numpy
   - pip:
     - azure-storage-blob
     - msrestazure


### PR DESCRIPTION
We recently introduced NumPy as a dependency with #39 and there will be other features that will use NumPy (like #24) in the future.