### PR TITLE
Add translation from NPZ to Terms

### DIFF
--- a/azure-quantum/tests/unit/test_problem.py
+++ b/azure-quantum/tests/unit/test_problem.py
@@ -151,7 +151,7 @@ class TestProblemClass(unittest.TestCase):
         default_pubo = numpy.load(self.default_pubo)
         with_keywords_pubo = numpy.load(self.with_keywords_pubo)
 
-        # Valid files
+        ## Valid files
         self.assertTrue(self.problem.is_valid_npz(default_qubo.files))
         self.assertTrue(self.problem.is_valid_npz(
             default_qubo.files,
@@ -197,7 +197,6 @@ class TestProblemClass(unittest.TestCase):
             "k")
         )
 
-        # Wrong column names
         self.assertFalse(self.pubo_problem.is_valid_npz(
             with_keywords_pubo.files,
             ["x", "y", "z"],
@@ -221,7 +220,6 @@ class TestProblemClass(unittest.TestCase):
     def test_terms_from_npz_qubo(self):
         # Exceptions are raised for invalid file paths or files with incorrect naming
         self.assertRaises(Exception, self.problem.terms_from_npz, "invalid_file_path.npz")
-
         self.assertRaises(
             Exception,
             self.problem.terms_from_npz,
@@ -231,7 +229,6 @@ class TestProblemClass(unittest.TestCase):
         )
 
         # Terms are produced for valid files
-
         self.assertEqual(
             self.problem.terms_from_npz(self.default_qubo),
             self.problem.terms
@@ -249,7 +246,6 @@ class TestProblemClass(unittest.TestCase):
     def test_terms_from_npz_pubo(self):
         # Exceptions are raised for invalid file paths or files with incorrect naming
         self.assertRaises(Exception, self.pubo_problem.terms_from_npz, "invalid_file_path.npz")
-
         self.assertRaises(
             Exception,
             self.pubo_problem.terms_from_npz,
@@ -259,7 +255,6 @@ class TestProblemClass(unittest.TestCase):
         )
 
         # Terms are produced for valid files
-
         self.assertEqual(
             self.pubo_problem.terms_from_npz(
                 self.default_pubo,

--- a/azure-quantum/tests/unit/test_problem.py
+++ b/azure-quantum/tests/unit/test_problem.py
@@ -14,17 +14,75 @@ from azure.quantum.optimization import Problem, Term
 import azure.quantum.optimization.problem
 from common import expected_terms
 import json
+import numpy
+import os
 
 class TestProblemClass(unittest.TestCase):
     def setUp(self):
         self.mock_ws = Mock()
         self.mock_ws._get_linked_storage_sas_uri.return_value = Mock()
+
+        ## QUBO problem
         self.problem = Problem(name="test")
         self.problem.terms = [
             Term(c=3, indices=[1, 0]),
             Term(c=5, indices=[2, 0]),
         ]
         self.problem.uploaded_blob_uri = "mock_blob_uri"
+
+        # Create equivalent NPZ file for translation
+        self.problem.row = numpy.array([1, 2])
+        self.problem.col = numpy.array([0, 0])
+        self.problem.data = numpy.array([3, 5])
+        
+        # If arguments are passed to savez with no keywords
+        # then default names are used (e.g. "arr_0", "arr_1", etc)
+        # otherwise it uses those supplied by user (e.g. "row", "col", etc)
+        self.default_qubo = "default_qubo.npz"
+        numpy.savez(self.default_qubo, 
+            self.problem.row,
+            self.problem.col,
+            self.problem.data
+        )
+
+        self.with_keywords_qubo = "with_keywords_qubo.npz"
+        numpy.savez(self.with_keywords_qubo,
+            row=self.problem.row,
+            col=self.problem.col,
+            data=self.problem.data
+        )
+
+        ## PUBO problem
+        self.pubo_problem = Problem(name="test")
+        self.pubo_problem.terms = [
+            Term(c=3, indices=[1, 0, 1]),
+            Term(c=5, indices=[2, 0, 0]),
+            Term(c=-1, indices=[1, 0, 0]),
+            Term(c=4, indices=[0, 2, 1])
+        ]
+
+        # Create equivalent NPZ file for translation
+        self.pubo_problem.i = numpy.array([1, 2, 1, 0])
+        self.pubo_problem.j = numpy.array([0, 0, 0, 2])
+        self.pubo_problem.k = numpy.array([1, 0, 0, 1])
+        self.pubo_problem.c = numpy.array([3, 5, -1, 4])
+        
+        self.default_pubo = "default_pubo.npz"
+        numpy.savez(self.default_pubo, 
+            self.pubo_problem.i,
+            self.pubo_problem.j,
+            self.pubo_problem.k,
+            self.pubo_problem.c
+        )
+
+        self.with_keywords_pubo = "with_keywords_pubo.npz"
+        numpy.savez(self.with_keywords_pubo,
+            i=self.pubo_problem.i,
+            j=self.pubo_problem.j,
+            k=self.pubo_problem.k,
+            c=self.pubo_problem.c
+        )
+        
 
     def test_download(self):
         azure.quantum.optimization.problem.download_blob = Mock(
@@ -46,3 +104,189 @@ class TestProblemClass(unittest.TestCase):
         test_prob = Problem(name="random")
         with self.assertRaises(Exception):
             test_prob.get_terms(id=0)
+
+    def test_create_npz_file_default(self):
+        # When no keywords are supplied, columns have default names
+        # e.g. "arr_0", "arr_1" etc
+        
+        # QUBO
+        npz_file = numpy.load(self.default_qubo)
+        num_columns = 3
+
+        self.assertEqual(len(npz_file.files), num_columns)
+        for i in range(num_columns):
+            self.assertEqual(npz_file.files[i], "arr_%s" % i)
+
+        # PUBO
+        npz_file = numpy.load(self.default_pubo)
+        num_columns = 4
+
+        self.assertEqual(len(npz_file.files), num_columns)
+        for i in range(num_columns):
+            self.assertEqual(npz_file.files[i], "arr_%s" % i)
+
+    def test_create_npz_file_with_keywords(self):
+        # When keywords are supplied, columns use these names
+
+        # QUBO
+        npz_file = numpy.load(self.with_keywords_qubo)
+        keywords = ["row", "col", "data"]
+
+        self.assertEqual(len(npz_file.files), len(keywords))
+        for i in range(len(keywords)):
+            self.assertEqual(npz_file.files[i], keywords[i])
+
+        # PUBO
+        npz_file = numpy.load(self.with_keywords_pubo)
+        keywords = ["i", "j", "k", "c"]
+
+        self.assertEqual(len(npz_file.files), len(keywords))
+        for i in range(len(keywords)):
+            self.assertEqual(npz_file.files[i], keywords[i])
+
+    def test_valid_npz(self):
+        default_qubo = numpy.load(self.default_qubo)
+        with_keywords_qubo = numpy.load(self.with_keywords_qubo)
+
+        default_pubo = numpy.load(self.default_pubo)
+        with_keywords_pubo = numpy.load(self.with_keywords_pubo)
+
+        # Valid files
+        self.assertTrue(self.problem.is_valid_npz(default_qubo.files))
+        self.assertTrue(self.problem.is_valid_npz(
+            default_qubo.files,
+            ["arr_0", "arr_1"],
+            "arr_2")
+        )
+
+        self.assertTrue(self.problem.is_valid_npz(
+            with_keywords_qubo.files,
+            ["col", "row"],
+            "data")
+        )
+
+        self.assertTrue(self.pubo_problem.is_valid_npz(
+            default_pubo.files,
+            ["arr_0", "arr_1", "arr_2"],
+            "arr_3")
+        )
+        self.assertTrue(self.pubo_problem.is_valid_npz(
+            with_keywords_pubo.files,
+            ["i", "j", "k"],
+            "c")
+        )
+
+        ## Invalid files
+        # Too many columns
+        self.assertFalse(self.problem.is_valid_npz(
+            default_qubo.files,
+            ["arr_0", "arr_1", "arr_2"],
+            "arr_3")
+        )
+
+        self.assertFalse(self.pubo_problem.is_valid_npz(
+            default_pubo.files,
+            ["arr_0", "arr_1", "arr_2", "arr_3"],
+            "arr_4")
+        )
+
+        # Wrong column names
+        self.assertFalse(self.problem.is_valid_npz(
+            with_keywords_qubo.files,
+            ["i", "j"],
+            "k")
+        )
+
+        # Wrong column names
+        self.assertFalse(self.pubo_problem.is_valid_npz(
+            with_keywords_pubo.files,
+            ["x", "y", "z"],
+            "c")
+        )
+
+        # No indices column names
+        self.assertFalse(self.problem.is_valid_npz(
+            with_keywords_qubo.files,
+            [],
+            "data")
+        )
+
+        # Wrong coefficient column name
+        self.assertFalse(self.problem.is_valid_npz(
+           with_keywords_qubo.files,
+           ["row", "col"], 
+           "")
+        )
+
+    def test_terms_from_npz_qubo(self):
+        # Exceptions are raised for invalid file paths or files with incorrect naming
+        self.assertRaises(Exception, self.problem.terms_from_npz, "invalid_file_path.npz")
+
+        self.assertRaises(
+            Exception,
+            self.problem.terms_from_npz,
+            self.default_qubo,
+            ["arr_0", "arr_1", "arr_2"],
+            "arr_3"
+        )
+
+        # Terms are produced for valid files
+
+        self.assertEqual(
+            self.problem.terms_from_npz(self.default_qubo),
+            self.problem.terms
+        )
+
+        self.assertEqual(
+            self.problem.terms_from_npz(
+                self.with_keywords_qubo,
+                ["row", "col"],
+                "data"
+            ),
+            self.problem.terms
+        )
+
+    def test_terms_from_npz_pubo(self):
+        # Exceptions are raised for invalid file paths or files with incorrect naming
+        self.assertRaises(Exception, self.pubo_problem.terms_from_npz, "invalid_file_path.npz")
+
+        self.assertRaises(
+            Exception,
+            self.pubo_problem.terms_from_npz,
+            self.default_pubo,
+            ["arr_0", "arr_1", "arr_2", "arr_3"],
+            "arr_4"
+        )
+
+        # Terms are produced for valid files
+
+        self.assertEqual(
+            self.pubo_problem.terms_from_npz(
+                self.default_pubo,
+                ["arr_0", "arr_1", "arr_2"],
+                "arr_3"
+            ),
+            self.pubo_problem.terms
+        )
+
+        self.assertEqual(
+            self.pubo_problem.terms_from_npz(
+                self.with_keywords_pubo,
+                ["i", "j", "k"],
+                "c"
+            ),
+            self.pubo_problem.terms
+        )
+
+
+    def tearDown(self):
+        test_files = [
+            self.default_qubo,
+            self.with_keywords_qubo,
+            self.default_pubo,
+            self.with_keywords_pubo
+        ]
+
+        for test_file in test_files:
+            if os.path.isfile(test_file):
+                os.remove(test_file)


### PR DESCRIPTION
Adds a utility function `terms_from_npz()` to `problem.py`:
- includes helper function `is_valid_npz` to check whether the supplied NPZ file's array names match the default or user-supplied namings
- adds `terms_from_npz` which loads an NPZ file, reads in the data, and converts it to a list of `Term` (which can be added to a problem)
- adds unit tests to `test_problem.py`, this tests the loading of qubo and pubo problems from an NPZ file and their translation into Terms