### PR TITLE
Make the credential a required parameter to create a workspace

### DIFF
--- a/azure-quantum/azure/quantum/workspace.py
+++ b/azure-quantum/azure/quantum/workspace.py
@@ -76,6 +76,12 @@ class Workspace:
     If the Azure Quantum workspace does not have linked storage, the caller
     must also pass a valid Azure storage account connection string.
 
+    :param credential:
+        The credential to use to connect to Azure services.
+        Normally one of the credential types from Azure.Identity (https://docs.microsoft.com/en-us/python/api/overview/azure/identity-readme?view=azure-python#credential-classes).
+        Please see https://aka.ms/quantum-python-sdk-auth for 
+        more information and examples.
+
     :param subscription_id:
         The Azure subscription ID. Ignored if resource_id is specified.
 
@@ -97,27 +103,28 @@ class Workspace:
         The Azure region where the Azure Quantum workspace is provisioned.
         This may be specified as a region name such as
         \"East US\" or a location name such as \"eastus\".
-
-    :param credential:
-        The credential to use to connect to Azure services.
-        Normally one of the credential types from Azure.Identity (https://docs.microsoft.com/en-us/python/api/overview/azure/identity-readme?view=azure-python#credential-classes).
-
-        Defaults to \"DefaultAzureCredential\", which will attempt multiple 
-        forms of authentication.
     """
 
     credentials = None
 
     def __init__(
         self,
+        credential,
         subscription_id: Optional[str] = None,
         resource_group: Optional[str] = None,
         name: Optional[str] = None,
         storage: Optional[str] = None,
         resource_id: Optional[str] = None,
         location: Optional[str] = None,
-        credential: Optional[object] = DefaultAzureCredential(exclude_interactive_browser_credential=False),
     ):
+        if credential is None:
+            raise ValueError(
+                "You need to pass a credential to authenticate \
+                 against the Azure Services. \
+                 Please see https://aka.ms/quantum-python-sdk-auth \
+                 for more information."
+            )
+
         self.credentials = credential
 
         if resource_id is not None:

--- a/azure-quantum/tests/unit/test_workspace.py
+++ b/azure-quantum/tests/unit/test_workspace.py
@@ -11,7 +11,7 @@ import pytest
 
 from azure.quantum import Workspace
 from common import QuantumTestBase
-
+from azure.identity import DefaultAzureCredential
 
 class TestWorkspace(QuantumTestBase):
 
@@ -22,7 +22,10 @@ class TestWorkspace(QuantumTestBase):
         storage = "strg"
         location = "eastus"
 
+        credential = DefaultAzureCredential()
+
         ws = Workspace(
+            credential=credential,
             subscription_id=subscription_id,
             resource_group=resource_group,
             name=name,
@@ -34,6 +37,7 @@ class TestWorkspace(QuantumTestBase):
         assert ws.location == location
 
         ws = Workspace(
+            credential=credential,
             subscription_id=subscription_id,
             resource_group=resource_group,
             name=name,
@@ -43,12 +47,21 @@ class TestWorkspace(QuantumTestBase):
         assert ws.storage == storage
 
         resource_id = f"/subscriptions/{subscription_id}/ResourceGroups/{resource_group}/providers/Microsoft.Quantum/Workspaces/{name}"
-        ws = Workspace(resource_id=resource_id, location=location)
+        ws = Workspace(
+            credential=credential,
+            resource_id=resource_id, 
+            location=location
+        )
         assert ws.subscription_id == subscription_id
         assert ws.resource_group == resource_group
         assert ws.name == name
 
-        ws = Workspace(resource_id=resource_id, storage=storage, location=location)
+        ws = Workspace(
+            credential=credential,
+            resource_id=resource_id, 
+            storage=storage, 
+            location=location
+        )
         assert ws.storage == storage
 
     def test_create_workspace_locations(self):
@@ -56,9 +69,12 @@ class TestWorkspace(QuantumTestBase):
         resource_group = "rg"
         name = "n"
 
+        credential = DefaultAzureCredential()
+
         # location is mandatory
         with self.assertRaises(Exception) as context:
             ws = Workspace(
+                credential=credential,
                 subscription_id=subscription_id,
                 resource_group=resource_group,
                 name=name,
@@ -68,6 +84,7 @@ class TestWorkspace(QuantumTestBase):
         # User-provided location name should be normalized
         location = "East US"
         ws = Workspace(
+            credential=credential,
             subscription_id=subscription_id,
             resource_group=resource_group,
             name=name,
@@ -78,21 +95,29 @@ class TestWorkspace(QuantumTestBase):
     def test_create_workspace_instance_invalid(self):
         subscription_id = "44ef49ad-64e4-44e5-a3ba-1ee87e19d3f4"
         resource_group = "rg"
-        name = "n"
         storage = "strg"
 
-        with pytest.raises(ValueError):
-            ws = Workspace()
+        credential = DefaultAzureCredential()
 
         with pytest.raises(ValueError):
-            ws = Workspace(
+            Workspace(credential=credential)
+
+        with pytest.raises(ValueError):
+            Workspace(
+                credential=credential,
                 subscription_id=subscription_id,
                 resource_group=resource_group,
                 name="",
             )
 
         with pytest.raises(ValueError):
-            ws = Workspace(resource_id="invalid/resource/id")
+            Workspace(
+                credential=credential,
+                resource_id="invalid/resource/id"
+            )
 
         with pytest.raises(ValueError):
-            ws = Workspace(storage=storage)
+            Workspace(
+                credential=credential,
+                storage=storage
+            )


### PR DESCRIPTION
This PR makes the credential a required parameter to create a workspace, per Azure SDK recommendations.

Users will need to specify a valid Azure Credential from https://docs.microsoft.com/en-us/python/api/overview/azure/identity-readme?view=azure-python#credential-classes.

There will be another PR soon to create a new page in our docs with examples and the https://aka.ms/quantum-python-sdk-auth link will point to it. 
