### PR TITLE
azure-quantum: Require minimum version of dependencies

### DIFF
--- a/azure-quantum/README.md
+++ b/azure-quantum/README.md
@@ -28,6 +28,12 @@ Then to activate the environment:
 conda activate azure-quantum
 ```
 
+In case you have created the conda environment a while ago, you can make sure you have the latest versions of all dependencies by updating your environment:
+
+```bash
+conda env update -f environment.yml -n azure-quantum --prune
+```
+
 ### Install the local development package ###
 
 To install the package in development mode, run:

--- a/azure-quantum/environment.yml
+++ b/azure-quantum/environment.yml
@@ -4,8 +4,8 @@ channels:
   - conda-forge
 dependencies:
   - python=3.7
-  - pip>21.1.3
-  - pytest>6.2.4
+  - pip>=21.1.3
+  - pytest>=6.2.4
   - numpy>=1.21.0
   - deprecated>=1.2.12
   - msrest>=0.6.21

--- a/azure-quantum/environment.yml
+++ b/azure-quantum/environment.yml
@@ -4,14 +4,14 @@ channels:
   - conda-forge
 dependencies:
   - python=3.7
-  - pip
-  - pytest
-  - numpy
-  - deprecated
-  - msrest
-  - azure-core
-  - azure-identity
-  - azure-storage-blob
-  - azure-mgmt-core
+  - pip>21.1.3
+  - pytest>6.2.4
+  - numpy>=1.21.0
+  - deprecated>=1.2.12
+  - msrest>=0.6.21
+  - azure-core>=1.14.0
+  - azure-identity>=1.6.0
+  - azure-storage-blob>=12.8.1
+  - azure-mgmt-core>=1.2.2
   - pip:
-    - azure-devtools
+    - azure-devtools>=1.2.0

--- a/azure-quantum/requirements.txt
+++ b/azure-quantum/requirements.txt
@@ -1,7 +1,7 @@
-azure-core
-azure-identity
-azure-mgmt-core
-azure-storage-blob
-msrest
-numpy
-deprecated
+azure-core>=1.16.0
+azure-identity>=1.6.0
+azure-mgmt-core>= 1.3.0
+azure-storage-blob>=12.8.1
+msrest>=0.6.21
+numpy>=1.21.0
+deprecated>=1.2.12


### PR DESCRIPTION
This PR add requirements for minimum versions of the dependencies needed by the `azure-quantum` package.

We should eventually use Dependabot for this #41, but at least this is a start and if fixes issue #80.