### PR TITLE
fail test.ps1 script if pytest did not return zero exit code

### DIFF
--- a/azure-quantum/requirements.txt
+++ b/azure-quantum/requirements.txt
@@ -1,4 +1,4 @@
-azure-core>=1.16.0
+azure-core<=1.19.1
 azure-identity>=1.6.0
 azure-mgmt-core>= 1.3.0
 azure-storage-blob>=12.8.1

--- a/azure-quantum/tests/unit/conftest.py
+++ b/azure-quantum/tests/unit/conftest.py
@@ -1,6 +1,8 @@
 import pytest
 import asyncio
 
+raise ValueError("Test")
+
 
 @pytest.fixture(scope="class")
 def event_loop_instance(request):

--- a/azure-quantum/tests/unit/conftest.py
+++ b/azure-quantum/tests/unit/conftest.py
@@ -1,8 +1,6 @@
 import pytest
 import asyncio
 
-raise ValueError("Test")
-
 
 @pytest.fixture(scope="class")
 def event_loop_instance(request):

--- a/build/package-utils.psm1
+++ b/build/package-utils.psm1
@@ -152,9 +152,10 @@ function Invoke-Tests() {
     # Activate env
     Use-CondaEnv $EnvName
     # Install testing deps
-    python -m pip install --upgrade pip
-    pip install pytest pytest-azurepipelines pytest-cov
+    python -m pip install --upgrade pip | Write-Host
+    pip install pytest pytest-azurepipelines pytest-cov | Write-Host
     # Run tests
     $PkgName = $PackageName.replace("-", ".")
-    pytest --cov-report term --cov=$PkgName --junitxml test-output-$PackageName.xml $AbsPackageDir
+    pytest --cov-report term --cov=$PkgName --junitxml test-output-$PackageName.xml $AbsPackageDir | Write-Host
+    return $LASTEXITCODE
 }

--- a/build/package-utils.psm1
+++ b/build/package-utils.psm1
@@ -157,9 +157,4 @@ function Invoke-Tests() {
     # Run tests
     $PkgName = $PackageName.replace("-", ".")
     pytest --cov-report term --cov=$PkgName --junitxml test-output-$PackageName.xml $AbsPackageDir
-    if (0 -eq $LastExitCode) {
-        return $True;
-    } else {
-        return $False;
-    }
 }

--- a/build/package-utils.psm1
+++ b/build/package-utils.psm1
@@ -157,5 +157,5 @@ function Invoke-Tests() {
     # Run tests
     $PkgName = $PackageName.replace("-", ".")
     pytest --cov-report term --cov=$PkgName --junitxml test-output-$PackageName.xml $AbsPackageDir | Write-Host
-    return $LASTEXITCODE
+    return ($LASTEXITCODE -eq 0)
 }

--- a/build/package-utils.psm1
+++ b/build/package-utils.psm1
@@ -157,4 +157,9 @@ function Invoke-Tests() {
     # Run tests
     $PkgName = $PackageName.replace("-", ".")
     pytest --cov-report term --cov=$PkgName --junitxml test-output-$PackageName.xml $AbsPackageDir
+    if (0 -eq $LastExitCode) {
+        return $True;
+    } else {
+        return $False;
+    }
 }

--- a/build/test.ps1
+++ b/build/test.ps1
@@ -24,5 +24,8 @@ if ($Env:ENABLE_PYTHON -eq "false") {
   foreach ($PackageName in $PackageNames) {
     $EnvName = GetEnvName -PackageName $PackageName -CondaEnvironmentSuffix $CondaEnvironmentSuffix
     Invoke-Tests -PackageName $PackageName -EnvName $EnvName
+    if (0 -ne $LastExitCode) {
+      exit 1
+    }
   }
 }

--- a/build/test.ps1
+++ b/build/test.ps1
@@ -24,10 +24,12 @@ if ($Env:ENABLE_PYTHON -eq "false") {
   $ExitCode = 0;
   foreach ($PackageName in $PackageNames) {
     $EnvName = GetEnvName -PackageName $PackageName -CondaEnvironmentSuffix $CondaEnvironmentSuffix
-    $Success = Invoke-Tests -PackageName $PackageName -EnvName $EnvName
-    if ($True -ne $Success) {
+    Invoke-Tests -PackageName $PackageName -EnvName $EnvName
+    if (0 -ne $LastExitCode) {
       $ExitCode = 1;
+      Write-Host "##vso[task.logissue type=error;]Tests for package $PackageName failed."
+      exit $ExitCode;
     }
-  exit $ExitCode;
   }
+  exit $ExitCode;
 }

--- a/build/test.ps1
+++ b/build/test.ps1
@@ -28,7 +28,6 @@ if ($Env:ENABLE_PYTHON -eq "false") {
     if (0 -ne $LastExitCode) {
       $ExitCode = 1;
       Write-Host "##vso[task.logissue type=error;]Tests for package $PackageName failed."
-      exit $ExitCode;
     }
   }
   exit $ExitCode;

--- a/build/test.ps1
+++ b/build/test.ps1
@@ -25,7 +25,6 @@ if ($Env:ENABLE_PYTHON -eq "false") {
   foreach ($PackageName in $PackageNames) {
     $EnvName = GetEnvName -PackageName $PackageName -CondaEnvironmentSuffix $CondaEnvironmentSuffix
     $Success = Invoke-Tests -PackageName $PackageName -EnvName $EnvName
-    Write-Host $Success
     if ($Success -ne $True) {
         $ExitCode = 1;
         Write-Host "##vso[task.logissue type=error;]Tests for package $PackageName failed."

--- a/build/test.ps1
+++ b/build/test.ps1
@@ -21,11 +21,13 @@ if ($Env:ENABLE_PYTHON -eq "false") {
   Write-Host "##vso[task.logissue type=warning;]Skipping testing Python packages. Env:ENABLE_PYTHON was set to 'false'."
 } else {
   $PackageNames = PackagesList -PackageName $PackageName
+  $ExitCode = 0;
   foreach ($PackageName in $PackageNames) {
     $EnvName = GetEnvName -PackageName $PackageName -CondaEnvironmentSuffix $CondaEnvironmentSuffix
-    Invoke-Tests -PackageName $PackageName -EnvName $EnvName
-    if (0 -ne $LastExitCode) {
-      exit 1
+    $Success = Invoke-Tests -PackageName $PackageName -EnvName $EnvName
+    if ($True -ne $Success) {
+      $ExitCode = 1;
     }
+  exit $ExitCode;
   }
 }

--- a/build/test.ps1
+++ b/build/test.ps1
@@ -24,11 +24,12 @@ if ($Env:ENABLE_PYTHON -eq "false") {
   $ExitCode = 0;
   foreach ($PackageName in $PackageNames) {
     $EnvName = GetEnvName -PackageName $PackageName -CondaEnvironmentSuffix $CondaEnvironmentSuffix
-    Invoke-Tests -PackageName $PackageName -EnvName $EnvName
-    if (0 -ne $LastExitCode) {
-      $ExitCode = 1;
-      Write-Host "##vso[task.logissue type=error;]Tests for package $PackageName failed."
+    $Success = Invoke-Tests -PackageName $PackageName -EnvName $EnvName
+    Write-Host $Success
+    if ($Success -ne $True) {
+        $ExitCode = 1;
+        Write-Host "##vso[task.logissue type=error;]Tests for package $PackageName failed."
+      }
     }
-  }
-  exit $ExitCode;
+    exit $ExitCode;
 }


### PR DESCRIPTION
This fixes the issue that failing unit tests are not causing build steps to fail. See: https://ms-quantum.visualstudio.com/Quantum%20Program/_build/results?buildId=174305&view=logs&j=0cf5fac5-e08e-5c92-a2db-66aab767ad9a&t=3561fc1c-61af-5606-6b74-430059fea15f&l=131