### PR TITLE
Add support for custom TokenFileCredential

### DIFF
--- a/azure-quantum/README.md
+++ b/azure-quantum/README.md
@@ -25,7 +25,7 @@ conda env create -f environment.yml
 Then to activate the environment:
 
 ```bash
-conda activate azure-quantum
+conda activate azurequantum
 ```
 
 In case you have created the conda environment a while ago, you can make sure you have the latest versions of all dependencies by updating your environment:

--- a/azure-quantum/azure/quantum/_authentication/__init__.py
+++ b/azure-quantum/azure/quantum/_authentication/__init__.py
@@ -6,4 +6,4 @@
 
 from ._chained import *
 from ._default import _DefaultAzureCredential
-from ._token import _AzureQuantumTokenCredential
+from ._token import _TokenFileCredential

--- a/azure-quantum/azure/quantum/_authentication/__init__.py
+++ b/azure-quantum/azure/quantum/_authentication/__init__.py
@@ -6,3 +6,4 @@
 
 from ._chained import *
 from ._default import _DefaultAzureCredential
+from ._token import _AzureQuantumTokenCredential

--- a/azure-quantum/azure/quantum/_authentication/_default.py
+++ b/azure-quantum/azure/quantum/_authentication/_default.py
@@ -21,6 +21,7 @@ from azure.identity import (
     _credentials
 )
 from ._chained import _ChainedTokenCredential
+from ._token import _AzureQuantumTokenCredential
 
 try:
     from typing import TYPE_CHECKING
@@ -39,7 +40,7 @@ class _DefaultAzureCredential(_ChainedTokenCredential):
     Based on Azure.Identity.DefaultAzureCredential from:
     https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/identity/azure-identity/azure/identity/_credentials/default.py
 
-    The two key differences are:
+    The three key differences are:
     1) Inherit from _ChainedTokenCredential, which has 
        more aggressive error handling than ChainedTokenCredential
     2) Instantiate the internal credentials the first time the get_token gets called
@@ -51,10 +52,11 @@ class _DefaultAzureCredential(_ChainedTokenCredential):
        We need the following parameters to enable auto-detection of tenant_id
        - subscription_id
        - arm_base_url (defaults to the production url "https://management.azure.com/")
+    3) Add custom AzureQuantumTokenCredential as first method to attempt, which will look for a local access token.
     """
     def __init__(self, **kwargs):
         # type: (**Any) -> None
-        self._successfull_tenant_id = None
+        self._successful_tenant_id = None
 
         self.authority = kwargs.pop("authority", None)
         self.authority = normalize_authority(self.authority) if self.authority else get_default_authority()
@@ -83,6 +85,7 @@ class _DefaultAzureCredential(_ChainedTokenCredential):
             "visual_studio_code_tenant_id", os.environ.get(EnvironmentVariables.AZURE_TENANT_ID)
         )
 
+        self.exclude_azure_quantum_token_credential = kwargs.pop("exclude_azure_quantum_token_credential", False)
         self.exclude_environment_credential = kwargs.pop("exclude_environment_credential", False)
         self.exclude_managed_identity_credential = kwargs.pop("exclude_managed_identity_credential", False)
         self.exclude_shared_token_cache_credential = kwargs.pop("exclude_shared_token_cache_credential", True)
@@ -106,6 +109,8 @@ class _DefaultAzureCredential(_ChainedTokenCredential):
                 self.interactive_browser_tenant_id = self._get_tenant_id(arm_base_url=self.arm_base_url, subscription_id=self.subscription_id)
 
         credentials = []  # type: List[TokenCredential]
+        if not self.exclude_azure_quantum_token_credential:
+            credentials.append(_AzureQuantumTokenCredential())
         if not self.exclude_environment_credential:
             credentials.append(EnvironmentCredential(authority=self.authority))
         if not self.exclude_managed_identity_credential:
@@ -155,8 +160,8 @@ class _DefaultAzureCredential(_ChainedTokenCredential):
             raise ValueError("subscription_id is mandatory parameter")
 
         # returns the cached tenant_id if available
-        if self._successfull_tenant_id is not None:
-            return self._successfull_tenant_id
+        if self._successful_tenant_id is not None:
+            return self._successful_tenant_id
 
         try:
             uri = (
@@ -200,8 +205,8 @@ class _DefaultAzureCredential(_ChainedTokenCredential):
             )
 
             regex = re.compile(pattern=r"([a-f0-9]+[-]){4}[a-f0-9]+", flags=re.IGNORECASE)
-            self._successfull_tenant_id = regex.search(tenant_uri).group()
-            return self._successfull_tenant_id
+            self._successful_tenant_id = regex.search(tenant_uri).group()
+            return self._successful_tenant_id
 
         except Exception as e:
             _LOGGER.debug(

--- a/azure-quantum/azure/quantum/_authentication/_default.py
+++ b/azure-quantum/azure/quantum/_authentication/_default.py
@@ -21,7 +21,7 @@ from azure.identity import (
     _credentials
 )
 from ._chained import _ChainedTokenCredential
-from ._token import _AzureQuantumTokenCredential
+from ._token import _TokenFileCredential
 
 try:
     from typing import TYPE_CHECKING
@@ -52,7 +52,7 @@ class _DefaultAzureCredential(_ChainedTokenCredential):
        We need the following parameters to enable auto-detection of tenant_id
        - subscription_id
        - arm_base_url (defaults to the production url "https://management.azure.com/")
-    3) Add custom AzureQuantumTokenCredential as first method to attempt, which will look for a local access token.
+    3) Add custom TokenFileCredential as first method to attempt, which will look for a local access token.
     """
     def __init__(self, **kwargs):
         # type: (**Any) -> None
@@ -85,7 +85,7 @@ class _DefaultAzureCredential(_ChainedTokenCredential):
             "visual_studio_code_tenant_id", os.environ.get(EnvironmentVariables.AZURE_TENANT_ID)
         )
 
-        self.exclude_azure_quantum_token_credential = kwargs.pop("exclude_azure_quantum_token_credential", False)
+        self.exclude_token_file_credential = kwargs.pop("exclude_token_file_credential", False)
         self.exclude_environment_credential = kwargs.pop("exclude_environment_credential", False)
         self.exclude_managed_identity_credential = kwargs.pop("exclude_managed_identity_credential", False)
         self.exclude_shared_token_cache_credential = kwargs.pop("exclude_shared_token_cache_credential", True)
@@ -109,8 +109,8 @@ class _DefaultAzureCredential(_ChainedTokenCredential):
                 self.interactive_browser_tenant_id = self._get_tenant_id(arm_base_url=self.arm_base_url, subscription_id=self.subscription_id)
 
         credentials = []  # type: List[TokenCredential]
-        if not self.exclude_azure_quantum_token_credential:
-            credentials.append(_AzureQuantumTokenCredential())
+        if not self.exclude_token_file_credential:
+            credentials.append(_TokenFileCredential())
         if not self.exclude_environment_credential:
             credentials.append(EnvironmentCredential(authority=self.authority))
         if not self.exclude_managed_identity_credential:

--- a/azure-quantum/azure/quantum/_authentication/_token.py
+++ b/azure-quantum/azure/quantum/_authentication/_token.py
@@ -27,7 +27,7 @@ _TOKEN_FILE_ENV_VARIABLE="AZUREQUANTUM_TOKEN_FILE"
 _AZURE_QUANTUM_SCOPE = "https://quantum.microsoft.com/.default"
 
 
-class _AzureQuantumTokenCredential(object):
+class _TokenFileCredential(object):
     """
     Implements a custom TokenCredential to use a local file as the source for an AzureQuantum token.
 
@@ -54,7 +54,7 @@ class _AzureQuantumTokenCredential(object):
           `message` attribute with the error message.
         """
         if scopes != (_AZURE_QUANTUM_SCOPE,):
-            raise CredentialUnavailableError(message="AzureQuantumTokenCredential only supports {} scope.".format(_AZURE_QUANTUM_SCOPE))
+            raise CredentialUnavailableError(message="TokenFileCredential only supports {} scope.".format(_AZURE_QUANTUM_SCOPE))
 
         if not self.token_file:
             raise CredentialUnavailableError(message="Token file location not set.")

--- a/azure-quantum/azure/quantum/_authentication/_token.py
+++ b/azure-quantum/azure/quantum/_authentication/_token.py
@@ -24,8 +24,6 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 _TOKEN_FILE_ENV_VARIABLE="AZUREQUANTUM_TOKEN_FILE"
-_AZURE_QUANTUM_SCOPE = "https://quantum.microsoft.com/.default"
-
 
 class _TokenFileCredential(object):
     """
@@ -53,9 +51,6 @@ class _TokenFileCredential(object):
         :raises ~azure.identity.CredentialUnavailableError: when failing to get token. The exception has a
           `message` attribute with the error message.
         """
-        if scopes != (_AZURE_QUANTUM_SCOPE,):
-            raise CredentialUnavailableError(message="TokenFileCredential only supports {} scope.".format(_AZURE_QUANTUM_SCOPE))
-
         if not self.token_file:
             raise CredentialUnavailableError(message="Token file location not set.")
 

--- a/azure-quantum/azure/quantum/_authentication/_token.py
+++ b/azure-quantum/azure/quantum/_authentication/_token.py
@@ -1,0 +1,87 @@
+##
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+##
+import json
+from json.decoder import JSONDecodeError
+import logging
+import os
+import time
+
+from azure.identity import CredentialUnavailableError
+from azure.core.credentials import AccessToken
+
+try:
+    from typing import TYPE_CHECKING
+except ImportError:
+    TYPE_CHECKING = False
+
+if TYPE_CHECKING:
+    # pylint:disable=unused-import,ungrouped-imports
+    from typing import Any, Optional
+    from azure.core.credentials import AccessToken
+
+_LOGGER = logging.getLogger(__name__)
+
+_TOKEN_FILE_ENV_VARIABLE="AZUREQUANTUM_TOKEN_FILE"
+_AZURE_QUANTUM_SCOPE = "https://quantum.microsoft.com/.default"
+
+
+class _AzureQuantumTokenCredential(object):
+    """
+    Implements a custom TokenCredential to use a local file as the source for an AzureQuantum token.
+
+    It will only use the local file if the AZUREQUANTUM_TOKEN_FILE environment variable is set, and references
+    an existing json file that contains the access_token and expires_on timestamp in milliseconds.
+
+    If the environment variable is not set, the file does not exist, or the token is invalid in any way (expires or close to expiring),
+    then the credential will throw CredentialUnavailableError, so that _ChainedTokenCredential can fallback to other methods.
+    """
+    def __init__(self, **kwargs):
+        # type: (**Any) -> None
+        self.token_file = os.environ.get(_TOKEN_FILE_ENV_VARIABLE)
+        if self.token_file:
+            _LOGGER.debug("Using provided token file location: {}".format(self.token_file))
+        else:
+            _LOGGER.debug("No token file location provided for {} environment variable.".format(_TOKEN_FILE_ENV_VARIABLE))
+
+    def get_token(self, *scopes, **kwargs):  # pylint:disable=unused-argument
+        # type: (*str, **Any) -> AccessToken
+        """Request an access token for `scopes`.
+        This method is called automatically by Azure SDK clients.
+        :param str scopes: desired scopes for the access token. This method only returns tokens for the https://quantum.microsoft.com/.default scope.
+        :raises ~azure.identity.CredentialUnavailableError: when failing to get token. The exception has a
+          `message` attribute with the error message.
+        """
+        if scopes != (_AZURE_QUANTUM_SCOPE,):
+            raise CredentialUnavailableError(message="AzureQuantumTokenCredential only supports {} scope.".format(_AZURE_QUANTUM_SCOPE))
+
+        if not self.token_file:
+            raise CredentialUnavailableError(message="Token file location not set.")
+
+        if not os.path.isfile(self.token_file):
+            raise CredentialUnavailableError(message="Token file at {} does not exist.".format(self.token_file))
+
+        try:
+            token = self._parse_token_file(self.token_file)
+        except JSONDecodeError:
+            raise CredentialUnavailableError(message="Failed to parse token file: Invalid JSON.")
+        except KeyError as e:
+            raise CredentialUnavailableError(message="Failed to parse token file: Missing expected value: " + str(e))
+        except Exception as e:
+            raise CredentialUnavailableError(message="Failed to parse token file: " + str(e))
+
+        if token.expires_on - time.time() < 300:
+            raise CredentialUnavailableError(message="Token already expired or too close to expiring at {}".format(time.asctime(time.localtime(token.expires_on))))
+
+        return token
+    
+    def _parse_token_file(self, path):
+        # type: (*str) -> AccessToken
+                
+        with open(path, "r") as file:
+            data = json.load(file)
+            expires_on = int(data["expires_on"]) / 1000 # Convert ms to seconds, since python time.time only handles epoch time in seconds
+            token = AccessToken(data["access_token"],  expires_on)
+
+        return token

--- a/azure-quantum/azure/quantum/_authentication/_token.py
+++ b/azure-quantum/azure/quantum/_authentication/_token.py
@@ -67,7 +67,7 @@ class _TokenFileCredential(object):
             raise CredentialUnavailableError(message="Failed to parse token file: " + str(e))
 
         if token.expires_on <= time.time():
-            raise CredentialUnavailableError(message="Token already expired at {}".format(time.asctime(time.localtime(token.expires_on))))
+            raise CredentialUnavailableError(message="Token already expired at {}".format(time.asctime(time.gmtime(token.expires_on))))
 
         return token
     

--- a/azure-quantum/azure/quantum/_authentication/_token.py
+++ b/azure-quantum/azure/quantum/_authentication/_token.py
@@ -34,7 +34,7 @@ class _AzureQuantumTokenCredential(object):
     It will only use the local file if the AZUREQUANTUM_TOKEN_FILE environment variable is set, and references
     an existing json file that contains the access_token and expires_on timestamp in milliseconds.
 
-    If the environment variable is not set, the file does not exist, or the token is invalid in any way (expires or close to expiring),
+    If the environment variable is not set, the file does not exist, or the token is invalid in any way (expired, for example),
     then the credential will throw CredentialUnavailableError, so that _ChainedTokenCredential can fallback to other methods.
     """
     def __init__(self, **kwargs):
@@ -71,8 +71,8 @@ class _AzureQuantumTokenCredential(object):
         except Exception as e:
             raise CredentialUnavailableError(message="Failed to parse token file: " + str(e))
 
-        if token.expires_on - time.time() < 300:
-            raise CredentialUnavailableError(message="Token already expired or too close to expiring at {}".format(time.asctime(time.localtime(token.expires_on))))
+        if token.expires_on <= time.time():
+            raise CredentialUnavailableError(message="Token already expired at {}".format(time.asctime(time.localtime(token.expires_on))))
 
         return token
     

--- a/azure-quantum/azure/quantum/workspace.py
+++ b/azure-quantum/azure/quantum/workspace.py
@@ -54,10 +54,6 @@ if sdk_environment("dogfood"):
         or f"https://{location}.quantum-test.azure.com/"
     )
     ARM_BASE_URL = "https://api-dogfood.resources.windows-int.net/"
-    # Microsoft Quantum Development Kit
-    AAD_CLIENT_ID = "46a998aa-43d0-4281-9cbb-5709a507ac36"
-    AAD_SCOPES = ["api://dogfood.azure-quantum/Jobs.ReadWrite"]
-
 else:
     if sdk_environment("canary"):
         logger.info("Using CANARY configuration.")
@@ -72,9 +68,6 @@ else:
             or f"https://{location}.quantum.azure.com/"
         )
     ARM_BASE_URL = "https://management.azure.com/"
-    # Microsoft Quantum Development Kit
-    AAD_CLIENT_ID = "84ba0947-6c53-4dd2-9ca9-b3694761521b"
-    AAD_SCOPES = ["https://quantum.microsoft.com/Jobs.ReadWrite"]
 
 class Workspace:
     """Represents an Azure Quantum workspace.

--- a/azure-quantum/tests/unit/test_authentication.py
+++ b/azure-quantum/tests/unit/test_authentication.py
@@ -87,7 +87,7 @@ class TestWorkspace(QuantumTestBase):
             with pytest.raises(CredentialUnavailableError) as exception:
                 credential.get_token(_AZURE_QUANTUM_SCOPE)
             
-            assert "Token already expired or too close to expiring at Mon Aug  9 14:05:25 2021" in str(exception.value)
+            assert "Token already expired at Mon Aug  9 14:05:25 2021" in str(exception.value)
 
     def test_azure_quantum_token_credential_file_valid_token(self):
         one_hour_ahead = time.time() + 60*60

--- a/azure-quantum/tests/unit/test_authentication.py
+++ b/azure-quantum/tests/unit/test_authentication.py
@@ -79,7 +79,7 @@ class TestWorkspace(QuantumTestBase):
             with pytest.raises(CredentialUnavailableError) as exception:
                 credential.get_token(_AZURE_QUANTUM_SCOPE)
             
-            assert "Token already expired at Mon Aug  9 14:05:25 2021" in str(exception.value)
+            assert "Token already expired at Mon Aug  9 21:05:25 2021" in str(exception.value)
 
     def test_azure_quantum_token_credential_file_valid_token(self):
         one_hour_ahead = time.time() + 60*60

--- a/azure-quantum/tests/unit/test_authentication.py
+++ b/azure-quantum/tests/unit/test_authentication.py
@@ -15,7 +15,7 @@ import pytest
 from unittest.mock import patch
 
 from azure.identity import CredentialUnavailableError
-from azure.quantum._authentication import _AzureQuantumTokenCredential
+from azure.quantum._authentication import _TokenFileCredential
 from common import QuantumTestBase
 
 _AZURE_QUANTUM_SCOPE = "https://quantum.microsoft.com/.default"
@@ -24,14 +24,14 @@ _AZURE_QUANTUM_SCOPE = "https://quantum.microsoft.com/.default"
 class TestWorkspace(QuantumTestBase):
 
     def test_azure_quantum_token_credential_file_unsupported_scope(self):
-        credential = _AzureQuantumTokenCredential()
+        credential = _TokenFileCredential()
         with pytest.raises(CredentialUnavailableError) as exception:
             credential.get_token("invalid scope")
 
-        assert "AzureQuantumTokenCredential only supports https://quantum.microsoft.com/.default scope." in str(exception.value)
+        assert "TokenFileCredential only supports https://quantum.microsoft.com/.default scope." in str(exception.value)
 
     def test_azure_quantum_token_credential_file_not_set(self):
-        credential = _AzureQuantumTokenCredential()
+        credential = _TokenFileCredential()
         with pytest.raises(CredentialUnavailableError) as exception:
             credential.get_token(_AZURE_QUANTUM_SCOPE)
 
@@ -41,7 +41,7 @@ class TestWorkspace(QuantumTestBase):
         with patch.dict(os.environ, { "AZUREQUANTUM_TOKEN_FILE": "fake_file_path" }, clear=True):
             with patch('os.path.isfile') as mock_isfile:
                 mock_isfile.return_value = False
-                credential = _AzureQuantumTokenCredential()                
+                credential = _TokenFileCredential()                
                 with pytest.raises(CredentialUnavailableError) as exception:
                     credential.get_token(_AZURE_QUANTUM_SCOPE)
                 
@@ -52,7 +52,7 @@ class TestWorkspace(QuantumTestBase):
         file = Path(tmpdir) / "token.json"
         file.write_text("not a json")
         with patch.dict(os.environ, { "AZUREQUANTUM_TOKEN_FILE": str(file.resolve()) }, clear=True):
-            credential = _AzureQuantumTokenCredential()                
+            credential = _TokenFileCredential()                
             with pytest.raises(CredentialUnavailableError) as exception:
                 credential.get_token(_AZURE_QUANTUM_SCOPE)
             
@@ -67,7 +67,7 @@ class TestWorkspace(QuantumTestBase):
         file = Path(tmpdir) / "token.json"
         file.write_text(json.dumps(content))
         with patch.dict(os.environ, { "AZUREQUANTUM_TOKEN_FILE": str(file.resolve()) }, clear=True):
-            credential = _AzureQuantumTokenCredential()                
+            credential = _TokenFileCredential()                
             with pytest.raises(CredentialUnavailableError) as exception:
                 credential.get_token(_AZURE_QUANTUM_SCOPE)
             
@@ -83,7 +83,7 @@ class TestWorkspace(QuantumTestBase):
         file = Path(tmpdir) / "token.json"
         file.write_text(json.dumps(content))
         with patch.dict(os.environ, { "AZUREQUANTUM_TOKEN_FILE": str(file.resolve()) }, clear=True):
-            credential = _AzureQuantumTokenCredential()                
+            credential = _TokenFileCredential()                
             with pytest.raises(CredentialUnavailableError) as exception:
                 credential.get_token(_AZURE_QUANTUM_SCOPE)
             
@@ -100,7 +100,7 @@ class TestWorkspace(QuantumTestBase):
         file = Path(tmpdir) / "token.json"
         file.write_text(json.dumps(content))
         with patch.dict(os.environ, { "AZUREQUANTUM_TOKEN_FILE": str(file.resolve()) }, clear=True):
-            credential = _AzureQuantumTokenCredential()                
+            credential = _TokenFileCredential()                
             token = credential.get_token(_AZURE_QUANTUM_SCOPE)
         
         assert token.token == "fake_token"

--- a/azure-quantum/tests/unit/test_authentication.py
+++ b/azure-quantum/tests/unit/test_authentication.py
@@ -22,14 +22,6 @@ _AZURE_QUANTUM_SCOPE = "https://quantum.microsoft.com/.default"
 
 
 class TestWorkspace(QuantumTestBase):
-
-    def test_azure_quantum_token_credential_file_unsupported_scope(self):
-        credential = _TokenFileCredential()
-        with pytest.raises(CredentialUnavailableError) as exception:
-            credential.get_token("invalid scope")
-
-        assert "TokenFileCredential only supports https://quantum.microsoft.com/.default scope." in str(exception.value)
-
     def test_azure_quantum_token_credential_file_not_set(self):
         credential = _TokenFileCredential()
         with pytest.raises(CredentialUnavailableError) as exception:

--- a/azure-quantum/tests/unit/test_authentication.py
+++ b/azure-quantum/tests/unit/test_authentication.py
@@ -1,0 +1,107 @@
+#!/bin/env python
+# -*- coding: utf-8 -*-
+##
+# test_authentication.py: Checks correctness of azure.quantum._authentication module.
+##
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+##
+import json
+import os
+from pathlib import Path
+import time
+
+import pytest
+from unittest.mock import patch
+
+from azure.identity import CredentialUnavailableError
+from azure.quantum._authentication import _AzureQuantumTokenCredential
+from common import QuantumTestBase
+
+_AZURE_QUANTUM_SCOPE = "https://quantum.microsoft.com/.default"
+
+
+class TestWorkspace(QuantumTestBase):
+
+    def test_azure_quantum_token_credential_file_unsupported_scope(self):
+        credential = _AzureQuantumTokenCredential()
+        with pytest.raises(CredentialUnavailableError) as exception:
+            credential.get_token("invalid scope")
+
+        assert "AzureQuantumTokenCredential only supports https://quantum.microsoft.com/.default scope." in str(exception.value)
+
+    def test_azure_quantum_token_credential_file_not_set(self):
+        credential = _AzureQuantumTokenCredential()
+        with pytest.raises(CredentialUnavailableError) as exception:
+            credential.get_token(_AZURE_QUANTUM_SCOPE)
+
+        assert "Token file location not set." in str(exception.value)
+
+    def test_azure_quantum_token_credential_file_not_exists(self):
+        with patch.dict(os.environ, { "AZUREQUANTUM_TOKEN_FILE": "fake_file_path" }, clear=True):
+            with patch('os.path.isfile') as mock_isfile:
+                mock_isfile.return_value = False
+                credential = _AzureQuantumTokenCredential()                
+                with pytest.raises(CredentialUnavailableError) as exception:
+                    credential.get_token(_AZURE_QUANTUM_SCOPE)
+                
+                assert "Token file at fake_file_path does not exist." in str(exception.value)
+
+    def test_azure_quantum_token_credential_file_invalid_json(self):
+        tmpdir = self.create_temp_dir()
+        file = Path(tmpdir) / "token.json"
+        file.write_text("not a json")
+        with patch.dict(os.environ, { "AZUREQUANTUM_TOKEN_FILE": str(file.resolve()) }, clear=True):
+            credential = _AzureQuantumTokenCredential()                
+            with pytest.raises(CredentialUnavailableError) as exception:
+                credential.get_token(_AZURE_QUANTUM_SCOPE)
+            
+            assert "Failed to parse token file: Invalid JSON." in str(exception.value)
+
+    def test_azure_quantum_token_credential_file_missing_expires_on(self):
+        content = {
+            "access_token": "fake_token",
+        }
+
+        tmpdir = self.create_temp_dir()
+        file = Path(tmpdir) / "token.json"
+        file.write_text(json.dumps(content))
+        with patch.dict(os.environ, { "AZUREQUANTUM_TOKEN_FILE": str(file.resolve()) }, clear=True):
+            credential = _AzureQuantumTokenCredential()                
+            with pytest.raises(CredentialUnavailableError) as exception:
+                credential.get_token(_AZURE_QUANTUM_SCOPE)
+            
+            assert "Failed to parse token file: Missing expected value: 'expires_on'" in str(exception.value)
+
+    def test_azure_quantum_token_credential_file_token_expired(self):
+        content = {
+            "access_token": "fake_token",
+            "expires_on": 1628543125086 # Matches timestamp in error message below
+        }
+
+        tmpdir = self.create_temp_dir()
+        file = Path(tmpdir) / "token.json"
+        file.write_text(json.dumps(content))
+        with patch.dict(os.environ, { "AZUREQUANTUM_TOKEN_FILE": str(file.resolve()) }, clear=True):
+            credential = _AzureQuantumTokenCredential()                
+            with pytest.raises(CredentialUnavailableError) as exception:
+                credential.get_token(_AZURE_QUANTUM_SCOPE)
+            
+            assert "Token already expired or too close to expiring at Mon Aug  9 14:05:25 2021" in str(exception.value)
+
+    def test_azure_quantum_token_credential_file_valid_token(self):
+        one_hour_ahead = time.time() + 60*60
+        content = {
+            "access_token": "fake_token",
+            "expires_on": one_hour_ahead * 1000 # Convert to milliseconds
+        }
+
+        tmpdir = self.create_temp_dir()
+        file = Path(tmpdir) / "token.json"
+        file.write_text(json.dumps(content))
+        with patch.dict(os.environ, { "AZUREQUANTUM_TOKEN_FILE": str(file.resolve()) }, clear=True):
+            credential = _AzureQuantumTokenCredential()                
+            token = credential.get_token(_AZURE_QUANTUM_SCOPE)
+        
+        assert token.token == "fake_token"
+        assert token.expires_on == pytest.approx(one_hour_ahead)


### PR DESCRIPTION
This PR adds support for a custom _TokenFileCredential type that will be used for seamless auth in hosted notebook scenarios.

The credential will only be successful if:
- AZUREQUANTUM_TOKEN_FILE environment variable is set to a valid path
- Token file exists
- Token file contains json with access_token and expires_on in milliseconds
- Token has not expired
- Scope requested is for https://quantum.microsoft.com/.default

In all other cases, the credential will fall back to other methods in the chained credential.