### PR TITLE
Modify problem upload and add tests

### DIFF
--- a/azure-quantum/azure/quantum/optimization/problem.py
+++ b/azure-quantum/azure/quantum/optimization/problem.py
@@ -136,7 +136,7 @@ class Problem:
         self,
         workspace: "Workspace",
         container_name: str = "qio-problems",
-        blob_name: str = None,
+        blob_name: str = "inputData",
         compress: bool = True,
     ):
         """Uploads an optimization problem instance to
@@ -156,9 +156,6 @@ class Problem:
         blob_params = [workspace, container_name, blob_name, compress]
         if self.uploaded_blob_uri and self.uploaded_blob_params == blob_params:
             return self.uploaded_blob_uri
-
-        if blob_name is None:
-            blob_name = "{}-{}".format(self.name, uuid.uuid1())
 
         problem_json = self.serialize()
         logger.debug("Problem json: " + problem_json)

--- a/azure-quantum/tests/unit/test_problem.py
+++ b/azure-quantum/tests/unit/test_problem.py
@@ -82,7 +82,18 @@ class TestProblemClass(unittest.TestCase):
             k=self.pubo_problem.k,
             c=self.pubo_problem.c
         )
-        
+              
+    def test_upload(self):
+        azure.quantum.optimization.problem.BlobClient = Mock()
+        azure.quantum.optimization.problem.BlobClient.from_blob_url.return_value = Mock()
+        azure.quantum.optimization.problem.ContainerClient = Mock()
+        azure.quantum.optimization.problem.ContainerClient.from_container_url.return_value = Mock()
+        azure.quantum.optimization.problem.upload_blob = Mock()
+        azure.quantum.optimization.problem.upload_blob.get_blob_uri_with_sas_token = Mock()
+
+        assert(self.pubo_problem.uploaded_blob_uri == None)
+        actual_result = self.pubo_problem.upload(self.mock_ws)
+        azure.quantum.optimization.problem.upload_blob.assert_called_once() 
 
     def test_download(self):
         azure.quantum.optimization.problem.download_blob = Mock(
@@ -92,8 +103,8 @@ class TestProblemClass(unittest.TestCase):
         azure.quantum.optimization.problem.BlobClient.from_blob_url.return_value = Mock()
         azure.quantum.optimization.problem.ContainerClient = Mock()
         azure.quantum.optimization.problem.ContainerClient.from_container_url.return_value = Mock()
-        acutal_result = self.problem.download(self.mock_ws)
-        assert acutal_result.name == "test"
+        actual_result = self.problem.download(self.mock_ws)
+        assert actual_result.name == "test"
         azure.quantum.optimization.problem.download_blob.assert_called_once()
 
     def test_get_term(self):

--- a/azure-quantum/tests/unit/test_solvers.py
+++ b/azure-quantum/tests/unit/test_solvers.py
@@ -10,7 +10,7 @@
 import unittest
 from unittest.mock import Mock, patch
 from azure.quantum import Workspace, storage
-from azure.quantum.optimization import Solver, OnlineProblem
+from azure.quantum.optimization import Solver, OnlineProblem, Problem
 import azure.quantum.storage
 
 
@@ -22,6 +22,15 @@ class TestSolvers(unittest.TestCase):
         self.testsolver = Solver(
             self.mock_ws, "Microsoft", "SimulatedAnnealing", "json", "json"
         )
+
+    def test_submit_problem(self):
+        azure.quantum.optimization.problem.upload_blob = Mock()
+        azure.quantum.optimization.problem.upload_blob.get_blob_uri_with_sas_token = Mock()
+        
+        problem = Problem(name="test", terms = [])
+        job = self.testsolver.submit(problem)
+        azure.quantum.optimization.problem.upload_blob.assert_called_once()
+        self.testsolver.workspace.submit_job.assert_called_once()
 
     def test_submit_online_problem(self):
         # Arrange


### PR DESCRIPTION
## Overview
In Azure Quantum we have two main ways of submitting a problem to a solver:
1. Uploading the `Problem` to a `Workspace`, and then calling `submit()` supplying the returned URI for where the problem was uploaded:
```py
problem = Problem(name="test", terms = [])
uri = problem.upload(workspace)
job = solver.submit(uri)
```
2. Or we can call `submit()` supplying the `Problem`, which will upload the problem for the user automatically:
```py
problem = Problem(name="test", terms = [])
job = solver.submit(problem)
```

Currently the second method uses a default name for the blob, if the `submit` method receives an instance of a `Problem` then the blob name is by default set to "inputData": 
```py
elif isinstance(problem, Problem):
    name = problem.name
    problem_uri = problem.upload(
        self.workspace,
        compress=compress,
        container_name=container_name,
        blob_name="inputData",
    )
```
[source](https://github.com/frtibble/qdk-python/blob/fcc4600128bb3512d83b841e833fdd1d3efafb8a/azure-quantum/azure/quantum/optimization/solvers.py#L125)

In the first method, it uses a formatted version of the (user-defined) `Problem` name, e.g. "My Optimization Problem" or "Ship Balancing Problem" etc. 
```py
blob_name = "{}-{}".format(self.name, uuid.uuid1())
```
[source](https://github.com/microsoft/qdk-python/compare/main...frtibble:upload?expand=1#diff-b92db1ca1b2f7fda9616bd9cbbf59f2084c809b4b8a073b7299f41b504f2d128
)

In some cases this has resulted issues (due to the naming of the blob) causing the job to fail. To resolve this (and for consistency) this PR adopts the approach used in (2), by using a default name for the blob. Currently there isn't a requirement for this to be user-definable (as it isn't in (2)).

## Changes
- Modified the `upload()` method in `problem.py` to use a default blob_name (done in azure/quantum/optimization/solvers.py also)
- Adds a test cases for the `upload()` method and `submit()` method
- Minor typo fix
