### PR TITLE
Remove lingering FleetManagement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -360,6 +360,7 @@ MigrationBackup/
 *.egg-info
 *.pickle
 .ipynb_checkpoints/
+[.]venv/
 
 # Javascript
 *.cache.js

--- a/azure-quantum/azure/quantum/optimization/solvers.py
+++ b/azure-quantum/azure/quantum/optimization/solvers.py
@@ -16,4 +16,3 @@ from azure.quantum.target.microsoft.qio import (
     PopulationAnnealing,
     SubstochasticMonteCarlo,
 )
-from azure.quantum.target.microsoft.fleet_management import FleetManagement


### PR DESCRIPTION
After #134 we removed the `FleetManagement` target, but forgot to remove its `import` in `Solvers`, which creates a run time error when trying to import the `azure.quantum.optimization.solvers` namespace.