### PR TITLE
azure-quantum unit test recording infrastructure fixes

### DIFF
--- a/azure-quantum/tests/unit/common.py
+++ b/azure-quantum/tests/unit/common.py
@@ -101,6 +101,9 @@ class QuantumTestBase(ReplayableTest):
             r"jobs/([a-f0-9]+[-]){4}[a-f0-9]+", "jobs/" + ZERO_UID
         )
         regex_replacer.register_regex(
+            r"job-([a-f0-9]+[-]){4}[a-f0-9]+", "job-" + ZERO_UID
+        )
+        regex_replacer.register_regex(
             r"\d{8}-\d{6}", "20210101-000000"
         )        
         regex_replacer.register_regex(
@@ -195,7 +198,9 @@ class CustomRecordingProcessor(RecordingProcessor):
 
     ALLOW_HEADERS = [
         "connection",
+        "content-disposition",
         "content-length",
+        "content-range",
         "content-type",
         "accept",
         "accept-encoding",


### PR DESCRIPTION
Fixes #92 by:
1) Adding `content-disposition` and `content-range` HTTP Headers that are used by Storage SDK blob download in the test recording allow-list
2) Introducing a `InteractiveAccessTokenReplacer` to sanitize interactive credentials from the test recordings
3) Sanitize HTTP Headers with the same regexes that we use to sanitize the HTTP URI and Body