### PR TITLE
Add limit checks for schedule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -399,3 +399,6 @@ azure-quantum/dist
 azure-quantum/temp
 azure-quantum/build
 !azure-quantum/tests/unit/recordings/*.yaml
+qdk/dist
+qdk/build
+*.txt

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,201 @@
+NOTICES AND INFORMATION
+Do Not Translate or Localize
+
+This software incorporates material from third parties. Microsoft makes certain
+open source code available at https://3rdpartysource.microsoft.com, or you may
+send a check or money order for US $5.00, including the product name, the open
+source component name, and version number, to:
+
+Source Code Compliance Team
+Microsoft Corporation
+One Microsoft Way
+Redmond, WA 98052
+USA
+
+Notwithstanding any other terms, you may reverse engineer this software to the
+extent required to debug changes to any libraries licensed under the GNU Lesser
+General Public License.
+
+---------------------------------------------------------
+---------------------------------------------------------
+
+certifi 2021.05.30 - MPL-2.0
+
+
+(c) 2006 Entrust, Inc.
+(c) 2007 GeoTrust Inc.
+(c) 2008 VeriSign, Inc.
+(c) 1999 Entrust.net Limited
+(c) 2009 Entrust, Inc. - for
+(c) 2012 Entrust, Inc. - for
+(c) 2015 Entrust, Inc. - for
+(c) 2006 Entrust, Inc. Label Entrust Root Certification
+(c) 1999 Entrust.net Limited Label Entrust.net Premium 2048 Secure Server CA Serial
+
+Mozilla Public License Version 2.0
+
+   1. Definitions
+
+      1.1. "Contributor" means each individual or legal entity that creates, contributes to the creation of, or owns Covered Software.
+
+      1.2. "Contributor Version" means the combination of the Contributions of others (if any) used by a Contributor and that particular Contributor's Contribution.
+
+      1.3. "Contribution" means Covered Software of a particular Contributor.
+
+      1.4. "Covered Software" means Source Code Form to which the initial Contributor has attached the notice in Exhibit A, the Executable Form of such Source Code Form, and Modifications of such Source Code Form, in each case including portions thereof.
+
+      1.5. "Incompatible With Secondary Licenses" means
+
+         (a) that the initial Contributor has attached the notice described in Exhibit B to the Covered Software; or
+
+         (b) that the Covered Software was made available under the terms of version 1.1 or earlier of the License, but not also under the terms of a Secondary License.
+
+      1.6. "Executable Form" means any form of the work other than Source Code Form.
+
+      1.7. "Larger Work" means a work that combines Covered Software with other material, in a separate file or files, that is not Covered Software.
+
+      1.8. "License" means this document.
+
+      1.9. "Licensable" means having the right to grant, to the maximum extent possible, whether at the time of the initial grant or subsequently, any and all of the rights conveyed by this License.
+
+      1.10. "Modifications" means any of the following:
+
+         (a) any file in Source Code Form that results from an addition to, deletion from, or modification of the contents of Covered Software; or
+
+         (b) any new file in Source Code Form that contains any Covered Software.
+
+      1.11. "Patent Claims" of a Contributor means any patent claim(s), including without limitation, method, process, and apparatus claims, in any patent Licensable by such Contributor that would be infringed, but for the grant of the License, by the making, using, selling, offering for sale, having made, import, or transfer of either its Contributions or its Contributor Version.
+
+      1.12. "Secondary License" means either the GNU General Public License, Version 2.0, the GNU Lesser General Public License, Version 2.1, the GNU Affero General Public License, Version 3.0, or any later versions of those licenses.
+
+      1.13. "Source Code Form" means the form of the work preferred for making modifications.
+
+      1.14. "You" (or "Your") means an individual or a legal entity exercising rights under this License. For legal entities, "You" includes any entity that controls, is controlled by, or is under common control with You. For purposes of this definition, "control" means (a) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (b) ownership of more than fifty percent (50%) of the outstanding shares or beneficial ownership of such entity.
+
+   2. License Grants and Conditions
+
+      2.1. Grants
+
+      Each Contributor hereby grants You a world-wide, royalty-free, non-exclusive license:
+
+         (a) under intellectual property rights (other than patent or trademark) Licensable by such Contributor to use, reproduce, make available, modify, display, perform, distribute, and otherwise exploit its Contributions, either on an unmodified basis, with Modifications, or as part of a Larger Work; and
+
+         (b) under Patent Claims of such Contributor to make, use, sell, offer for sale, have made, import, and otherwise transfer either its Contributions or its Contributor Version.
+
+      2.2. Effective Date
+
+      The licenses granted in Section 2.1 with respect to any Contribution become effective for each Contribution on the date the Contributor first distributes such Contribution.
+
+      2.3. Limitations on Grant Scope
+
+      The licenses granted in this Section 2 are the only rights granted under this License. No additional rights or licenses will be implied from the distribution or licensing of Covered Software under this License. Notwithstanding Section 2.1(b) above, no patent license is granted by a Contributor:
+
+         (a) for any code that a Contributor has removed from Covered Software; or
+
+         (b) for infringements caused by: (i) Your and any other third party's modifications of Covered Software, or (ii) the combination of its Contributions with other software (except as part of its Contributor Version); or
+
+         (c) under Patent Claims infringed by Covered Software in the absence of its Contributions.
+
+      This License does not grant any rights in the trademarks, service marks, or logos of any Contributor (except as may be necessary to comply with the notice requirements in Section 3.4).
+
+      2.4. Subsequent Licenses
+
+      No Contributor makes additional grants as a result of Your choice to distribute the Covered Software under a subsequent version of this License (see Section 10.2) or under the terms of a Secondary License (if permitted under the terms of Section 3.3).
+
+      2.5. Representation
+
+      Each Contributor represents that the Contributor believes its Contributions are its original creation(s) or it has sufficient rights to grant the rights to its Contributions conveyed by this License.
+
+      2.6. Fair Use
+
+      This License is not intended to limit any rights You have under applicable copyright doctrines of fair use, fair dealing, or other equivalents.
+
+      2.7. Conditions
+
+      Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in Section 2.1.
+
+   3. Responsibilities
+
+      3.1. Distribution of Source Form
+
+      All distribution of Covered Software in Source Code Form, including any Modifications that You create or to which You contribute, must be under the terms of this License. You must inform recipients that the Source Code Form of the Covered Software is governed by the terms of this License, and how they can obtain a copy of this License. You may not attempt to alter or restrict the recipients' rights in the Source Code Form.
+
+      3.2. Distribution of Executable Form
+
+      If You distribute Covered Software in Executable Form then:
+
+         (a) such Covered Software must also be made available in Source Code Form, as described in Section 3.1, and You must inform recipients of the Executable Form how they can obtain a copy of such Source Code Form by reasonable means in a timely manner, at a charge no more than the cost of distribution to the recipient; and
+
+         (b) You may distribute such Executable Form under the terms of this License, or sublicense it under different terms, provided that the license for the Executable Form does not attempt to limit or alter the recipients' rights in the Source Code Form under this License.
+
+      3.3. Distribution of a Larger Work
+
+      You may create and distribute a Larger Work under terms of Your choice, provided that You also comply with the requirements of this License for the Covered Software. If the Larger Work is a combination of Covered Software with a work governed by one or more Secondary Licenses, and the Covered Software is not Incompatible With Secondary Licenses, this License permits You to additionally distribute such Covered Software under the terms of such Secondary License(s), so that the recipient of the Larger Work may, at their option, further distribute the Covered Software under the terms of either this License or such Secondary License(s).
+
+      3.4. Notices
+
+      You may not remove or alter the substance of any license notices (including copyright notices, patent notices, disclaimers of warranty, or limitations of liability) contained within the Source Code Form of the Covered Software, except that You may alter any license notices to the extent required to remedy known factual inaccuracies.
+
+      3.5. Application of Additional Terms
+
+      You may choose to offer, and to charge a fee for, warranty, support, indemnity or liability obligations to one or more recipients of Covered Software. However, You may do so only on Your own behalf, and not on behalf of any Contributor. You must make it absolutely clear that any such warranty, support, indemnity, or liability obligation is offered by You alone, and You hereby agree to indemnify every Contributor for any liability incurred by such Contributor as a result of warranty, support, indemnity or liability terms You offer. You may include additional disclaimers of warranty and limitations of liability specific to any jurisdiction.
+
+   4. Inability to Comply Due to Statute or Regulation
+
+   If it is impossible for You to comply with any of the terms of this License with respect to some or all of the Covered Software due to statute, judicial order, or regulation then You must: (a) comply with the terms of this License to the maximum extent possible; and (b) describe the limitations and the code they affect. Such description must be placed in a text file included with all distributions of the Covered Software under this License. Except to the extent prohibited by statute or regulation, such description must be sufficiently detailed for a recipient of ordinary skill to be able to understand it.
+
+   5. Termination
+
+      5.1. The rights granted under this License will terminate automatically if You fail to comply with any of its terms. However, if You become compliant, then the rights granted under this License from a particular Contributor are reinstated (a) provisionally, unless and until such Contributor explicitly and finally terminates Your grants, and (b) on an ongoing basis, if such Contributor fails to notify You of the non-compliance by some reasonable means prior to 60 days after You have come back into compliance. Moreover, Your grants from a particular Contributor are reinstated on an ongoing basis if such Contributor notifies You of the non-compliance by some reasonable means, this is the first time You have received notice of non-compliance with this License from such Contributor, and You become compliant prior to 30 days after Your receipt of the notice.
+
+      5.2. If You initiate litigation against any entity by asserting a patent infringement claim (excluding declaratory judgment actions, counter-claims, and cross-claims) alleging that a Contributor Version directly or indirectly infringes any patent, then the rights granted to You by any and all Contributors for the Covered Software under Section 2.1 of this License shall terminate.
+
+      5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user license agreements (excluding distributors and resellers) which have been validly granted by You or Your distributors under this License prior to termination shall survive termination.
+
+   6. Disclaimer of Warranty
+
+   Covered Software is provided under this License on an "as is" basis, without warranty of any kind, either expressed, implied, or statutory, including, without limitation, warranties that the Covered Software is free of defects, merchantable, fit for a particular purpose or non-infringing. The entire risk as to the quality and performance of the Covered Software is with You. Should any Covered Software prove defective in any respect, You (not any Contributor) assume the cost of any necessary servicing, repair, or correction. This disclaimer of warranty constitutes an essential part of this License. No use of any Covered Software is authorized under this License except under this disclaimer.
+
+   7. Limitation of Liability
+
+   Under no circumstances and under no legal theory, whether tort (including negligence), contract, or otherwise, shall any Contributor, or anyone who distributes Covered Software as permitted above, be liable to You for any direct, indirect, special, incidental, or consequential damages of any character including, without limitation, damages for lost profits, loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses, even if such party shall have been informed of the possibility of such damages. This limitation of liability shall not apply to liability for death or personal injury resulting from such party's negligence to the extent applicable law prohibits such limitation. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so this exclusion and limitation may not apply to You.
+
+   8. Litigation
+
+   Any litigation relating to this License may be brought only in the courts of a jurisdiction where the defendant maintains its principal place of business and such litigation shall be governed by laws of that jurisdiction, without reference to its conflict-of-law provisions. Nothing in this Section shall prevent a party's ability to bring cross-claims or counter-claims.
+
+   9. Miscellaneous
+
+   This License represents the complete agreement concerning the subject matter hereof. If any provision of this License is held to be unenforceable, such provision shall be reformed only to the extent necessary to make it enforceable. Any law or regulation which provides that the language of a contract shall be construed against the drafter shall not be used to construe this License against a Contributor.
+
+   10. Versions of the License
+
+      10.1. New Versions
+
+      Mozilla Foundation is the license steward. Except as provided in Section 10.3, no one other than the license steward has the right to modify or publish new versions of this License. Each version will be given a distinguishing version number.
+
+      10.2. Effect of New Versions
+
+      You may distribute the Covered Software under the terms of the version of the License under which You originally received the Covered Software, or under the terms of any subsequent version published by the license steward.
+
+      10.3. Modified Versions
+
+      If you create software not governed by this License, and you want to create a new license for such software, you may create and use a modified version of this License if you rename the license and remove any references to the name of the license steward (except to note that such modified license differs from this License).
+
+      10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
+
+      If You choose to distribute Source Code Form that is Incompatible With Secondary Licenses under the terms of this version of the License, the notice described in Exhibit B of this License must be attached. Exhibit A - Source Code Form License Notice
+
+This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file, then You may include the notice in a location (such as a LICENSE file in a relevant directory) where a recipient would be likely to look for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+
+This Source Code Form is "Incompatible With Secondary Licenses", as defined by the Mozilla Public License, v. 2.0.
+
+
+---------------------------------------------------------
+---------------------------------------------------------

--- a/azure-quantum/README.md
+++ b/azure-quantum/README.md
@@ -28,6 +28,12 @@ Then to activate the environment:
 conda activate azure-quantum
 ```
 
+In case you have created the conda environment a while ago, you can make sure you have the latest versions of all dependencies by updating your environment:
+
+```bash
+conda env update -f environment.yml -n azure-quantum --prune
+```
+
 ### Install the local development package ###
 
 To install the package in development mode, run:

--- a/azure-quantum/azure/quantum/optimization/solvers.py
+++ b/azure-quantum/azure/quantum/optimization/solvers.py
@@ -585,6 +585,7 @@ class SubstochasticMonteCarlo(Solver):
         step_limit: Optional[int] = None,
         beta: Optional[RangeSchedule] = None,
         steps_per_walker: Optional[int] = None,
+        timeout: Optional[int] = None,
     ):
         """The constructor of Substochastic Monte Carlo solver.
 
@@ -606,8 +607,17 @@ class SubstochasticMonteCarlo(Solver):
             beta (resampling factor) values evolve over time
         :param steps_per_walker:
             number of steps to attempt for each walker, must be postive
+        :param timeout:
+            specifies maximum number of seconds to run the core solver
+            loop. Initialization time does not respect this value, so the
+            solver may run longer than the value specified. Setting this value
+            will trigger the parameter free substochastic monte carlo solver.
         """
-        target = "microsoft.substochasticmontecarlo.cpu"
+
+        if timeout is None:
+            target = "microsoft.substochasticmontecarlo.cpu" 
+        else:
+            target = "microsoft.substochasticmontecarlo-parameterfree.cpu"
         super().__init__(
             workspace=workspace,
             provider="Microsoft",
@@ -621,3 +631,4 @@ class SubstochasticMonteCarlo(Solver):
         self.check_set_positive_int(target_population, "target_population")
         self.check_set_positive_int(steps_per_walker, "steps_per_walker")
         self.check_set_positive_int(step_limit, "step_limit")
+        self.check_set_positive_int(timeout, "timeout")

--- a/azure-quantum/azure/quantum/optimization/solvers.py
+++ b/azure-quantum/azure/quantum/optimization/solvers.py
@@ -234,15 +234,15 @@ class Solver:
         the specified bound.
 
         :param schedule_name:
-            name of the schedule parameter.
+            Name of the schedule parameter.
         :param schedule_value:
-            schedule value to be assigned and checked.
+            Schedule value to be assigned and checked.
         :param evolution
-            expected schedule evolution (INCREASING or DECREASING)
+            Expected schedule evolution (INCREASING or DECREASING)
         :lower_bound_exclusive:
-            exclusive lower bound for both ends of the schedule, optional.
+            Exclusive lower bound for both ends of the schedule, optional.
         :lower_bound_inclusive:
-            inclusive lower bound for both ends of the schedule, optional.
+            Inclusive lower bound for both ends of the schedule, optional.
         """
         if not (schedule_value is None):
             if not isinstance(schedule_value, RangeSchedule):
@@ -294,9 +294,9 @@ class Solver:
         and check that it is a positive integer.
 
         :param parameter_name:
-            name of the parameter.
+            Name of the parameter.
         :param parameter_value:
-            value to be assigned and checked.
+            Value to be assigned and checked.
         """
         if not (parameter_value is None):
             if not isinstance(parameter_value, int):
@@ -321,13 +321,13 @@ class Solver:
         and check that it has a float value satisfying bounds.
 
         :param parameter_name:
-            name of the parameter.
+            Name of the parameter.
         :param parameter_value:
-            value to be assigned and checked.
+            Value to be assigned and checked.
         :lower_bound_exclusive:
-            exclusive lower bound to check parameter_value against, optional.
+            Exclusive lower bound to check parameter_value against, optional.
         :lower_bound_inclusive:
-            inclusive lower bound to check parameter_value against, optional.
+            Inclusive lower bound to check parameter_value against, optional.
         """
         if not (parameter_value is None):
             if not (isinstance(parameter_value, float) or
@@ -350,13 +350,13 @@ class Solver:
         """Check whether `parameter_value` satisfies a lower bound.
 
         :param parameter_name:
-            name of the parameter.
+            Name of the parameter.
         :param parameter_value:
-            value to be checked.
+            Value to be checked.
         :lower_bound_exclusive:
-            exclusive lower bound to check parameter_value against, optional.
+            Exclusive lower bound to check parameter_value against, optional.
         :lower_bound_inclusive:
-            inclusive lower bound to check parameter_value against, optional.
+            Inclusive lower bound to check parameter_value against, optional.
         """
         if not (parameter_value is None):
             if (lower_bound_exclusive is not None and

--- a/azure-quantum/azure/quantum/optimization/solvers.py
+++ b/azure-quantum/azure/quantum/optimization/solvers.py
@@ -221,7 +221,7 @@ class Solver:
     def check_set_schedule(
         self, schedule: RangeSchedule, schedule_name: str,
         evolution: Optional[ScheduleEvolution] = None,
-        lower_bound: Optional[float] = None,
+        lower_bound_exclusive: Optional[float] = None,
         lower_bound_inclusive: Optional[float] = None,
     ):
         """Check whether the schedule parameter is set well from RangeSchedule.
@@ -231,7 +231,7 @@ class Solver:
             name of the schedule parameter.
         :param evolution
             expected schedule evolution (INCREASING or DECREASING)
-        :lower_bound:
+        :lower_bound_exclusive:
             lower limit value of the schedule to be checked (exclusive)
         :lower_bound_inclusive:
             lower limit value of the schedule to be checked (inclusive)
@@ -265,11 +265,11 @@ class Solver:
                     )
             self.check_limit(
                     schedule.initial, f"{schedule_name}.initial",
-                    lower_bound=lower_bound,
+                    lower_bound_exclusive=lower_bound_exclusive,
                     lower_bound_inclusive=lower_bound_inclusive)
             self.check_limit(
                     schedule.final, f"{schedule_name}.final",
-                    lower_bound=lower_bound,
+                    lower_bound_exclusive=lower_bound_exclusive,
                     lower_bound_inclusive=lower_bound_inclusive)
             self.set_one_param(schedule_name, schedule_param)
 
@@ -289,7 +289,7 @@ class Solver:
 
     def check_set_float_limit(
         self, var: float, var_name: str,
-        lower_bound: Optional[float] = None,
+        lower_bound_exclusive: Optional[float] = None,
         lower_bound_inclusive: Optional[float] = None,
     ):
         """Check whether the var parameter is a float satisfying bounds.
@@ -298,7 +298,7 @@ class Solver:
             whether is a float larger than var_limit.
         :param var_name:
             name of the variable.
-        :lower_bound:
+        :lower_bound_exclusive:
             lower limit value of the variable to be checked (exclusive)
         :lower_bound_inclusive:
             lower limit value of the variable to be checked (inclusive)
@@ -307,13 +307,13 @@ class Solver:
             if not (isinstance(var, float) or isinstance(var, int)):
                 raise ValueError(f"{var_name} shall be float!")
             self.check_limit(
-                    var, var_name, lower_bound=lower_bound,
+                    var, var_name, lower_bound_exclusive=lower_bound_exclusive,
                     lower_bound_inclusive=lower_bound_inclusive)
             self.set_one_param(var_name, var)
 
     def check_limit(
         self, var: Optional[float], var_name: str,
-        lower_bound: Optional[float] = None,
+        lower_bound_exclusive: Optional[float] = None,
         lower_bound_inclusive: Optional[float] = None,
     ):
         """Check whether the var parameter is a float satisfying bounds.
@@ -322,15 +322,17 @@ class Solver:
             whether is a float larger than var_limit.
         :param var_name:
             name of the variable.
-        :lower_bound:
+        :lower_bound_exclusive:
             lower limit value of the variable to be checked (exclusive)
         :lower_bound_inclusive:
             lower limit value of the variable to be checked (inclusive)
         """
         if not (var is None):
-            if lower_bound is not None and var <= lower_bound:
+            if (lower_bound_exclusive is not None and
+                    var <= lower_bound_exclusive):
                 raise ValueError(
-                    f"{var_name} must be greater than {lower_bound}; "
+                    f"{var_name} must be greater than "
+                    f"{lower_bound_exclusive}; "
                     f"found {var_name}={var}."
                 )
             if (lower_bound_inclusive is not None and
@@ -639,13 +641,13 @@ class PopulationAnnealing(Solver):
             output_data_format="microsoft.qio-results.v2",
         )
 
-        self.check_set_float_limit(alpha, "alpha", lower_bound=1.0)
+        self.check_set_float_limit(alpha, "alpha", lower_bound_exclusive=1.0)
         self.set_one_param("seed", seed)
         self.check_set_positive_int(population, "population")
         self.check_set_positive_int(sweeps, "sweeps")
         self.check_set_schedule(
                 beta, "beta", evolution=self.ScheduleEvolution.INCREASING,
-                lower_bound=0)
+                lower_bound_exclusive=0)
 
 
 class SubstochasticMonteCarlo(Solver):
@@ -708,9 +710,9 @@ class SubstochasticMonteCarlo(Solver):
         self.check_set_positive_int("target_population", target_population)
         self.check_set_positive_int("step_limit", step_limit)
         self.check_set_schedule(
-                alpha, "alpha", evolution=self.ScheduleEvolution.DECREASING,
+                "alpha", alpha, evolution=self.ScheduleEvolution.DECREASING,
                 lower_bound_inclusive=0)
         self.check_set_schedule(
-                beta, "beta", evolution=self.ScheduleEvolution.INCREASING,
-                lower_bound=0)
+                "beta", beta, evolution=self.ScheduleEvolution.INCREASING,
+                lower_bound_exclusive=0)
         self.check_set_positive_int("timeout", timeout)

--- a/azure-quantum/azure/quantum/optimization/solvers.py
+++ b/azure-quantum/azure/quantum/optimization/solvers.py
@@ -268,7 +268,7 @@ class Solver:
                     lower_bound=lower_bound,
                     lower_bound_inclusive=lower_bound_inclusive)
             self.check_limit(
-                    schedule.initial, f"{schedule_name}.final",
+                    schedule.final, f"{schedule_name}.final",
                     lower_bound=lower_bound,
                     lower_bound_inclusive=lower_bound_inclusive)
             self.set_one_param(schedule_name, schedule_param)
@@ -307,7 +307,7 @@ class Solver:
             if not (isinstance(var, float) or isinstance(var, int)):
                 raise ValueError(f"{var_name} shall be float!")
             self.check_limit(
-                    lower_bound=lower_bound,
+                    var, var_name, lower_bound=lower_bound,
                     lower_bound_inclusive=lower_bound_inclusive)
             self.set_one_param(var_name, var)
 

--- a/azure-quantum/azure/quantum/optimization/solvers.py
+++ b/azure-quantum/azure/quantum/optimization/solvers.py
@@ -230,7 +230,7 @@ class Solver:
         :param schedule_name:
             name of the schedule parameter.
         :param evolution
-            required ScheduleEvolution (INCREASING or DECREASING)
+            expected schedule evolution (INCREASING or DECREASING)
         :lower_bound:
             lower limit value of the schedule to be checked (exclusive)
         :lower_bound_inclusive:

--- a/azure-quantum/azure/quantum/optimization/solvers.py
+++ b/azure-quantum/azure/quantum/optimization/solvers.py
@@ -32,15 +32,15 @@ __all__ = [
 
 class RangeSchedule:
     def __init__(self, schedule_type: str, initial: float, final: float):
-        """The constructor of Range Scheduler for solver.
+        """Constructor of RangeSchedule for solvers.
 
         :param schedule_type:
-            specifies schedule_type of range scheduler,
-            currently only support 'linear' and 'geometric'.
+            str, type of the RangeSchedule
+            currently only supports 'linear' and 'geometric'.
         :param initial:
-            initial value of range schedule.
+            float, initial value of RangeSchedule
         :param final:
-            stop value of range schedule
+            float, final value of the RangeSchedule
         """
         self.schedule_type = schedule_type
         self.initial = initial
@@ -49,7 +49,7 @@ class RangeSchedule:
             self.schedule_type == "linear" or self.schedule_type == "geometric"
         ):
             raise ValueError(
-                '"schedule_type" can only be "linear" or "geometric"!'
+                '"schedule_type" must be "linear" or "geometric"!'
             )
 
 
@@ -179,8 +179,11 @@ class Solver:
             params[name] = str(value) if self.force_str_params else value
 
     def set_number_of_solutions(self, number_of_solutions: int):
-        """Sets the number of solutions to return. Applies to all solvers. Default 1 if not supplied.
-        
+        """Sets the number of solutions to return.
+
+        Applies to all solvers.
+        Default value is 1 if not supplied.
+
         :param number_of_solutions:
             Number of solutions to return. Must be a positive integer.
         """
@@ -219,128 +222,156 @@ class Solver:
         DECREASING = 2
 
     def check_set_schedule(
-        self, schedule: RangeSchedule, schedule_name: str,
+        self,
+        schedule_name: str,
+        schedule_value: RangeSchedule,
         evolution: Optional[ScheduleEvolution] = None,
         lower_bound_exclusive: Optional[float] = None,
         lower_bound_inclusive: Optional[float] = None,
     ):
-        """Check whether the schedule parameter is set well from RangeSchedule.
-        :param schedule:
-            schedule paramter to be checked whether is from RangeSchedule.
+        """Set the parameter `schedule_name` from the value `schedule_value`
+        and check that it is of type `RangeSchedule` and each end satisfies
+        the specified bound.
+
         :param schedule_name:
             name of the schedule parameter.
+        :param schedule_value:
+            schedule value to be assigned and checked.
         :param evolution
             expected schedule evolution (INCREASING or DECREASING)
         :lower_bound_exclusive:
-            lower limit value of the schedule to be checked (exclusive)
+            exclusive lower bound for both ends of the schedule, optional.
         :lower_bound_inclusive:
-            lower limit value of the schedule to be checked (inclusive)
+            inclusive lower bound for both ends of the schedule, optional.
         """
-        if not (schedule is None):
-            if not isinstance(schedule, RangeSchedule):
+        if not (schedule_value is None):
+            if not isinstance(schedule_value, RangeSchedule):
                 raise ValueError(
-                    f'{schedule_name} can only be from class "RangeSchedule"!'
+                    f"{schedule_name} must be of type RangeSchedule; found"
+                    f" type({schedule_name})={type(schedule_value).__name__}."
                 )
             schedule_param = {
-                "type": schedule.schedule_type,
-                "initial": schedule.initial,
-                "final": schedule.final,
+                "type": schedule_value.schedule_type,
+                "initial": schedule_value.initial,
+                "final": schedule_value.final,
             }
             if evolution is not None:
                 if (evolution == self.ScheduleEvolution.INCREASING and
-                        schedule.initial > schedule.final):
+                        schedule_value.initial > schedule_value.final):
                     raise ValueError(
                             f"Schedule for {schedule_name} must be increasing;"
-                            f" found {schedule_name}.initial = "
-                            f"{schedule.initial} > {schedule.final} = "
-                            f"{schedule_name}.final."
+                            f" found {schedule_name}.initial"
+                            f"={schedule_value.initial}"
+                            f" > {schedule_value.final}"
+                            f"={schedule_name}.final."
                     )
                 if (evolution == self.ScheduleEvolution.DECREASING and
-                        schedule.initial < schedule.final):
+                        schedule_value.initial < schedule_value.final):
                     raise ValueError(
                             f"Schedule for {schedule_name} must be decreasing;"
-                            f" found {schedule_name}.initial = "
-                            f"{schedule.initial} < {schedule.final} = "
-                            f"{schedule_name}.final."
+                            f" found {schedule_name}.initial"
+                            f"={schedule_value.initial}"
+                            f" < {schedule_value.final}"
+                            f"={schedule_name}.final."
                     )
             self.check_limit(
-                    schedule.initial, f"{schedule_name}.initial",
+                    f"{schedule_name}.initial",
+                    schedule_value.initial,
                     lower_bound_exclusive=lower_bound_exclusive,
                     lower_bound_inclusive=lower_bound_inclusive)
             self.check_limit(
-                    schedule.final, f"{schedule_name}.final",
+                    f"{schedule_name}.final",
+                    schedule_value.final,
                     lower_bound_exclusive=lower_bound_exclusive,
                     lower_bound_inclusive=lower_bound_inclusive)
             self.set_one_param(schedule_name, schedule_param)
 
-    def check_set_positive_int(self, var: int, var_name: str):
-        """Check whether the var parameter is a positive integer.
-        :param var:
-            var paramter to be checked whether is a positive integer.
-        :param var_name:
-            name of the variable.
-        """
-        if not (var is None):
-            if not isinstance(var, int):
-                raise ValueError(f"{var_name} shall be int!")
-            if var <= 0:
-                raise ValueError(f"{var_name} must be positive!")
-            self.set_one_param(var_name, var)
+    def check_set_positive_int(
+            self,
+            parameter_name: str,
+            parameter_value: int):
+        """Set the parameter `parameter_name` from the value `parameter_value`
+        and check that it is a positive integer.
 
-    def check_set_float_limit(
-        self, var: float, var_name: str,
+        :param parameter_name:
+            name of the parameter.
+        :param parameter_value:
+            value to be assigned and checked.
+        """
+        if not (parameter_value is None):
+            if not isinstance(parameter_value, int):
+                raise ValueError(
+                        f"{parameter_name} must be of type int; found"
+                        f"type({parameter_name})"
+                        f"={type(parameter_value).__name__}.")
+            if parameter_value <= 0:
+                raise ValueError(
+                        f"{parameter_name} must be positive; found "
+                        f"{parameter_name}={parameter_value}.")
+            self.set_one_param(parameter_name, parameter_value)
+
+    def check_set_float(
+        self,
+        parameter_name: str,
+        parameter_value: float,
         lower_bound_exclusive: Optional[float] = None,
         lower_bound_inclusive: Optional[float] = None,
     ):
-        """Check whether the var parameter is a float satisfying bounds.
-        :param var:
-            var paramter to be checked
-            whether is a float larger than var_limit.
-        :param var_name:
-            name of the variable.
+        """Set the parameter `parameter_name` from the value `parameter_value`
+        and check that it has a float value satisfying bounds.
+
+        :param parameter_name:
+            name of the parameter.
+        :param parameter_value:
+            value to be assigned and checked.
         :lower_bound_exclusive:
-            lower limit value of the variable to be checked (exclusive)
+            exclusive lower bound to check parameter_value against, optional.
         :lower_bound_inclusive:
-            lower limit value of the variable to be checked (inclusive)
+            inclusive lower bound to check parameter_value against, optional.
         """
-        if not (var is None):
-            if not (isinstance(var, float) or isinstance(var, int)):
-                raise ValueError(f"{var_name} shall be float!")
+        if not (parameter_value is None):
+            if not (isinstance(parameter_value, float) or
+                    isinstance(parameter_value, int)):
+                raise ValueError(f"{parameter_name} must be a float!")
             self.check_limit(
-                    var, var_name, lower_bound_exclusive=lower_bound_exclusive,
+                    parameter_name=parameter_name,
+                    parameter_value=parameter_value,
+                    lower_bound_exclusive=lower_bound_exclusive,
                     lower_bound_inclusive=lower_bound_inclusive)
-            self.set_one_param(var_name, var)
+            self.set_one_param(parameter_name, parameter_value)
 
     def check_limit(
-        self, var: Optional[float], var_name: str,
+        self,
+        parameter_name: str,
+        parameter_value: Optional[float],
         lower_bound_exclusive: Optional[float] = None,
         lower_bound_inclusive: Optional[float] = None,
     ):
-        """Check whether the var parameter is a float satisfying bounds.
-        :param var:
-            var paramter to be checked
-            whether is a float larger than var_limit.
-        :param var_name:
-            name of the variable.
+        """Check whether `parameter_value` satisfies a lower bound.
+
+        :param parameter_name:
+            name of the parameter.
+        :param parameter_value:
+            value to be checked.
         :lower_bound_exclusive:
-            lower limit value of the variable to be checked (exclusive)
+            exclusive lower bound to check parameter_value against, optional.
         :lower_bound_inclusive:
-            lower limit value of the variable to be checked (inclusive)
+            inclusive lower bound to check parameter_value against, optional.
         """
-        if not (var is None):
+        if not (parameter_value is None):
             if (lower_bound_exclusive is not None and
-                    var <= lower_bound_exclusive):
+                    parameter_value <= lower_bound_exclusive):
                 raise ValueError(
-                    f"{var_name} must be greater than "
+                    f"{parameter_name} must be greater than "
                     f"{lower_bound_exclusive}; "
-                    f"found {var_name}={var}."
+                    f"found {parameter_name}={parameter_value}."
                 )
             if (lower_bound_inclusive is not None and
-                    var < lower_bound_inclusive):
+                    parameter_value < lower_bound_inclusive):
                 raise ValueError(
-                    f"{var_name} must be greater equal "
+                    f"{parameter_name} must be greater equal "
                     f"{lower_bound_inclusive}; found "
-                    f"{var_name}={var}."
+                    f"{parameter_name}={parameter_value}."
                 )
 
 
@@ -618,14 +649,14 @@ class PopulationAnnealing(Solver):
         This solver is CPU only.
         It currently does not support parameter-free invocation.
 
-        :param seed:
-            Specifies the random number generator seed value.
-        :param sweeps:
-            Number of Monte Carlo sweeps. Must be positive.
-        :population:
-            Size of the population. Must be positive.
         :param alpha:
             Ratio to trigger a restart. Must be larger than 1.
+        :param seed:
+            Specifies the random number generator seed value.
+        :population:
+            Size of the population. Must be positive.
+        :param sweeps:
+            Number of Monte Carlo sweeps. Must be positive.
         :param beta:
             Evolution of the inverse annealing temperature.
             Must be an object of type RangeSchedule describing
@@ -641,12 +672,12 @@ class PopulationAnnealing(Solver):
             output_data_format="microsoft.qio-results.v2",
         )
 
-        self.check_set_float_limit(alpha, "alpha", lower_bound_exclusive=1.0)
+        self.check_set_float("alpha", alpha, lower_bound_exclusive=1.0)
         self.set_one_param("seed", seed)
-        self.check_set_positive_int(population, "population")
-        self.check_set_positive_int(sweeps, "sweeps")
+        self.check_set_positive_int("population", population)
+        self.check_set_positive_int("sweeps", sweeps)
         self.check_set_schedule(
-                beta, "beta", evolution=self.ScheduleEvolution.INCREASING,
+                "beta", beta, evolution=self.ScheduleEvolution.INCREASING,
                 lower_bound_exclusive=0)
 
 

--- a/azure-quantum/azure/quantum/optimization/solvers.py
+++ b/azure-quantum/azure/quantum/optimization/solvers.py
@@ -330,13 +330,15 @@ class Solver:
         if not (var is None):
             if lower_bound is not None and var <= lower_bound:
                 raise ValueError(
-                    f"{var_name} must be greater than {lower_bound}!"
+                    f"{var_name} must be greater than {lower_bound}; "
+                    f"found {var_name}={var}."
                 )
             if (lower_bound_inclusive is not None and
                     var < lower_bound_inclusive):
                 raise ValueError(
                     f"{var_name} must be greater equal "
-                    f"{lower_bound_inclusive}!"
+                    f"{lower_bound_inclusive}; found "
+                    f"{var_name}={var}."
                 )
 
 

--- a/azure-quantum/environment.yml
+++ b/azure-quantum/environment.yml
@@ -4,14 +4,14 @@ channels:
   - conda-forge
 dependencies:
   - python=3.7
-  - pip
-  - pytest
-  - numpy
-  - deprecated
-  - msrest
-  - azure-core
-  - azure-identity
-  - azure-storage-blob
-  - azure-mgmt-core
+  - pip>=21.1.3
+  - pytest>=6.2.4
+  - numpy>=1.21.0
+  - deprecated>=1.2.12
+  - msrest>=0.6.21
+  - azure-core>=1.14.0
+  - azure-identity>=1.6.0
+  - azure-storage-blob>=12.8.1
+  - azure-mgmt-core>=1.2.2
   - pip:
-    - azure-devtools
+    - azure-devtools>=1.2.0

--- a/azure-quantum/requirements.txt
+++ b/azure-quantum/requirements.txt
@@ -1,7 +1,7 @@
-azure-core
-azure-identity
-azure-mgmt-core
-azure-storage-blob
-msrest
-numpy
-deprecated
+azure-core>=1.16.0
+azure-identity>=1.6.0
+azure-mgmt-core>= 1.3.0
+azure-storage-blob>=12.8.1
+msrest>=0.6.21
+numpy>=1.21.0
+deprecated>=1.2.12

--- a/azure-quantum/tests/unit/test_optimization.py
+++ b/azure-quantum/tests/unit/test_optimization.py
@@ -410,6 +410,16 @@ class TestSolvers(QuantumTestBase):
             {"type": "linear", "initial": 2.8, "final": 15.8},
             good.params["params"]["beta"],
         )
+    
+    def test_SubstochasticMonteCarlo_parameter_free(self):
+        ws = self.create_workspace()
+        good = SubstochasticMonteCarlo(
+            ws,
+            timeout=10,
+        )
+        self.assertIsNotNone(good)
+        self.assertEqual("microsoft.substochasticmontecarlo-parameterfree.cpu", good.target)
+        self.assertEqual(10, good.params["params"]["timeout"])
 
     def test_SSMC_bad_input_params(self):
         bad_range = None

--- a/azure-quantum/tests/unit/test_optimization.py
+++ b/azure-quantum/tests/unit/test_optimization.py
@@ -459,6 +459,117 @@ class TestSolvers(QuantumTestBase):
         self.assertTrue(
                 ("steps_per_walker must be positive; "
                  "found steps_per_walker=-1") in str(context.exception))
+<<<<<<< HEAD
+        self.assertTrue(bad_solver is None)
+
+        alpha_increasing = RangeSchedule("linear", 1.0, 2.0)
+        with self.assertRaises(ValueError) as context:
+            bad_solver = SubstochasticMonteCarlo(
+                ws,
+                seed=1888,
+                target_population=3000,
+                step_limit=1000,
+                alpha=alpha_increasing,
+                beta=beta,
+            )
+        self.assertTrue(
+                ("alpha must be decreasing; "
+                 "found alpha.initial=1.0 < 2.0=alpha.final.")
+                in str(context.exception))
+        self.assertTrue(bad_solver is None)
+
+        alpha_negative = RangeSchedule("linear", 1.0, -1.0)
+        with self.assertRaises(ValueError) as context:
+            bad_solver = SubstochasticMonteCarlo(
+                ws,
+                seed=1888,
+                target_population=3000,
+                step_limit=1000,
+                alpha=alpha_negative,
+                beta=beta,
+            )
+        self.assertTrue(
+                ("alpha.final must be greater equal 0; "
+                 "found alpha.final=-1.") in str(context.exception))
+        self.assertTrue(bad_solver is None)
+
+        alpha_strictly_negative = RangeSchedule("linear", -1.0, -2.0)
+        with self.assertRaises(ValueError) as context:
+            bad_solver = SubstochasticMonteCarlo(
+                ws,
+                seed=1888,
+                target_population=3000,
+                step_limit=1000,
+                alpha=alpha_strictly_negative,
+                beta=beta,
+            )
+        self.assertTrue(
+                ("alpha.initial must be greater equal 0; "
+                 "found alpha.initial=-1.") in str(context.exception))
+        self.assertTrue(bad_solver is None)
+
+        alpha = RangeSchedule("linear", 1.0, 0.0)
+        beta_decreasing = RangeSchedule("linear", 2.0, 1.0)
+        with self.assertRaises(ValueError) as context:
+            bad_solver = SubstochasticMonteCarlo(
+                ws,
+                seed=1888,
+                target_population=3000,
+                step_limit=1000,
+                alpha=alpha,
+                beta=beta_decreasing,
+            )
+        self.assertTrue(
+                ("beta must be increasing; "
+                 "found beta.initial=2.0 > 1.0=beta.final.")
+                in str(context.exception))
+        self.assertTrue(bad_solver is None)
+
+        beta_zero = RangeSchedule("linear", 0.0, 1.0)
+        with self.assertRaises(ValueError) as context:
+            bad_solver = SubstochasticMonteCarlo(
+                ws,
+                seed=1888,
+                target_population=3000,
+                step_limit=1000,
+                alpha=alpha,
+                beta=beta_zero,
+            )
+        self.assertTrue(
+                ("beta.initial must be greater than 0; "
+                 "found beta.initial=0.") in str(context.exception))
+        self.assertTrue(bad_solver is None)
+
+        beta_negative = RangeSchedule("linear", -1.0, 1.0)
+        with self.assertRaises(ValueError) as context:
+            bad_solver = SubstochasticMonteCarlo(
+                ws,
+                seed=1888,
+                target_population=3000,
+                step_limit=1000,
+                alpha=alpha,
+                beta=beta_negative,
+            )
+        self.assertTrue(
+                ("beta.initial must be greater than 0; "
+                 "found beta.initial=-1.0") in str(context.exception))
+        self.assertTrue(bad_solver is None)
+
+        beta_strictly_negative = RangeSchedule("linear", -2.0, -1.0)
+        with self.assertRaises(ValueError) as context:
+            bad_solver = SubstochasticMonteCarlo(
+                ws,
+                seed=1888,
+                target_population=3000,
+                step_limit=1000,
+                alpha=alpha,
+                beta=beta_strictly_negative,
+            )
+        self.assertTrue(
+                ("beta.initial must be greater than 0; "
+                 "found beta.initial=-2.0") in str(context.exception))
+=======
+>>>>>>> requested edits & cleanup
         self.assertTrue(bad_solver is None)
 
         alpha_increasing = RangeSchedule("linear", 1.0, 2.0)
@@ -569,98 +680,6 @@ class TestSolvers(QuantumTestBase):
                  "found beta.initial=-2.0") in str(context.exception))
         self.assertTrue(bad_solver is None)
 
-        alpha_increasing = RangeSchedule("linear", 1.0, 2.0)
-        with self.assertRaises(ValueError) as context:
-            bad_solver = SubstochasticMonteCarlo(
-                ws,
-                seed=1888,
-                target_population=3000,
-                step_limit=1000,
-                alpha=alpha_increasing,
-                beta=beta,
-            )
-        self.assertTrue("must be decreasing" in str(context.exception))
-        self.assertTrue(bad_solver is None)
-
-        alpha_negative = RangeSchedule("linear", 1.0, -1.0)
-        with self.assertRaises(ValueError) as context:
-            bad_solver = SubstochasticMonteCarlo(
-                ws,
-                seed=1888,
-                target_population=3000,
-                step_limit=1000,
-                alpha=alpha_negative,
-                beta=beta,
-            )
-        self.assertTrue("must be greater equal" in str(context.exception))
-        self.assertTrue(bad_solver is None)
-
-        alpha_strictly_negative = RangeSchedule("linear", -1.0, -2.0)
-        with self.assertRaises(ValueError) as context:
-            bad_solver = SubstochasticMonteCarlo(
-                ws,
-                seed=1888,
-                target_population=3000,
-                step_limit=1000,
-                alpha=alpha_strictly_negative,
-                beta=beta,
-            )
-        self.assertTrue("must be greater equal" in str(context.exception))
-        self.assertTrue(bad_solver is None)
-
-        alpha = RangeSchedule("linear", 1.0, 0.0)
-        beta_decreasing = RangeSchedule("linear", 2.0, 1.0)
-        with self.assertRaises(ValueError) as context:
-            bad_solver = SubstochasticMonteCarlo(
-                ws,
-                seed=1888,
-                target_population=3000,
-                step_limit=1000,
-                alpha=alpha,
-                beta=beta_decreasing,
-            )
-        self.assertTrue("must be increasing" in str(context.exception))
-        self.assertTrue(bad_solver is None)
-
-        beta_zero = RangeSchedule("linear", 0.0, 1.0)
-        with self.assertRaises(ValueError) as context:
-            bad_solver = SubstochasticMonteCarlo(
-                ws,
-                seed=1888,
-                target_population=3000,
-                step_limit=1000,
-                alpha=alpha,
-                beta=beta_zero,
-            )
-        self.assertTrue("must be greater than" in str(context.exception))
-        self.assertTrue(bad_solver is None)
-
-        beta_negative = RangeSchedule("linear", -1.0, 1.0)
-        with self.assertRaises(ValueError) as context:
-            bad_solver = SubstochasticMonteCarlo(
-                ws,
-                seed=1888,
-                target_population=3000,
-                step_limit=1000,
-                alpha=alpha,
-                beta=beta_negative,
-            )
-        self.assertTrue("must be greater than" in str(context.exception))
-        self.assertTrue(bad_solver is None)
-
-        beta_strictly_negative = RangeSchedule("linear", -2.0, -1.0)
-        with self.assertRaises(ValueError) as context:
-            bad_solver = SubstochasticMonteCarlo(
-                ws,
-                seed=1888,
-                target_population=3000,
-                step_limit=1000,
-                alpha=alpha,
-                beta=beta_strictly_negative,
-            )
-        self.assertTrue("must be greater than" in str(context.exception))
-        self.assertTrue(bad_solver is None)
-
     def test_PA_bad_input_params(self):
         beta = 1
         ws = self.create_workspace()
@@ -759,45 +778,6 @@ class TestSolvers(QuantumTestBase):
         self.assertTrue(
                 ("beta.initial must be greater than 0; "
                  "found beta.initial=-2.0") in str(context.exception))
-        self.assertTrue(bad_solver is None)
-
-        beta_zero = RangeSchedule("linear", 0.0, 1.0)
-        with self.assertRaises(ValueError) as context:
-            bad_solver = PopulationAnnealing(
-                ws,
-                alpha=100,
-                seed=8888,
-                population=300,
-                sweeps=1000,
-                beta=beta_zero,
-            )
-        self.assertTrue("must be greater than" in str(context.exception))
-        self.assertTrue(bad_solver is None)
-
-        beta_negative = RangeSchedule("linear", -1.0, 1.0)
-        with self.assertRaises(ValueError) as context:
-            bad_solver = PopulationAnnealing(
-                ws,
-                alpha=100,
-                seed=8888,
-                population=300,
-                sweeps=1000,
-                beta=beta_negative,
-            )
-        self.assertTrue("must be greater than" in str(context.exception))
-        self.assertTrue(bad_solver is None)
-
-        beta_strictly_negative = RangeSchedule("linear", -2.0, -1.0)
-        with self.assertRaises(ValueError) as context:
-            bad_solver = PopulationAnnealing(
-                ws,
-                alpha=100,
-                seed=8888,
-                population=300,
-                sweeps=1000,
-                beta=beta_strictly_negative,
-            )
-        self.assertTrue("must be greater than" in str(context.exception))
         self.assertTrue(bad_solver is None)
 
 

--- a/azure-quantum/tests/unit/test_optimization.py
+++ b/azure-quantum/tests/unit/test_optimization.py
@@ -496,6 +496,7 @@ class TestSolvers(QuantumTestBase):
         self.assertTrue("must be greater equal" in str(context.exception))
         self.assertTrue(bad_solver is None)
 
+        alpha = RangeSchedule("linear", 1.0, 0.0)
         beta_decreasing = RangeSchedule("linear", 2.0, 1.0)
         with self.assertRaises(ValueError) as context:
             bad_solver = SubstochasticMonteCarlo(

--- a/azure-quantum/tests/unit/test_optimization.py
+++ b/azure-quantum/tests/unit/test_optimization.py
@@ -569,6 +569,32 @@ class TestSolvers(QuantumTestBase):
                  "found beta.initial=-2.0") in str(context.exception))
         self.assertTrue(bad_solver is None)
 
+        alpha_increasing = RangeSchedule("linear", 1.0, 2.0)
+        with self.assertRaises(ValueError) as context:
+            bad_solver = PopulationAnnealing(
+                ws,
+                seed=1888,
+                target_population=3000,
+                step_limit=1000,
+                alpha=alpha_increasing,
+                beta=beta,
+            )
+        self.assertTrue("alpha must be decreasing" in str(context.exception))
+        self.assertTrue(bad_solver is None)
+
+        beta_decreasing = RangeSchedule("linear", 2.0, 1.0)
+        with self.assertRaises(ValueError) as context:
+            bad_solver = PopulationAnnealing(
+                ws,
+                seed=1888,
+                target_population=3000,
+                step_limit=1000,
+                alpha=alpha,
+                beta=beta_decreasing,
+            )
+        self.assertTrue("beta must be increasing" in str(context.exception))
+        self.assertTrue(bad_solver is None)
+
     def test_PA_bad_input_params(self):
         beta = 1
         ws = self.create_workspace()

--- a/azure-quantum/tests/unit/test_optimization.py
+++ b/azure-quantum/tests/unit/test_optimization.py
@@ -368,7 +368,6 @@ class TestSolvers(QuantumTestBase):
             seed=8888,
             population=300,
             sweeps=1000,
-            culling_fraction=0.5,
             beta=beta,
         )
         self.assertIsNotNone(good)
@@ -377,7 +376,6 @@ class TestSolvers(QuantumTestBase):
         self.assertEqual(100.0, good.params["params"]["alpha"])
         self.assertEqual(300, good.params["params"]["population"])
         self.assertEqual(1000, good.params["params"]["sweeps"])
-        self.assertEqual(0.5, good.params["params"]["culling_fraction"])
         self.assertEqual(
             {"type": "linear", "initial": 0.8, "final": 5.8},
             good.params["params"]["beta"],
@@ -386,7 +384,7 @@ class TestSolvers(QuantumTestBase):
     def test_SubstochasticMonteCarlo_input_params(self):
         ws = self.create_workspace()
         beta = RangeSchedule("linear", 2.8, 15.8)
-        alpha = RangeSchedule("geometric", 1.8, 2.8)
+        alpha = RangeSchedule("geometric", 2.8, 1.8)
         good = SubstochasticMonteCarlo(
             ws,
             alpha=alpha,
@@ -400,7 +398,7 @@ class TestSolvers(QuantumTestBase):
         self.assertEqual("microsoft.substochasticmontecarlo.cpu", good.target)
         self.assertEqual(1888, good.params["params"]["seed"])
         self.assertEqual(
-            {"type": "geometric", "initial": 1.8, "final": 2.8},
+            {"type": "geometric", "initial": 2.8, "final": 1.8},
             good.params["params"]["alpha"],
         )
         self.assertEqual(3000, good.params["params"]["target_population"])
@@ -459,6 +457,32 @@ class TestSolvers(QuantumTestBase):
         self.assertTrue("must be positive" in str(context.exception))
         self.assertTrue(bad_solver is None)
 
+        alpha_increasing = RangeSchedule("linear", 1.0, 2.0)
+        with self.assertRaises(ValueError) as context:
+            bad_solver = PopulationAnnealing(
+                ws,
+                seed=1888,
+                target_population=3000,
+                step_limit=1000,
+                alpha=alpha_increasing,
+                beta=beta,
+            )
+        self.assertTrue("alpha must be decreasing" in str(context.exception))
+        self.assertTrue(bad_solver is None)
+
+        beta_decreasing = RangeSchedule("linear", 2.0, 1.0)
+        with self.assertRaises(ValueError) as context:
+            bad_solver = PopulationAnnealing(
+                ws,
+                seed=1888,
+                target_population=3000,
+                step_limit=1000,
+                alpha=alpha,
+                beta=beta_decreasing,
+            )
+        self.assertTrue("beta must be increasing" in str(context.exception))
+        self.assertTrue(bad_solver is None)
+
     def test_PA_bad_input_params(self):
         beta = 1
         ws = self.create_workspace()
@@ -470,7 +494,6 @@ class TestSolvers(QuantumTestBase):
                 seed=8888,
                 population=300,
                 sweeps=1000,
-                culling_fraction=0.5,
                 beta=beta,
             )
         self.assertTrue(
@@ -485,16 +508,28 @@ class TestSolvers(QuantumTestBase):
                 seed=8888,
                 population=-300,
                 sweeps=1000,
-                culling_fraction=0.5,
             )
         self.assertTrue("must be positive" in str(context.exception))
         self.assertTrue(bad_solver is None)
 
         with self.assertRaises(ValueError) as context:
             bad_solver = PopulationAnnealing(
-                ws, alpha=0.2, seed=8888, sweeps=1000, culling_fraction=0.5
+                ws, alpha=0.2, seed=8888, sweeps=1000,
             )
-        self.assertTrue("can not be smaller than" in str(context.exception))
+        self.assertTrue("alpha must be greater than" in str(context.exception))
+        self.assertTrue(bad_solver is None)
+
+        beta_decreasing = RangeSchedule("linear", 2.0, 1.0)
+        with self.assertRaises(ValueError) as context:
+            bad_solver = PopulationAnnealing(
+                ws,
+                alpha=100,
+                seed=8888,
+                population=300,
+                sweeps=1000,
+                beta=beta_decreasing,
+            )
+        self.assertTrue("must be increasing" in str(context.exception))
         self.assertTrue(bad_solver is None)
 
 

--- a/azure-quantum/tests/unit/test_optimization.py
+++ b/azure-quantum/tests/unit/test_optimization.py
@@ -579,7 +579,33 @@ class TestSolvers(QuantumTestBase):
                 alpha=alpha_increasing,
                 beta=beta,
             )
-        self.assertTrue("alpha must be decreasing" in str(context.exception))
+        self.assertTrue("must be decreasing" in str(context.exception))
+        self.assertTrue(bad_solver is None)
+
+        alpha_negative = RangeSchedule("linear", 1.0, -1.0)
+        with self.assertRaises(ValueError) as context:
+            bad_solver = SubstochasticMonteCarlo(
+                ws,
+                seed=1888,
+                target_population=3000,
+                step_limit=1000,
+                alpha=alpha_negative,
+                beta=beta,
+            )
+        self.assertTrue("must be greater equal" in str(context.exception))
+        self.assertTrue(bad_solver is None)
+
+        alpha_strictly_negative = RangeSchedule("linear", -1.0, -2.0)
+        with self.assertRaises(ValueError) as context:
+            bad_solver = SubstochasticMonteCarlo(
+                ws,
+                seed=1888,
+                target_population=3000,
+                step_limit=1000,
+                alpha=alpha_strictly_negative,
+                beta=beta,
+            )
+        self.assertTrue("must be greater equal" in str(context.exception))
         self.assertTrue(bad_solver is None)
 
         beta_decreasing = RangeSchedule("linear", 2.0, 1.0)
@@ -592,7 +618,46 @@ class TestSolvers(QuantumTestBase):
                 alpha=alpha,
                 beta=beta_decreasing,
             )
-        self.assertTrue("beta must be increasing" in str(context.exception))
+        self.assertTrue("must be increasing" in str(context.exception))
+        self.assertTrue(bad_solver is None)
+
+        beta_zero = RangeSchedule("linear", 0.0, 1.0)
+        with self.assertRaises(ValueError) as context:
+            bad_solver = SubstochasticMonteCarlo(
+                ws,
+                seed=1888,
+                target_population=3000,
+                step_limit=1000,
+                alpha=alpha,
+                beta=beta_zero,
+            )
+        self.assertTrue("must be greater than" in str(context.exception))
+        self.assertTrue(bad_solver is None)
+
+        beta_negative = RangeSchedule("linear", -1.0, 1.0)
+        with self.assertRaises(ValueError) as context:
+            bad_solver = SubstochasticMonteCarlo(
+                ws,
+                seed=1888,
+                target_population=3000,
+                step_limit=1000,
+                alpha=alpha,
+                beta=beta_negative,
+            )
+        self.assertTrue("must be greater than" in str(context.exception))
+        self.assertTrue(bad_solver is None)
+
+        beta_strictly_negative = RangeSchedule("linear", -2.0, -1.0)
+        with self.assertRaises(ValueError) as context:
+            bad_solver = SubstochasticMonteCarlo(
+                ws,
+                seed=1888,
+                target_population=3000,
+                step_limit=1000,
+                alpha=alpha,
+                beta=beta_strictly_negative,
+            )
+        self.assertTrue("must be greater than" in str(context.exception))
         self.assertTrue(bad_solver is None)
 
     def test_PA_bad_input_params(self):
@@ -693,6 +758,45 @@ class TestSolvers(QuantumTestBase):
         self.assertTrue(
                 ("beta.initial must be greater than 0; "
                  "found beta.initial=-2.0") in str(context.exception))
+        self.assertTrue(bad_solver is None)
+
+        beta_zero = RangeSchedule("linear", 0.0, 1.0)
+        with self.assertRaises(ValueError) as context:
+            bad_solver = PopulationAnnealing(
+                ws,
+                alpha=100,
+                seed=8888,
+                population=300,
+                sweeps=1000,
+                beta=beta_zero,
+            )
+        self.assertTrue("must be greater than" in str(context.exception))
+        self.assertTrue(bad_solver is None)
+
+        beta_negative = RangeSchedule("linear", -1.0, 1.0)
+        with self.assertRaises(ValueError) as context:
+            bad_solver = PopulationAnnealing(
+                ws,
+                alpha=100,
+                seed=8888,
+                population=300,
+                sweeps=1000,
+                beta=beta_negative,
+            )
+        self.assertTrue("must be greater than" in str(context.exception))
+        self.assertTrue(bad_solver is None)
+
+        beta_strictly_negative = RangeSchedule("linear", -2.0, -1.0)
+        with self.assertRaises(ValueError) as context:
+            bad_solver = PopulationAnnealing(
+                ws,
+                alpha=100,
+                seed=8888,
+                population=300,
+                sweeps=1000,
+                beta=beta_strictly_negative,
+            )
+        self.assertTrue("must be greater than" in str(context.exception))
         self.assertTrue(bad_solver is None)
 
 

--- a/azure-quantum/tests/unit/test_optimization.py
+++ b/azure-quantum/tests/unit/test_optimization.py
@@ -571,7 +571,7 @@ class TestSolvers(QuantumTestBase):
 
         alpha_increasing = RangeSchedule("linear", 1.0, 2.0)
         with self.assertRaises(ValueError) as context:
-            bad_solver = PopulationAnnealing(
+            bad_solver = SubstochasticMonteCarlo(
                 ws,
                 seed=1888,
                 target_population=3000,
@@ -584,7 +584,7 @@ class TestSolvers(QuantumTestBase):
 
         beta_decreasing = RangeSchedule("linear", 2.0, 1.0)
         with self.assertRaises(ValueError) as context:
-            bad_solver = PopulationAnnealing(
+            bad_solver = SubstochasticMonteCarlo(
                 ws,
                 seed=1888,
                 target_population=3000,

--- a/azure-quantum/tests/unit/test_optimization.py
+++ b/azure-quantum/tests/unit/test_optimization.py
@@ -459,7 +459,7 @@ class TestSolvers(QuantumTestBase):
 
         alpha_increasing = RangeSchedule("linear", 1.0, 2.0)
         with self.assertRaises(ValueError) as context:
-            bad_solver = PopulationAnnealing(
+            bad_solver = SubstochasticMonteCarlo(
                 ws,
                 seed=1888,
                 target_population=3000,
@@ -472,7 +472,7 @@ class TestSolvers(QuantumTestBase):
 
         beta_decreasing = RangeSchedule("linear", 2.0, 1.0)
         with self.assertRaises(ValueError) as context:
-            bad_solver = PopulationAnnealing(
+            bad_solver = SubstochasticMonteCarlo(
                 ws,
                 seed=1888,
                 target_population=3000,

--- a/azure-quantum/tests/unit/test_optimization.py
+++ b/azure-quantum/tests/unit/test_optimization.py
@@ -424,7 +424,7 @@ class TestSolvers(QuantumTestBase):
         with self.assertRaises(ValueError) as context:
             bad_range = RangeSchedule("nothing", 2.8, 15.8)
         self.assertTrue(
-            '"schedule_type" can only be' in str(context.exception)
+            '"schedule_type" must be' in str(context.exception)
         )
         self.assertTrue(bad_range is None)
         beta = 1
@@ -441,8 +441,10 @@ class TestSolvers(QuantumTestBase):
                 steps_per_walker=5,
                 beta=beta,
             )
+        print(str(context.exception))
         self.assertTrue(
-            'can only be from class "RangeSchedule"!' in str(context.exception)
+            ('alpha must be of type RangeSchedule; '
+             'found type(alpha)=int') in str(context.exception)
         )
         self.assertTrue(bad_solver is None)
 
@@ -454,7 +456,9 @@ class TestSolvers(QuantumTestBase):
                 step_limit=1000,
                 steps_per_walker=-1,
             )
-        self.assertTrue("must be positive" in str(context.exception))
+        self.assertTrue(
+                ("steps_per_walker must be positive; "
+                 "found steps_per_walker=-1") in str(context.exception))
         self.assertTrue(bad_solver is None)
 
         alpha_increasing = RangeSchedule("linear", 1.0, 2.0)
@@ -467,7 +471,10 @@ class TestSolvers(QuantumTestBase):
                 alpha=alpha_increasing,
                 beta=beta,
             )
-        self.assertTrue("must be decreasing" in str(context.exception))
+        self.assertTrue(
+                ("alpha must be decreasing; "
+                 "found alpha.initial=1.0 < 2.0=alpha.final.")
+                in str(context.exception))
         self.assertTrue(bad_solver is None)
 
         alpha_negative = RangeSchedule("linear", 1.0, -1.0)
@@ -480,7 +487,9 @@ class TestSolvers(QuantumTestBase):
                 alpha=alpha_negative,
                 beta=beta,
             )
-        self.assertTrue("must be greater equal" in str(context.exception))
+        self.assertTrue(
+                ("alpha.final must be greater equal 0; "
+                 "found alpha.final=-1.") in str(context.exception))
         self.assertTrue(bad_solver is None)
 
         alpha_strictly_negative = RangeSchedule("linear", -1.0, -2.0)
@@ -493,7 +502,9 @@ class TestSolvers(QuantumTestBase):
                 alpha=alpha_strictly_negative,
                 beta=beta,
             )
-        self.assertTrue("must be greater equal" in str(context.exception))
+        self.assertTrue(
+                ("alpha.initial must be greater equal 0; "
+                 "found alpha.initial=-1.") in str(context.exception))
         self.assertTrue(bad_solver is None)
 
         alpha = RangeSchedule("linear", 1.0, 0.0)
@@ -507,7 +518,10 @@ class TestSolvers(QuantumTestBase):
                 alpha=alpha,
                 beta=beta_decreasing,
             )
-        self.assertTrue("must be increasing" in str(context.exception))
+        self.assertTrue(
+                ("beta must be increasing; "
+                 "found beta.initial=2.0 > 1.0=beta.final.")
+                in str(context.exception))
         self.assertTrue(bad_solver is None)
 
         beta_zero = RangeSchedule("linear", 0.0, 1.0)
@@ -520,7 +534,9 @@ class TestSolvers(QuantumTestBase):
                 alpha=alpha,
                 beta=beta_zero,
             )
-        self.assertTrue("must be greater than" in str(context.exception))
+        self.assertTrue(
+                ("beta.initial must be greater than 0; "
+                 "found beta.initial=0.") in str(context.exception))
         self.assertTrue(bad_solver is None)
 
         beta_negative = RangeSchedule("linear", -1.0, 1.0)
@@ -533,7 +549,9 @@ class TestSolvers(QuantumTestBase):
                 alpha=alpha,
                 beta=beta_negative,
             )
-        self.assertTrue("must be greater than" in str(context.exception))
+        self.assertTrue(
+                ("beta.initial must be greater than 0; "
+                 "found beta.initial=-1.0") in str(context.exception))
         self.assertTrue(bad_solver is None)
 
         beta_strictly_negative = RangeSchedule("linear", -2.0, -1.0)
@@ -546,7 +564,9 @@ class TestSolvers(QuantumTestBase):
                 alpha=alpha,
                 beta=beta_strictly_negative,
             )
-        self.assertTrue("must be greater than" in str(context.exception))
+        self.assertTrue(
+                ("beta.initial must be greater than 0; "
+                 "found beta.initial=-2.0") in str(context.exception))
         self.assertTrue(bad_solver is None)
 
     def test_PA_bad_input_params(self):
@@ -563,7 +583,8 @@ class TestSolvers(QuantumTestBase):
                 beta=beta,
             )
         self.assertTrue(
-            'can only be from class "RangeSchedule"!' in str(context.exception)
+            ("beta must be of type RangeSchedule; "
+             "found type(beta)=int.") in str(context.exception)
         )
         self.assertTrue(bad_solver is None)
 
@@ -582,7 +603,9 @@ class TestSolvers(QuantumTestBase):
             bad_solver = PopulationAnnealing(
                 ws, alpha=0.2, seed=8888, sweeps=1000,
             )
-        self.assertTrue("alpha must be greater than" in str(context.exception))
+        self.assertTrue(
+                ("alpha must be greater than 1.0; "
+                 "found alpha=0.2.") in str(context.exception))
         self.assertTrue(bad_solver is None)
 
         beta_decreasing = RangeSchedule("linear", 2.0, 1.0)
@@ -595,7 +618,10 @@ class TestSolvers(QuantumTestBase):
                 sweeps=1000,
                 beta=beta_decreasing,
             )
-        self.assertTrue("must be increasing" in str(context.exception))
+        self.assertTrue(
+                ("beta must be increasing; "
+                 "found beta.initial=2.0 > 1.0=beta.final.")
+                in str(context.exception))
         self.assertTrue(bad_solver is None)
 
         beta_zero = RangeSchedule("linear", 0.0, 1.0)
@@ -608,7 +634,9 @@ class TestSolvers(QuantumTestBase):
                 sweeps=1000,
                 beta=beta_zero,
             )
-        self.assertTrue("must be greater than" in str(context.exception))
+        self.assertTrue(
+                ("beta.initial must be greater than 0; "
+                 "found beta.initial=0.") in str(context.exception))
         self.assertTrue(bad_solver is None)
 
         beta_negative = RangeSchedule("linear", -1.0, 1.0)
@@ -621,7 +649,9 @@ class TestSolvers(QuantumTestBase):
                 sweeps=1000,
                 beta=beta_negative,
             )
-        self.assertTrue("must be greater than" in str(context.exception))
+        self.assertTrue(
+                ("beta.initial must be greater than 0; "
+                 "found beta.initial=-1.0") in str(context.exception))
         self.assertTrue(bad_solver is None)
 
         beta_strictly_negative = RangeSchedule("linear", -2.0, -1.0)
@@ -634,7 +664,9 @@ class TestSolvers(QuantumTestBase):
                 sweeps=1000,
                 beta=beta_strictly_negative,
             )
-        self.assertTrue("must be greater than" in str(context.exception))
+        self.assertTrue(
+                ("beta.initial must be greater than 0; "
+                 "found beta.initial=-2.0") in str(context.exception))
         self.assertTrue(bad_solver is None)
 
 

--- a/azure-quantum/tests/unit/test_optimization.py
+++ b/azure-quantum/tests/unit/test_optimization.py
@@ -467,7 +467,33 @@ class TestSolvers(QuantumTestBase):
                 alpha=alpha_increasing,
                 beta=beta,
             )
-        self.assertTrue("alpha must be decreasing" in str(context.exception))
+        self.assertTrue("must be decreasing" in str(context.exception))
+        self.assertTrue(bad_solver is None)
+
+        alpha_negative = RangeSchedule("linear", 1.0, -1.0)
+        with self.assertRaises(ValueError) as context:
+            bad_solver = SubstochasticMonteCarlo(
+                ws,
+                seed=1888,
+                target_population=3000,
+                step_limit=1000,
+                alpha=alpha_negative,
+                beta=beta,
+            )
+        self.assertTrue("must be greater equal" in str(context.exception))
+        self.assertTrue(bad_solver is None)
+
+        alpha_strictly_negative = RangeSchedule("linear", -1.0, -2.0)
+        with self.assertRaises(ValueError) as context:
+            bad_solver = SubstochasticMonteCarlo(
+                ws,
+                seed=1888,
+                target_population=3000,
+                step_limit=1000,
+                alpha=alpha_strictly_negative,
+                beta=beta,
+            )
+        self.assertTrue("must be greater equal" in str(context.exception))
         self.assertTrue(bad_solver is None)
 
         beta_decreasing = RangeSchedule("linear", 2.0, 1.0)
@@ -480,7 +506,46 @@ class TestSolvers(QuantumTestBase):
                 alpha=alpha,
                 beta=beta_decreasing,
             )
-        self.assertTrue("beta must be increasing" in str(context.exception))
+        self.assertTrue("must be increasing" in str(context.exception))
+        self.assertTrue(bad_solver is None)
+
+        beta_zero = RangeSchedule("linear", 0.0, 1.0)
+        with self.assertRaises(ValueError) as context:
+            bad_solver = SubstochasticMonteCarlo(
+                ws,
+                seed=1888,
+                target_population=3000,
+                step_limit=1000,
+                alpha=alpha,
+                beta=beta_zero,
+            )
+        self.assertTrue("must be greater than" in str(context.exception))
+        self.assertTrue(bad_solver is None)
+
+        beta_negative = RangeSchedule("linear", -1.0, 1.0)
+        with self.assertRaises(ValueError) as context:
+            bad_solver = SubstochasticMonteCarlo(
+                ws,
+                seed=1888,
+                target_population=3000,
+                step_limit=1000,
+                alpha=alpha,
+                beta=beta_negative,
+            )
+        self.assertTrue("must be greater than" in str(context.exception))
+        self.assertTrue(bad_solver is None)
+
+        beta_strictly_negative = RangeSchedule("linear", -2.0, -1.0)
+        with self.assertRaises(ValueError) as context:
+            bad_solver = SubstochasticMonteCarlo(
+                ws,
+                seed=1888,
+                target_population=3000,
+                step_limit=1000,
+                alpha=alpha,
+                beta=beta_strictly_negative,
+            )
+        self.assertTrue("must be greater than" in str(context.exception))
         self.assertTrue(bad_solver is None)
 
     def test_PA_bad_input_params(self):
@@ -530,6 +595,45 @@ class TestSolvers(QuantumTestBase):
                 beta=beta_decreasing,
             )
         self.assertTrue("must be increasing" in str(context.exception))
+        self.assertTrue(bad_solver is None)
+
+        beta_zero = RangeSchedule("linear", 0.0, 1.0)
+        with self.assertRaises(ValueError) as context:
+            bad_solver = PopulationAnnealing(
+                ws,
+                alpha=100,
+                seed=8888,
+                population=300,
+                sweeps=1000,
+                beta=beta_zero,
+            )
+        self.assertTrue("must be greater than" in str(context.exception))
+        self.assertTrue(bad_solver is None)
+
+        beta_negative = RangeSchedule("linear", -1.0, 1.0)
+        with self.assertRaises(ValueError) as context:
+            bad_solver = PopulationAnnealing(
+                ws,
+                alpha=100,
+                seed=8888,
+                population=300,
+                sweeps=1000,
+                beta=beta_negative,
+            )
+        self.assertTrue("must be greater than" in str(context.exception))
+        self.assertTrue(bad_solver is None)
+
+        beta_strictly_negative = RangeSchedule("linear", -2.0, -1.0)
+        with self.assertRaises(ValueError) as context:
+            bad_solver = PopulationAnnealing(
+                ws,
+                alpha=100,
+                seed=8888,
+                population=300,
+                sweeps=1000,
+                beta=beta_strictly_negative,
+            )
+        self.assertTrue("must be greater than" in str(context.exception))
         self.assertTrue(bad_solver is None)
 
 

--- a/azure-quantum/tests/unit/test_optimization.py
+++ b/azure-quantum/tests/unit/test_optimization.py
@@ -608,6 +608,7 @@ class TestSolvers(QuantumTestBase):
         self.assertTrue("must be greater equal" in str(context.exception))
         self.assertTrue(bad_solver is None)
 
+        alpha = RangeSchedule("linear", 1.0, 0.0)
         beta_decreasing = RangeSchedule("linear", 2.0, 1.0)
         with self.assertRaises(ValueError) as context:
             bad_solver = SubstochasticMonteCarlo(

--- a/qdk/qdk/chemistry/_xyz2mol/ac.py
+++ b/qdk/qdk/chemistry/_xyz2mol/ac.py
@@ -12,6 +12,7 @@ Implementation by Jan H. Jensen, based on the paper
     DOI: 10.1002/bkcs.10334
 """
 
+import logging
 import os
 import sys
 import copy
@@ -34,6 +35,8 @@ from rdkit.Chem import AllChem, rdmolops
 
 from qdk.chemistry._xyz2mol.util import *
 from qdk.chemistry._xyz2mol.bo import *
+
+_log = logging.getLogger(__name__)
 
 
 def get_AC(mol, covalent_factor=1.3):
@@ -160,7 +163,7 @@ def AC2BO(AC, atoms, charge, allow_charged_fragments=True, use_graph=True):
         # valence can't be smaller than number of neighbourgs
         possible_valence = [x for x in atomic_valence[atomicNum] if x >= valence]
         if not possible_valence:
-            print('Valence of atom',i,'is',valence,'which bigger than allowed max',max(atomic_valence[atomicNum]),'. Stopping')
+            _log.error('Valence of atom',i,'is',valence,'which bigger than allowed max',max(atomic_valence[atomicNum]),'. Stopping')
             sys.exit()
         valences_list_of_lists.append(possible_valence)
 
@@ -199,7 +202,7 @@ def AC2BO(AC, atoms, charge, allow_charged_fragments=True, use_graph=True):
                 best_BO = BO.copy()
 
     if not charge_OK:
-        print("Warning: SMILES charge doesn't match input charge")
+        _log.debug("Warning: SMILES charge doesn't match input charge")
     return best_BO, atomic_valence_electrons
 
 

--- a/qdk/qdk/chemistry/geometry/rdkit_convert.py
+++ b/qdk/qdk/chemistry/geometry/rdkit_convert.py
@@ -4,6 +4,7 @@
 """Module for converting to and from RDKit data structures
 """
 
+import logging
 from typing import List, Tuple, Iterable, TYPE_CHECKING
 
 from .xyz import coordinates_to_xyz
@@ -12,6 +13,8 @@ from rdkit.Chem import AllChem as Chem
 
 if TYPE_CHECKING:
     from rdkit.Chem import Mol, Conformer
+
+_log = logging.getLogger(__name__)
 
 
 def get_conformer(mol: "Mol", num_confs: int = 10) -> "Conformer":
@@ -41,7 +44,7 @@ def get_conformer(mol: "Mol", num_confs: int = 10) -> "Conformer":
         ((not_converged, energy), conformer) = min(
             zip(res, mol.GetConformers()), key=lambda x: x[0][1])
         if not_converged:
-            print(f"Solution did not converge. Lowest energy found: {energy}")
+            _log.debug(f"Solution did not converge. Lowest energy found: {energy}")
     return conformer
 
 

--- a/qdk/qdk/chemistry/molecule.py
+++ b/qdk/qdk/chemistry/molecule.py
@@ -57,7 +57,9 @@ class Molecule(object):
         self.design_widget = None
         self._xyz = xyz
 
-        if mol:
+        if xyz:
+            self.widget = JsmolWidget.from_str(data=xyz)
+        elif mol:
             self.widget = JsmolWidget.from_mol(mol=mol, num_confs=num_confs)
         else:
             self.widget = None


### PR DESCRIPTION
Add checks for the evolution (INCREASING vs DECREASING) to the schedule parameter setter.

This allows misconfigurations of the schedules for alpha, beta in PopulationAnnealing and
SubstochasticMonteCarlo to be registered (and thrown) client side. These are already
checked server-side.

(From email thread, no ADO item).

Plus various cleanups of docstrings and requested refactoring of variable names.