### PR TITLE
Add honeywell.hqs-lt-s2 targets to unit tests.

### DIFF
--- a/azure-quantum/tests/unit/test_workspace.py
+++ b/azure-quantum/tests/unit/test_workspace.py
@@ -95,6 +95,8 @@ class TestWorkspace(QuantumTestBase):
             'honeywell.hqs-lt-s1',
             'honeywell.hqs-lt-s1-apival',
             'honeywell.hqs-lt-s1-sim',
+            'honeywell.hqs-lt-s2',
+            'honeywell.hqs-lt-s2-apival',
             'ionq.qpu',
             'ionq.simulator',
             'microsoft.paralleltempering-parameterfree.cpu',


### PR DESCRIPTION
This PR adapts unit tests to include targets recently added to e2e test providers.