### PR TITLE
Adding some user warnings to potentially large problems or long runtimes

### DIFF
--- a/azure-quantum/azure/quantum/optimization/problem.py
+++ b/azure-quantum/azure/quantum/optimization/problem.py
@@ -56,6 +56,12 @@ class Problem:
         self.uploaded_blob_uri = None
         self.uploaded_blob_params = None
 
+    """
+    Constant thresholds used to determine if a problem is "large".
+    """
+    NUM_VARIABLES_LARGE = 2500
+    NUM_TERMS_LARGE = 10e6
+
     def serialize(self) -> str:
         """Serializes the problem to a JSON string"""
         result = {
@@ -224,4 +230,4 @@ class Problem:
         for term in self.terms:
             set_vars.update(term.ids)
         
-        return (len(set_vars) >= 2500 and len(self.terms) >= 10e6)
+        return (len(set_vars) >= NUM_VARIABLES_LARGE and len(self.terms) >= NUM_TERMS_LARGE)

--- a/azure-quantum/azure/quantum/optimization/problem.py
+++ b/azure-quantum/azure/quantum/optimization/problem.py
@@ -222,7 +222,7 @@ class Problem:
     def is_large(self) -> bool:
         """Determines if the current problem is large. 
         "large" is an arbitrary threshold and can be easily changed. Based on usage data, we have defined a 
-        large problem to be 2500+ variables AND 1mil+ terms. 
+        large problem to be NUM_VARIABLES_LARGE+ variables AND NUM_TERMS_LARGE+ terms. 
         """
 
         set_vars = set()

--- a/azure-quantum/azure/quantum/optimization/problem.py
+++ b/azure-quantum/azure/quantum/optimization/problem.py
@@ -60,7 +60,7 @@ class Problem:
     Constant thresholds used to determine if a problem is "large".
     """
     NUM_VARIABLES_LARGE = 2500
-    NUM_TERMS_LARGE = 10e6
+    NUM_TERMS_LARGE = 1e6
 
     def serialize(self) -> str:
         """Serializes the problem to a JSON string"""
@@ -226,8 +226,7 @@ class Problem:
         """
 
         set_vars = set()
-        num_terms = len(self.terms)
         for term in self.terms:
             set_vars.update(term.ids)
         
-        return (len(set_vars) >= NUM_VARIABLES_LARGE and len(self.terms) >= NUM_TERMS_LARGE)
+        return (len(set_vars) >= Problem.NUM_VARIABLES_LARGE and len(self.terms) >= Problem.NUM_TERMS_LARGE)

--- a/azure-quantum/azure/quantum/optimization/problem.py
+++ b/azure-quantum/azure/quantum/optimization/problem.py
@@ -212,3 +212,16 @@ class Problem:
                 total_cost += term.evaluate(configuration_transformed)
 
         return total_cost
+
+    def is_large(self) -> bool:
+        """Determines if the current problem is large. 
+        "large" is an arbitrary threshold and can be easily changed. Based on usage data, we have defined a 
+        large problem to be 2500+ variables AND 1mil+ terms. 
+        """
+
+        set_vars = set()
+        num_terms = len(self.terms)
+        for term in self.terms:
+            set_vars.update(term.ids)
+        
+        return (len(set_vars) >= 2500 and len(self.terms) >= 10e6)

--- a/azure-quantum/azure/quantum/optimization/solvers.py
+++ b/azure-quantum/azure/quantum/optimization/solvers.py
@@ -45,6 +45,11 @@ class Solver:
         self.force_str_params = force_str_params
         self.params = { "params": {} } if nested_params else {}
 
+    """Constants that define thresholds for submission warnings
+    """
+    SWEEPS_WARNING = 10000
+    TIMEOUT_WARNING = 600
+
     def submit(self, problem: Union[str, Problem], compress: bool = True) -> Job:
         """Submits a job to execution to the associated Azure Quantum Workspace.
 
@@ -107,23 +112,8 @@ class Solver:
             or the URL of an Azure Storage Blob where the serialized version
             of a Problem has been uploaded.
         """
-        # print a warning if we suspect the job may take long based on its configured properties.
         if not isinstance(problem, str):
-            is_large_problem = problem.is_large()
-            if is_large_problem:
-                if nested_params and "sweeps" in self.params["params"]:
-                    sweeps = self.params["params"]["sweeps"]
-                    # if problem is large and sweeps is large, warn. 
-                    if sweeps >= 10000:
-                        logger.warn(f"There is a large problem submitted and a large number of sweeps ({sweeps}) configured. \
-                        This submission could result in a long runtime.")
-
-        # do a timeout check if param-free, to warn new users who accidentally set high timeout values.
-        if nested_params and "timeout" in self.params["params"]:
-            timeout = self.params["params"]["timeout"]
-            if timeout >= 600:
-                logger.warn(f"A large timeout has been set for this submission ({timeout}). If this is intended, disregard this warning. \
-                Otherwise, consider cancelling the job and resubmitting with a lower timeout.")
+            self.check_submission_warnings(problem)
 
         job = self.submit(problem)
         logger.info(f"Submitted job: '{job.id}'")
@@ -134,6 +124,24 @@ class Solver:
         if value is not None:
             params = self.params["params"] if self.nested_params else self.params
             params[name] = str(value) if self.force_str_params else value
+    
+    def check_submission_warnings(self, problem: Problem):
+        # print a warning if we suspect the job may take long based on its configured properties.
+        is_large_problem = problem.is_large()
+        if is_large_problem:
+            if nested_params and "sweeps" in self.params["params"]:
+                sweeps = int(self.params["params"]["sweeps"])
+                # if problem is large and sweeps is large, warn. 
+                if sweeps >= SWEEPS_WARNING:
+                    logger.warn(f"There is a large problem submitted and a large number of sweeps ({sweeps}) configured. \
+                    This submission could result in a long runtime.")
+
+        # do a timeout check if param-free, to warn new users who accidentally set high timeout values.
+        if nested_params and "timeout" in self.params["params"]:
+            timeout = int(self.params["params"]["timeout"])
+            if timeout >= TIMEOUT_WARNING:
+                logger.warn(f"A large timeout has been set for this submission ({timeout}). If this is intended, disregard this warning. \
+                Otherwise, consider cancelling the job and resubmitting with a lower timeout.")
 
 class HardwarePlatform(Enum):
     CPU = 1

--- a/azure-quantum/azure/quantum/optimization/solvers.py
+++ b/azure-quantum/azure/quantum/optimization/solvers.py
@@ -107,6 +107,24 @@ class Solver:
             or the URL of an Azure Storage Blob where the serialized version
             of a Problem has been uploaded.
         """
+        # print a warning if we suspect the job may take long based on its configured properties.
+        if not isinstance(problem, str):
+            is_large_problem = problem.is_large()
+            if is_large_problem:
+                if nested_params and "sweeps" in self.params["params"]:
+                    sweeps = self.params["params"]["sweeps"]
+                    # if problem is large and sweeps is large, warn. 
+                    if sweeps >= 10000:
+                        logger.warn(f"There is a large problem submitted and a large number of sweeps ({sweeps}) configured. \
+                        This submission could result in a long runtime.")
+
+        # do a timeout check if param-free, to warn new users who accidentally set high timeout values.
+        if nested_params and "timeout" in self.params["params"]:
+            timeout = self.params["params"]["timeout"]
+            if timeout >= 600:
+                logger.warn(f"A large timeout has been set for this submission ({timeout}). If this is intended, disregard this warning. \
+                Otherwise, consider cancelling the job and resubmitting with a lower timeout.")
+
         job = self.submit(problem)
         logger.info(f"Submitted job: '{job.id}'")
         

--- a/azure-quantum/azure/quantum/optimization/solvers.py
+++ b/azure-quantum/azure/quantum/optimization/solvers.py
@@ -129,18 +129,18 @@ class Solver:
         # print a warning if we suspect the job may take long based on its configured properties.
         is_large_problem = problem.is_large()
         if is_large_problem:
-            if nested_params and "sweeps" in self.params["params"]:
+            if self.nested_params and "sweeps" in self.params["params"]:
                 sweeps = int(self.params["params"]["sweeps"])
                 # if problem is large and sweeps is large, warn. 
-                if sweeps >= SWEEPS_WARNING:
-                    logger.warn(f"There is a large problem submitted and a large number of sweeps ({sweeps}) configured. \
+                if sweeps >= Solver.SWEEPS_WARNING:
+                    logger.warning(f"There is a large problem submitted and a large number of sweeps ({sweeps}) configured. \
                     This submission could result in a long runtime.")
 
         # do a timeout check if param-free, to warn new users who accidentally set high timeout values.
-        if nested_params and "timeout" in self.params["params"]:
+        if self.nested_params and "timeout" in self.params["params"]:
             timeout = int(self.params["params"]["timeout"])
-            if timeout >= TIMEOUT_WARNING:
-                logger.warn(f"A large timeout has been set for this submission ({timeout}). If this is intended, disregard this warning. \
+            if timeout >= Solver.TIMEOUT_WARNING:
+                logger.warning(f"A large timeout has been set for this submission ({timeout}). If this is intended, disregard this warning. \
                 Otherwise, consider cancelling the job and resubmitting with a lower timeout.")
 
 class HardwarePlatform(Enum):

--- a/azure-quantum/tests/unit/test_optimization.py
+++ b/azure-quantum/tests/unit/test_optimization.py
@@ -188,6 +188,19 @@ class TestProblem(QuantumTestBase):
         problem2 = problem.set_fixed_variables({'0':0})
         self.assertEqual({'1':1, '2':1}, problem2.init_config)
 
+    def test_problem_large(self):
+        problem = Problem(name="test", terms=[], problem_type=ProblemType.pubo)
+        self.assertTrue(not problem.is_large())
+
+        problem.add_term(5.0, [])
+        self.assertTrue(not problem.is_large())
+
+        problem.add_term(6.0, list(range(3000)))
+        self.assertTrue(not problem.is_large())
+
+        problem.add_terms([Term(indices=[9999], c=1.0)]*int(1e6)) #create 2mil dummy terms
+        self.assertTrue(problem.is_large())
+
 def _init_ws_():
     return Workspace(
         subscription_id="subs_id", 

--- a/azure-quantum/tests/unit/test_optimization.py
+++ b/azure-quantum/tests/unit/test_optimization.py
@@ -198,7 +198,7 @@ class TestProblem(QuantumTestBase):
         problem.add_term(6.0, list(range(3000)))
         self.assertTrue(not problem.is_large())
 
-        problem.add_terms([Term(indices=[9999], c=1.0)]*int(1e6)) #create 2mil dummy terms
+        problem.add_terms([Term(indices=[9999], c=1.0)]*int(1e6)) #create 1mil dummy terms
         self.assertTrue(problem.is_large())
 
 def _init_ws_():


### PR DESCRIPTION
Adding some user warnings to potentially large problems or long runtimes.

The "large problem" definition is arbitrary and based on historical usage. 
Timeout threshold is also debatable and based on some historical data. However we can change them easily in the future. 