### PR TITLE
Add timeout for wait_until_completed, make HW test more robust against downtime

### DIFF
--- a/azure-quantum/azure/quantum/job/base_job.py
+++ b/azure-quantum/azure/quantum/job/base_job.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_TIMEOUT = 180 # Default timeout for waiting for job to complete
+DEFAULT_TIMEOUT = 300 # Default timeout for waiting for job to complete
 
 
 class BaseJob(abc.ABC):

--- a/azure-quantum/azure/quantum/job/base_job.py
+++ b/azure-quantum/azure/quantum/job/base_job.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_TIMEOUT = 100
+DEFAULT_TIMEOUT = 180 # Default timeout for waiting for job to complete
 
 
 class BaseJob(abc.ABC):

--- a/azure-quantum/azure/quantum/job/job.py
+++ b/azure-quantum/azure/quantum/job/job.py
@@ -56,7 +56,7 @@ class Job(BaseJob, FilteredJob):
             or self.details.status == "Cancelled"
         )
 
-    def wait_until_completed(self, max_poll_wait_secs=30, timeout_secs=DEFAULT_TIMEOUT) -> None:
+    def wait_until_completed(self, max_poll_wait_secs=30, timeout_secs=None) -> None:
         """Keeps refreshing the Job's details
         until it reaches a finished status.
 
@@ -91,7 +91,7 @@ class Job(BaseJob, FilteredJob):
         """Get job results by downloading the results blob from the
         storage container linked via the workspace.
 
-        :param timeout_secs: Timeout in seconds, defaults to 60
+        :param timeout_secs: Timeout in seconds, defaults to 300
         :type timeout_secs: int
         :raises RuntimeError: [description]
         :return: [description]

--- a/azure-quantum/azure/quantum/job/job.py
+++ b/azure-quantum/azure/quantum/job/job.py
@@ -56,18 +56,23 @@ class Job(BaseJob, FilteredJob):
             or self.details.status == "Cancelled"
         )
 
-    def wait_until_completed(self, max_poll_wait_secs=30) -> None:
+    def wait_until_completed(self, max_poll_wait_secs=30, timeout=None) -> None:
         """Keeps refreshing the Job's details
         until it reaches a finished status."""
         self.refresh()
         poll_wait = 0.2
+        total_time = 0.
         while not self.has_completed():
+            if timeout is not None and total_time >= timeout:
+                raise TimeoutError(f"The wait time has exceeded {timeout} seconds.")
+ 
             logger.debug(
                 f"Waiting for job {self.id},"
                 + f"it is in status '{self.details.status}'"
             )
             print(".", end="", flush=True)
             time.sleep(poll_wait)
+            total_time += poll_wait
             self.refresh()
             poll_wait = (
                 max_poll_wait_secs

--- a/azure-quantum/azure/quantum/job/job.py
+++ b/azure-quantum/azure/quantum/job/job.py
@@ -56,15 +56,22 @@ class Job(BaseJob, FilteredJob):
             or self.details.status == "Cancelled"
         )
 
-    def wait_until_completed(self, max_poll_wait_secs=30, timeout=None) -> None:
+    def wait_until_completed(self, max_poll_wait_secs=30, timeout_secs=None) -> None:
         """Keeps refreshing the Job's details
-        until it reaches a finished status."""
+        until it reaches a finished status.
+
+        :param max_poll_wait_secs: Maximum poll wait time, defaults to 30
+        :type max_poll_wait_secs: int, optional
+        :param timeout_secs: Timeout in seconds, defaults to None
+        :type timeout_secs: int, optional
+        :raises TimeoutError: If the total poll time exceeds timeout, raise
+        """
         self.refresh()
         poll_wait = 0.2
         total_time = 0.
         while not self.has_completed():
-            if timeout is not None and total_time >= timeout:
-                raise TimeoutError(f"The wait time has exceeded {timeout} seconds.")
+            if timeout_secs is not None and total_time >= timeout_secs:
+                raise TimeoutError(f"The wait time has exceeded {timeout_secs} seconds.")
  
             logger.debug(
                 f"Waiting for job {self.id},"

--- a/azure-quantum/azure/quantum/optimization/problem.py
+++ b/azure-quantum/azure/quantum/optimization/problem.py
@@ -148,6 +148,7 @@ class Problem:
         return data.getvalue()
     
     def _blob_name(self):
+        import uuid
         return "{}-{}".format(self.name, uuid.uuid1())
 
     def upload(

--- a/azure-quantum/azure/quantum/optimization/solvers.py
+++ b/azure-quantum/azure/quantum/optimization/solvers.py
@@ -3,18 +3,12 @@
 # Licensed under the MIT License.
 ##
 import logging
-import azure.quantum
 
 from typing import List, Union, Any, Optional
 from enum import Enum
 from azure.quantum import Workspace, Job
-from azure.quantum._client.models import JobDetails
+from azure.quantum.job.base_job import DEFAULT_TIMEOUT
 from azure.quantum.optimization import Problem
-from azure.quantum.storage import (
-    ContainerClient,
-    create_container_using_client,
-    remove_sas_token,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -136,14 +130,19 @@ class Solver:
 
         return job
 
-    def optimize(self, problem: Union[str, Problem]):
-        """Submits the Problem to the associated
+    def optimize(self, problem: Union[str, Problem], timeout_secs: int=DEFAULT_TIMEOUT):
+        """[Submits the Problem to the associated
             Azure Quantum Workspace and get the results.
 
         :param problem:
             The Problem to solve. It can be an instance of a Problem,
             or the URL of an Azure Storage Blob where the serialized version
             of a Problem has been uploaded.
+        :type problem: Union[str, Problem]
+        :param timeout_secs: Timeout in seconds, defaults to 60
+        :type timeout_secs: int
+        :return: Job results
+        :rtype: dict
         """
         if not isinstance(problem, str):
             self.check_submission_warnings(problem)
@@ -151,7 +150,7 @@ class Solver:
         job = self.submit(problem)
         logger.info(f"Submitted job: '{job.id}'")
 
-        return job.get_results()
+        return job.get_results(timeout_secs=timeout_secs)
 
     def set_one_param(self, name: str, value: Any):
         if value is not None:

--- a/azure-quantum/azure/quantum/optimization/solvers.py
+++ b/azure-quantum/azure/quantum/optimization/solvers.py
@@ -139,7 +139,7 @@ class Solver:
             or the URL of an Azure Storage Blob where the serialized version
             of a Problem has been uploaded.
         :type problem: Union[str, Problem]
-        :param timeout_secs: Timeout in seconds, defaults to 60
+        :param timeout_secs: Timeout in seconds, defaults to 300
         :type timeout_secs: int
         :return: Job results
         :rtype: dict

--- a/azure-quantum/tests/unit/test_target.py
+++ b/azure-quantum/tests/unit/test_target.py
@@ -1,5 +1,7 @@
 import unittest
+import warnings
 
+from azure.core.exceptions import HttpResponseError
 from azure.quantum.job.job import Job
 from azure.quantum.target import IonQ
 from azure.quantum.target.honeywell import Honeywell
@@ -131,27 +133,29 @@ class TestHoneywell(QuantumTestBase):
             workspace = self.create_workspace()
             circuit = self._teleport()
             target = Honeywell(workspace=workspace)
-            job = target.submit(circuit)
+            try:
+                job = target.submit(circuit)
+            except HttpResponseError as e:
+                warnings.warn(e.message)
+            else:
+                # Make sure the job is completed before fetching the results
+                # playback currently does not work for repeated calls
+                if not self.is_playback:
+                    self.assertEqual(False, job.has_completed())
+                    if self.in_recording:
+                        import time
+                        time.sleep(3)
+                    job.refresh()
+                    try:
+                        job.wait_until_completed(timeout=5*60) # Set a timeout for Honeywell recording
+                    except TimeoutError:
+                        warnings.warn("Honeywell execution exceeded timeout. Skipping fetching results.")
+                    else:
+                        self.assertEqual(True, job.has_completed())
+                        job = workspace.get_job(job.id)
+                        self.assertEqual(True, job.has_completed())
 
-            # Make sure the job is completed before fetching the results
-            # playback currently does not work for repeated calls
-            if not self.is_playback:
-                self.assertEqual(False, job.has_completed())
-                if self.in_recording:
-                    import time
-                    time.sleep(3)
-                job.refresh()
-                try:
-                    job.wait_until_completed(timeout=5*60) # Set a timeout for Honeywell recording
-                except TimeoutError:
-                    import warnings
-                    warnings.warn("Honeywell execution exceeded timeout. Skipping fetching results.")
-                else:
-                    self.assertEqual(True, job.has_completed())
-                    job = workspace.get_job(job.id)
-                    self.assertEqual(True, job.has_completed())
-
-            if job.has_completed():
-                results = job.get_results()
-                assert results["c0"] == ["0"]
-                assert results["c1"] == ["000"]
+                if job.has_completed():
+                    results = job.get_results()
+                    assert results["c0"] == ["0"]
+                    assert results["c1"] == ["000"]

--- a/azure-quantum/tests/unit/test_target.py
+++ b/azure-quantum/tests/unit/test_target.py
@@ -147,7 +147,7 @@ class TestHoneywell(QuantumTestBase):
                         time.sleep(3)
                     job.refresh()
                     try:
-                        job.wait_until_completed(timeout=5*60) # Set a timeout for Honeywell recording
+                        job.wait_until_completed(timeout=60) # Set a timeout for Honeywell recording
                     except TimeoutError:
                         warnings.warn("Honeywell execution exceeded timeout. Skipping fetching results.")
                     else:

--- a/azure-quantum/tests/unit/test_target.py
+++ b/azure-quantum/tests/unit/test_target.py
@@ -141,11 +141,17 @@ class TestHoneywell(QuantumTestBase):
                     import time
                     time.sleep(3)
                 job.refresh()
-                job.wait_until_completed()
-                self.assertEqual(True, job.has_completed())
-                job = workspace.get_job(job.id)
-                self.assertEqual(True, job.has_completed())
+                try:
+                    job.wait_until_completed(timeout=5*60) # Set a timeout for Honeywell recording
+                except TimeoutError:
+                    import warnings
+                    warnings.warn("Honeywell execution exceeded timeout. Skipping fetching results.")
+                else:
+                    self.assertEqual(True, job.has_completed())
+                    job = workspace.get_job(job.id)
+                    self.assertEqual(True, job.has_completed())
 
-            results = job.get_results()
-            assert results["c0"] == ["0"]
-            assert results["c1"] == ["000"]
+            if job.has_completed():
+                results = job.get_results()
+                assert results["c0"] == ["0"]
+                assert results["c1"] == ["000"]


### PR DESCRIPTION
Adds a `timeout` argument to `Job.wait_until_completed` method, implements timeout on Honeywell service, catch `HttpResponseError` to mitigate missing Honeywell provider in E2E tests container