### PR TITLE
Add back missing imports for azure.quantum.optimization HardwarePlatform and RangeSchedule

### DIFF
--- a/azure-quantum/azure/quantum/optimization/__init__.py
+++ b/azure-quantum/azure/quantum/optimization/__init__.py
@@ -8,7 +8,7 @@ from .term import *
 from .problem import *
 from .streaming_problem import *
 from .online_problem import *
-from azure.quantum.target import Solver
+from azure.quantum.target.solvers import *
 from azure.quantum.target.microsoft.qio import (
     ParallelTempering,
     PopulationAnnealing,


### PR DESCRIPTION
There were two imports that worked before that broke after the September release.

from azure.quantum.optimization import HardwarePlatform, RangeSchedule

This PR adds them back to the azure.quantum.optimization path.