### PR TITLE
Updating comments in solver.py as parameter-free invocation is now supported

### DIFF
--- a/azure-quantum/azure/quantum/optimization/solvers.py
+++ b/azure-quantum/azure/quantum/optimization/solvers.py
@@ -648,7 +648,6 @@ class PopulationAnnealing(Solver):
         precision support for the coupler weights.
 
         This solver is CPU only.
-        It currently does not support parameter-free invocation.
 
         :param alpha:
             Ratio to trigger a restart. Must be larger than 1.
@@ -710,7 +709,6 @@ class SubstochasticMonteCarlo(Solver):
         precision support for the coupler weights.
 
         This solver is CPU only.
-        It currently does not support parameter-free invocation.
 
         :param alpha:
             Evolution of alpha (chance to step) over time.


### PR DESCRIPTION
Updating comments in solver.py as parameter-free invocation is now supported in the SDK