### PR TITLE
Workspace.get_targets() returns generic Target for unknown targets

### DIFF
--- a/azure-quantum/azure/quantum/target/target.py
+++ b/azure-quantum/azure/quantum/target/target.py
@@ -29,6 +29,8 @@ class Target:
         average_queue_time: float = None,
         current_availability: str = ""
     ):
+        if not provider_id and "." in name:
+            provider_id = name.split(".")[0]
         self.workspace = workspace
         self.name = name
         self.input_data_format = input_data_format

--- a/azure-quantum/azure/quantum/target/target_factory.py
+++ b/azure-quantum/azure/quantum/target/target_factory.py
@@ -28,7 +28,7 @@ class TargetFactory:
     def _get_all_target_cls() -> Dict[str, Target]:
         """Get all target classes by target name"""
         return {
-            name: _t for t in Target.__subclasses__()
+            name.lower(): _t for t in Target.__subclasses__()
             for _t in [t] + t.__subclasses__()
             for name in _t.target_names
         }
@@ -38,7 +38,7 @@ class TargetFactory:
 
     def _target_cls(self, provider_id: str, name: str):
         if name in self._all_targets:
-            return self._all_targets[name]
+            return self._all_targets[name.lower()]
 
         # case insensitive lookup
         default_targets = {k.lower(): v for k, v in DEFAULT_TARGETS.items()}

--- a/azure-quantum/azure/quantum/target/target_factory.py
+++ b/azure-quantum/azure/quantum/target/target_factory.py
@@ -40,13 +40,14 @@ class TargetFactory:
         if name in self._all_targets:
             return self._all_targets[name]
 
-        if provider_id in DEFAULT_TARGETS:
-            return DEFAULT_TARGETS[provider_id]
+        # case insensitive lookup
+        default_targets = {k.lower(): v for k, v in DEFAULT_TARGETS.items()}
+        if provider_id.lower() in default_targets:
+            return default_targets[provider_id.lower()]
  
         warnings.warn(
-            "No default target specified for provider {provider_id}. \
-Please check the provider name and try again or create an issue here: \
-https://github.com/microsoft/qdk-python/issues.")
+            f"No default Target class exists for provider {provider_id}. Returning stub Target instance.")
+        return Target
 
     def create_target(
         self, workspace: "Workspace", provider_id: str, name: str, **kwargs

--- a/azure-quantum/tests/unit/test_workspace.py
+++ b/azure-quantum/tests/unit/test_workspace.py
@@ -108,6 +108,9 @@ class TestWorkspace(QuantumTestBase):
         target.refresh()
         assert target.average_queue_time is not None
         assert target.current_availability is not None
+        # target lookup is case insensitive
+        target1 = ws.get_targets("IonQ.QPU")
+        assert target.name == target1.name
 
         with pytest.raises(ValueError):
             target.name = "foo"

--- a/azure-quantum/tests/unit/test_workspace.py
+++ b/azure-quantum/tests/unit/test_workspace.py
@@ -88,6 +88,7 @@ class TestWorkspace(QuantumTestBase):
     def test_workspace_get_targets(self):
         ws = self.create_workspace()
         targets = ws.get_targets()
+        assert None not in targets
         test_targets = set([
             'honeywell.hqs-lt-s1-apival',
             'ionq.simulator',


### PR DESCRIPTION
Fixes #147 

- Workspace.get_targets() returns generic `Target` for unknown targets
- Fix confusing error message
- Make `TargetFactory` case insensitive