### PR TITLE
No print on wait

### DIFF
--- a/azure-quantum/azure/quantum/job.py
+++ b/azure-quantum/azure/quantum/job.py
@@ -51,7 +51,7 @@ class Job:
             or self.details.status == "Cancelled"
         )
 
-    def wait_until_completed(self, max_poll_wait_secs=30):
+    def wait_until_completed(self, max_poll_wait_secs=30, print_progress=True):
         """Keeps refreshing the Job's details
         until it reaches a finished status."""
         self.refresh()

--- a/azure-quantum/azure/quantum/job.py
+++ b/azure-quantum/azure/quantum/job.py
@@ -61,7 +61,6 @@ class Job:
                 f"Waiting for job {self.id},"
                 + f"it is in status '{self.details.status}'"
             )
-            print(".", end="", flush=True)
             time.sleep(poll_wait)
             self.refresh()
             poll_wait = (

--- a/azure-quantum/azure/quantum/job.py
+++ b/azure-quantum/azure/quantum/job.py
@@ -61,6 +61,8 @@ class Job:
                 f"Waiting for job {self.id},"
                 + f"it is in status '{self.details.status}'"
             )
+            if print_progress:
+                print(".", end="", flush=True)
             time.sleep(poll_wait)
             self.refresh()
             poll_wait = (


### PR DESCRIPTION
The `Job.wait_until_completed()` method prints `.` to the console.

Users can fetch the status and the task is blocking. There's no way to disable the print and this is the only method to push data to the console.