### PR TITLE
Use exists() method to check if storage exists

### DIFF
--- a/azure-quantum/azure/quantum/storage.py
+++ b/azure-quantum/azure/quantum/storage.py
@@ -42,12 +42,9 @@ def create_container(
 
 def create_container_using_client(container_client: ContainerClient):
     """
-    Creates and initializes a container.
+    Creates the container if it doesn't already exist.
     """
-    try:
-        container_client.get_container_properties()
-        logger.debug(f'{"  - uploading to existing container"}')
-    except Exception:
+    if not container_client.exists():
         logger.debug(
             f'{"  - uploading to **new** container:"}'
             f"{container_client.container_name}"


### PR DESCRIPTION
Live tests have been sporadically failing. The issue seems to be two fold: 
to check if a container exists, we were calling `get_properties`; if that threw an exception, we assumed the container didn't exist and try to create it.

the root problem is that storage is closing the connection when getting the properties, which throws an exception so we incorrectly try to create an existing container.

this change simply replaces the `get_properties` with a new-ish `exist()` which behind the scenes does the same, but has a different error handling. this is in general the right approach (`exist` is a new method, which is why we were not using it before) and I hope it should improve things.