### PR TITLE
Fix Toshiba solver submit method call and target parameter name

### DIFF
--- a/azure-quantum/azure/quantum/optimization/toshiba/solvers.py
+++ b/azure-quantum/azure/quantum/optimization/toshiba/solvers.py
@@ -18,7 +18,7 @@ class SimulatedBifurcationMachine(Solver):
         workspace: Workspace,
         steps: Optional[int] = None,
         loops: Optional[int] = None,
-        target_val: Optional[float] = None,
+        target: Optional[float] = None,
         maxout: Optional[int] = None,
         timeout: Optional[float] = None,
         dt: Optional[float] = None,
@@ -47,7 +47,7 @@ class SimulatedBifurcationMachine(Solver):
             while repeating loops as many times as is specified.
             The default is 1. If 0 (zero) is specified, computation
             will be repeated until a timeout occurs. The maximum is 10,000,000.
-        :param target_val:
+        :param target:
             The end condition of a computation request. When the
             evaluation value reaches this value, the computation will stop.
             If 0 is specified for the parameter loops,
@@ -107,11 +107,11 @@ class SimulatedBifurcationMachine(Solver):
             input_data_format="microsoft.qio.v2",
             output_data_format="microsoft.qio-results.v2",
             nested_params=False,
-            force_str_params=True,
+            force_str_params=False,
         )
         self.set_one_param("steps", steps)
         self.set_one_param("loops", loops)
-        self.set_one_param("target_val", target_val)
+        self.set_one_param("target", target)
         self.set_one_param("maxout", maxout)
         self.set_one_param("timeout", timeout)
         self.set_one_param("dt", dt)
@@ -138,4 +138,4 @@ class SimulatedBifurcationMachine(Solver):
             Whether or not to compress the problem when uploading it
             the Blob Storage.
         """
-        super().submit(self=self, problem=problem, compress=False)
+        return super().submit(problem=problem, compress=False)


### PR DESCRIPTION
This PR fixes the following issues in the Toshiba solver introduced on `azure-quantum` package version `0.16.2104.138035`:

1. `solver.optimize()` produces an error “submit() got multiple values for argument 'self'”
   - Description: The following code, produces an exception:
     ```python
     solver = SimulatedBifurcationMachine(self.workspace, timeout=timeout, auto=True)
     result = solver.optimize(problem)
     ```
     Exception message: `submit() got multiple values for argument 'self'`

1. ` force_str_params` should be set to `False`
   - Description: With the current code, the number parameter like “loops” (integer) will have string type value.
 
1. The name of input params should be `target` instead of `target_val`
   - Description: All of “target_val” need to be changed to “target”.
 
1. There is no return value of the submit method
