### PR TITLE
Changing schema of grouped terms and separating term types

### DIFF
--- a/azure-quantum/azure/quantum/optimization/problem.py
+++ b/azure-quantum/azure/quantum/optimization/problem.py
@@ -13,7 +13,7 @@ import os
 
 from typing import List, Tuple, Union, Dict, Optional, Type, TYPE_CHECKING
 from enum import Enum
-from azure.quantum.optimization import TermBase, Term, GroupType, GroupedTerm
+from azure.quantum.optimization import TermBase, Term, GroupType, SlcTerm
 from azure.quantum.storage import (
     ContainerClient,
     download_blob,
@@ -60,12 +60,24 @@ class Problem:
         problem_type: ProblemType = ProblemType.ising,
     ):
         self.name = name
-        self.terms = terms.copy() if terms is not None else []
         self.problem_type = problem_type
-        self.check_for_grouped_term()
         self.init_config = init_config
         self.uploaded_blob_uri = None
         self.uploaded_blob_params = None
+
+        # each type of term has its own section for quicker serialization
+        self.terms = []
+        self.terms_slc = []
+
+        # set the terms
+        if terms:
+            for term in terms:
+                if isinstance(term, SlcTerm):
+                    self.terms_slc.append(term)
+                else:
+                    self.terms.append(term)
+
+        self.check_for_grouped_term()
 
     """
     Constant thresholds used to determine if a problem is "large".
@@ -79,9 +91,12 @@ class Problem:
             "cost_function": {
                 "version": "1.1" if self.init_config else "1.0",
                 "type": self.problem_type.name,
-                "terms": [term.to_dict() for term in self.terms],
+                "terms": [term.to_dict() for term in self.terms]
             }
         }
+
+        if len(self.terms_slc) > 0:
+            result["cost_function"]["terms_slc"] = [term.to_dict() for term in self.terms_slc]
 
         if self.init_config:
             result["cost_function"]["initial_configuration"] = self.init_config
@@ -101,13 +116,13 @@ class Problem:
         """
         result = json.loads(problem_as_json)
 
+        terms = [Term.from_dict(t) for t in result["cost_function"]["terms"]] if "terms" in result["cost_function"] else []
+        if "terms_slc" in result["cost_function"]:
+            terms.append([SlcTerm.from_dict(t) for t in result["cost_function"]["terms_slc"]])
+
         problem = Problem(
             name=name,
-            terms=[
-                GroupedTerm.from_dict(t) if GroupedTerm.is_grouped_term(t)
-                else Term.from_dict(t)
-                for t in result["cost_function"]["terms"]
-            ],
+            terms=terms,
             problem_type=ProblemType[result["cost_function"]["type"]],
         )
 
@@ -139,14 +154,14 @@ class Problem:
         :param terms: The list of terms to add to the problem
         :param term_type: Type of grouped term being added
             If GroupType.combination, terms will be added as ungrouped monomials.
-        :param c: Weight of grouped term, if applicable
+        :param c: Weight of grouped term, only applicable for grouped terms that support it.
         """
         if term_type is GroupType.combination:
-            # Cast as list of ungrouped monomial terms
-            self.terms += [Term(term.ids, c=c*term.c) for term in terms]
+            # Default type is a group of monomials
+            self.terms += terms
         else:
-            # Grouped term
-            self.terms.append(GroupedTerm(term_type, terms, c=c))
+            # Slc term
+            self.terms_slc.append(SlcTerm(terms=terms, c=c))
             self.problem_type_to_grouped()
         self.uploaded_blob_uri = None
     
@@ -157,7 +172,7 @@ class Problem:
         c: Union[int, float] = 1
     ):
         """Adds a squared linear combination term
-        to the `Problem` representation
+        to the `Problem` representation. Helper function to construct terms list.
         
         :param terms: List of monomial terms, with each represented by a pair.
             The first entry represents the monomial term weight.
@@ -170,17 +185,15 @@ class Problem:
         else:
             gterms = [Term([index], c=tc) if index is not None else Term([], c=tc)
                       for tc,index in terms]
-        self.terms.append(
-            GroupedTerm(GroupType.squared_linear_combination, gterms, c=c)
+        self.terms_slc.append(
+            SlcTerm(gterms, c=c)
         )
         self.problem_type_to_grouped()
         self.uploaded_blob_uri = None
 
     def check_for_grouped_term(self):
-        for term in self.terms:
-            if isinstance(term, GroupedTerm):
-                self.problem_type_to_grouped()
-                break
+        if len(self.terms_slc) != 0:
+            self.problem_type_to_grouped()
     
     def problem_type_to_grouped(self):
         if self.problem_type == ProblemType.pubo:
@@ -282,14 +295,15 @@ class Problem:
         new_terms = []
 
         constant = 0
-        for term in self.terms:
-            reduced_term = term.reduce_by_variable_state(fixed_transformed)
-            if reduced_term:
-                if isinstance(reduced_term, GroupedTerm) or len(reduced_term.ids) > 0:
-                    new_terms.append(reduced_term)
-                else:
-                    # reduced to a constant term
-                    constant += reduced_term.c
+        for terms in [self.terms, self.terms_slc]:
+            for term in terms:
+                reduced_term = term.reduce_by_variable_state(fixed_transformed)
+                if reduced_term:
+                    if not isinstance(reduced_term, Term) or len(reduced_term.ids) > 0:
+                        new_terms.append(reduced_term)
+                    else:
+                        # reduced to a constant term
+                        constant += reduced_term.c
 
         if constant:
             new_terms.append(Term(c=constant, indices=[]))
@@ -309,6 +323,13 @@ class Problem:
             problem_type=self.problem_type,
         )
 
+    def _evaluate(self, configuration, term_list):
+        total = 0
+        if term_list:
+            for term in term_list:
+                total += term.evaluate(configuration)
+        return total
+
     def evaluate(self, configuration: Union[Dict[int, int], Dict[str, int]]) -> float:
         """Given a configuration/variable assignment,
         return the cost function value of this problem.
@@ -319,10 +340,10 @@ class Problem:
         configuration_transformed = {
             int(k): configuration[k] for k in configuration
         }  # if ids are given in string form, convert them to int
+
         total_cost = 0
-        if self.terms:
-            for term in self.terms:
-                total_cost += term.evaluate(configuration_transformed)
+        for terms in [self.terms, self.terms_slc]:
+            total_cost += self._evaluate(configuration_transformed, terms)
 
         return total_cost
 
@@ -336,14 +357,15 @@ class Problem:
 
         set_vars = set()
         total_term_count = 0
-        for term in self.terms:
-            if isinstance(term, Term):
-                set_vars.update(term.ids)
-                total_term_count += 1
-            elif isinstance(term, GroupedTerm):
-                for subterm in term.terms:
-                    set_vars.update(subterm.ids)
+        for terms in [self.terms, self.terms_slc]:
+            for term in terms:
+                if isinstance(term, Term):
+                    set_vars.update(term.ids)
                     total_term_count += 1
+                elif isinstance(term, SlcTerm):
+                    for subterm in term.terms:
+                        set_vars.update(subterm.ids)
+                        total_term_count += 1
         
         return (
             len(set_vars) >= Problem.NUM_VARIABLES_LARGE
@@ -368,16 +390,17 @@ class Problem:
         a list of terms with that index
         """
         terms = []
-        if self.terms != []:
-            for term in self.terms:
-                if isinstance(term, Term):
-                    if id in term.ids:
-                        terms.append(term)
-                elif isinstance(term, GroupedTerm):
-                    for subterm in term.terms:
-                        if id in subterm.ids:
+        if self.terms != [] or self.terms_slc != []:
+            for all_terms in [self.terms, self.terms_slc]:
+                for term in all_terms:
+                    if isinstance(term, Term):
+                        if id in term.ids:
                             terms.append(term)
-                            break
+                    elif isinstance(term, SlcTerm):
+                        for subterm in term.terms:
+                            if id in subterm.ids:
+                                terms.append(term)
+                                break
             return terms
         else:
             raise Exception(

--- a/azure-quantum/tests/unit/test_job.py
+++ b/azure-quantum/tests/unit/test_job.py
@@ -15,7 +15,7 @@ from datetime import date, datetime, timedelta
 
 from common import QuantumTestBase, ZERO_UID
 from azure.quantum import Job
-from azure.quantum.optimization import Problem, ProblemType, Term, GroupedTerm, GroupType
+from azure.quantum.optimization import Problem, ProblemType, Term, SlcTerm, GroupType
 import azure.quantum.optimization as microsoft
 import azure.quantum.optimization.oneqbit as oneqbit
 import azure.quantum.optimization.toshiba as toshiba
@@ -127,13 +127,15 @@ class TestJob(QuantumTestBase):
         solver_type = functools.partial(microsoft.PopulationAnnealing, sweeps=200)
         solver_name = "PopulationAnnealing"
         self._test_job_submit(solver_name, solver_type)
-        self._test_job_submit(solver_name, solver_type, test_grouped=True)
+        # renable after schema change is deployed
+        #self._test_job_submit(solver_name, solver_type, test_grouped=True)
 
     def test_job_submit_microsoft_substochastic_monte_carlo(self):
         solver_type = functools.partial(microsoft.SubstochasticMonteCarlo, step_limit=280)
         solver_name = "SubstochasticMonteCarlo"
         self._test_job_submit(solver_name, solver_type)
-        self._test_job_submit(solver_name, solver_type, test_grouped=True)
+        # renable after schema change is deployed
+        #self._test_job_submit(solver_name, solver_type, test_grouped=True)
 
     def test_job_upload_and_run_solvers(self):
         problem_name = f'Test-problem-{datetime.now():"%Y%m%d-%H%M%S"}'
@@ -298,9 +300,8 @@ class TestJob(QuantumTestBase):
             Term(w=4, indices=[3, 2]),
         ]
         if test_grouped:
-            terms.append(GroupedTerm(
+            terms.append(SlcTerm(
                 c=1,
-                term_type=GroupType.squared_linear_combination,
                 terms=[Term(c=i+2, indices=[i]) for i in range(3)]
             ))
 

--- a/azure-quantum/tests/unit/test_optimization.py
+++ b/azure-quantum/tests/unit/test_optimization.py
@@ -9,7 +9,7 @@
 
 import json
 import unittest
-from azure.quantum.optimization import Problem, ProblemType, Term, GroupType, GroupedTerm
+from azure.quantum.optimization import Problem, ProblemType, Term, GroupType, SlcTerm
 from azure.quantum.optimization.solvers import (
     ParallelTempering,
     PopulationAnnealing,
@@ -77,33 +77,34 @@ class TestProblem(QuantumTestBase):
         subterms = [Term(c=1, indices=[i]) for i in range(count)]
         subterms.append(Term(c=-5, indices=[]))
         problem.add_slc_term(terms=[(1, i) for i in range(count)] + [(-5, None)], c=2)
-        self.assertEqual(2*count + 1, len(problem.terms))
+        self.assertEqual(2*count, len(problem.terms))
+        self.assertEqual(1, len(problem.terms_slc))
         self.assertEqual(
-            GroupedTerm(GroupType.squared_linear_combination,
-                        subterms, c=2),
-            problem.terms[-1]
+            SlcTerm(subterms, c=2),
+            problem.terms_slc[-1]
         )
 
         problem.add_terms(subterms, term_type=GroupType.squared_linear_combination, c=2)
-        self.assertEqual(2*count + 2, len(problem.terms))
+        self.assertEqual(2*count, len(problem.terms))
+        self.assertEqual(2, len(problem.terms_slc))
         self.assertEqual(
-            GroupedTerm(GroupType.squared_linear_combination,
-                        subterms, c=2),
-            problem.terms[-1]
+            SlcTerm(subterms, c=2),
+            problem.terms_slc[-1]
         )
+
         problem.add_terms(subterms, term_type=GroupType.combination, c=0.5)
-        self.assertEqual(3*count + 3, len(problem.terms))
+        self.assertEqual(3*count + 1, len(problem.terms))
         self.assertEqual(
-            [Term(subterm.ids, c=0.5*subterm.c) for subterm in subterms],
+            [Term(subterm.ids, c=subterm.c) for subterm in subterms],
             problem.terms[-len(subterms):]
         )
 
         problem.add_slc_term(subterms, c=3)
-        self.assertEqual(3*count + 4, len(problem.terms))
+        self.assertEqual(3*count + 1, len(problem.terms))
+        self.assertEqual(3, len(problem.terms_slc))
         self.assertEqual(
-            GroupedTerm(GroupType.squared_linear_combination,
-                        subterms, c=3),
-            problem.terms[-1]
+            SlcTerm(subterms, c=3),
+            problem.terms_slc[-1]
         )
 
     def test_provide_cterms(self):
@@ -111,8 +112,7 @@ class TestProblem(QuantumTestBase):
         terms = []
         for i in range(count):
             terms.append(Term(c=i, indices=[i, i + 1]))
-        terms.append(GroupedTerm(
-            GroupType.squared_linear_combination,
+        terms.append(SlcTerm(
             [Term(c=i/2, indices=[i+2]) for i in range(count)] + [Term(c=5, indices=[])],
             c=1)
         )
@@ -121,28 +121,21 @@ class TestProblem(QuantumTestBase):
         )
 
         self.assertEqual(ProblemType.pubo_grouped, problem.problem_type)
-        self.assertEqual(count+1, len(problem.terms))
+        self.assertEqual(count, len(problem.terms))
+        self.assertEqual(1, len(problem.terms_slc))
         self.assertEqual(Term(c=1, indices=[1, 2]), problem.terms[1])
 
     def test_errant_grouped_terms(self):
         with self.assertRaises(ValueError):
-            _ = GroupedTerm(
-                GroupType.combination,
-                [Term(c=i+2, indices=[i,i+1]) for i in range(2)], c=1
-            )
-        with self.assertRaises(ValueError):
-            _ = GroupedTerm(
-                GroupType.squared_linear_combination,
+            _ = SlcTerm(
                 [Term(c=i+2, indices=[i%2]) for i in range(3)], c=1
             )
         with self.assertRaises(ValueError):
-            _ = GroupedTerm(
-                GroupType.squared_linear_combination,
+            _ = SlcTerm(
                 [Term(c=i+1, indices=[i, i+1]) for i in range(2)], c=1
             )
         with self.assertRaises(ValueError):
-            _ = GroupedTerm(
-                GroupType.squared_linear_combination,
+            _ = SlcTerm(
                 [Term(c=i, indices=[]) for i in range(1,3)], c=1
             )
         
@@ -153,8 +146,7 @@ class TestProblem(QuantumTestBase):
         for i in range(count):
             terms.append(Term(c=i, indices=[i, i + 1]))
         terms.append(
-            GroupedTerm(
-                GroupType.squared_linear_combination,
+            SlcTerm(
                 [Term(c=0, indices=[0]), Term(c=1, indices=[1]), Term(c=-5, indices=[])],
                 c=1
             )
@@ -168,13 +160,15 @@ class TestProblem(QuantumTestBase):
                     "type": "ising_grouped",
                     "terms": [
                         {"c": 0, "ids": [0, 1]},
-                        {"c": 1, "ids": [1, 2]},
-                        {"type": "slc", "c": 1, "terms": [
+                        {"c": 1, "ids": [1, 2]}
+                    ],
+                    "terms_slc":[
+                        {"c": 1, "terms": [
                             {"c": 0, "ids": [0]},
                             {"c": 1, "ids": [1]},
                             {"c": -5, "ids": []}
                         ]}
-                    ],
+                    ]
                 }
             }
         )
@@ -213,7 +207,7 @@ class TestProblem(QuantumTestBase):
         subterms = [Term(c=1, indices=[i]) for i in range(3)]
         subterms.append(Term(c=-2, indices=[]))
         terms.append(
-            GroupedTerm(GroupType.squared_linear_combination, subterms, c=1)
+            SlcTerm(subterms, c=1)
         )
         problem = Problem(name="test", terms=terms)
         deserialized = Problem.deserialize(problem.serialize(), problem.name)
@@ -224,8 +218,8 @@ class TestProblem(QuantumTestBase):
         self.assertEqual(Term(c=0, indices=[0, 1]), problem.terms[0])
         self.assertEqual(Term(c=1, indices=[1, 2]), problem.terms[1])
         self.assertEqual(
-            GroupedTerm(GroupType.squared_linear_combination, subterms, c=1),
-            problem.terms[-1]
+            SlcTerm(subterms, c=1),
+            problem.terms_slc[-1]
         )
 
     def test_deserialize_init_config(self):
@@ -279,7 +273,7 @@ class TestProblem(QuantumTestBase):
 
         terms = [
             Term(c=2, indices=[0, 1, 2]),
-            GroupedTerm(GroupType.squared_linear_combination, terms=[
+            SlcTerm(terms=[
                 Term(c=1, indices=[0]),
                 Term(c=1, indices=[1]),
                 Term(c=1, indices=[2]),
@@ -322,7 +316,7 @@ class TestProblem(QuantumTestBase):
         terms = [
             Term(c=1, indices=[]),
             Term(c=2, indices=[0, 1, 2]),
-            GroupedTerm(GroupType.squared_linear_combination, terms=[
+            SlcTerm(terms=[
                 Term(c=1, indices=[0]),
                 Term(c=1, indices=[1]),
                 Term(c=-5, indices=[])
@@ -335,16 +329,21 @@ class TestProblem(QuantumTestBase):
             [Term(c=30, indices=[])],
             problem.set_fixed_variables({"0": 1, "1": 1, "2": 1}).terms,
         )
+
         self.assertEqual(
             [
                 Term(c=2, indices=[1]),
-                GroupedTerm(GroupType.squared_linear_combination, terms=[
-                    Term(c=-4, indices=[]),
-                    Term(c=1, indices=[1])
-                ], c=3),
                 Term(c=1, indices=[])
             ],
             problem.set_fixed_variables({"0": 1, "2": 1}).terms,
+        )
+
+        self.assertEqual(
+            [SlcTerm(terms=[
+                Term(c=-4, indices=[]),
+                Term(c=1, indices=[1])
+            ], c=3)],
+            problem.set_fixed_variables({"0": 1, "2": 1}).terms_slc,
         )
 
         # test init_config gets transferred
@@ -369,8 +368,8 @@ class TestProblem(QuantumTestBase):
         )  # create 1mil dummy terms
         self.assertTrue(problem.is_large())
 
-        problem = Problem(name="test", terms=[GroupedTerm(
-            GroupType.squared_linear_combination, terms=[Term(indices=[9999], c=1)], c=1
+        problem = Problem(name="test", terms=[SlcTerm(
+            terms=[Term(indices=[9999], c=1)], c=1
         ) for i in range(int(1e6))], problem_type=ProblemType.pubo)
         self.assertTrue(not problem.is_large())
 

--- a/azure-quantum/tests/unit/test_problem.py
+++ b/azure-quantum/tests/unit/test_problem.py
@@ -10,7 +10,7 @@
 import unittest
 from unittest.mock import Mock, patch
 from typing import TYPE_CHECKING
-from azure.quantum.optimization import Problem, ProblemType, Term, GroupedTerm
+from azure.quantum.optimization import Problem, ProblemType, Term, SlcTerm
 import azure.quantum.optimization.problem
 from common import expected_terms
 import numpy


### PR DESCRIPTION
The solutions team recently decided on a schema change on how grouped terms are supplied to the backend. 
For this reason we need to update the SDK side. This needs to make it by the August shiproom.  

Changing schema of grouped terms and separating term types. 
The new schema will also no longer work easily with streamingproblem.py so I am removing support there for now. 