### PR TITLE
Exclude SharedTokenCacheCredential by default

### DIFF
--- a/azure-quantum/azure/quantum/_authentication/_default.py
+++ b/azure-quantum/azure/quantum/_authentication/_default.py
@@ -85,7 +85,7 @@ class _DefaultAzureCredential(_ChainedTokenCredential):
 
         self.exclude_environment_credential = kwargs.pop("exclude_environment_credential", False)
         self.exclude_managed_identity_credential = kwargs.pop("exclude_managed_identity_credential", False)
-        self.exclude_shared_token_cache_credential = kwargs.pop("exclude_shared_token_cache_credential", False)
+        self.exclude_shared_token_cache_credential = kwargs.pop("exclude_shared_token_cache_credential", True)
         self.exclude_visual_studio_code_credential = kwargs.pop("exclude_visual_studio_code_credential", False)
         self.exclude_cli_credential = kwargs.pop("exclude_cli_credential", False)
         self.exclude_interactive_browser_credential = kwargs.pop("exclude_interactive_browser_credential", True)

--- a/azure-quantum/azure/quantum/workspace.py
+++ b/azure-quantum/azure/quantum/workspace.py
@@ -157,6 +157,7 @@ class Workspace:
         # See _DefaultAzureCredential documentation for more info.
         if credential is None:
             credential = _DefaultAzureCredential(exclude_interactive_browser_credential=False,
+                                                 exclude_shared_token_cache_credential=True,
                                                  subscription_id=subscription_id,
                                                  arm_base_url=ARM_BASE_URL)
 


### PR DESCRIPTION
Fixes #96, by excluding SharedTokenCacheCredential by default.