### PR TITLE
Update QDK to .NET6.0 (qdk-python)

### DIFF
--- a/examples/chemistry/Molecule.ipynb
+++ b/examples/chemistry/Molecule.ipynb
@@ -345,7 +345,7 @@
     "<Project Sdk=\"Microsoft.Quantum.Sdk/0.xx.xxxxxxxxxx\">\n",
     "    <PropertyGroup>\n",
     "        <OutputType>Exe</OutputType>\n",
-    "        <TargetFramework>netcoreapp3.1</TargetFramework>\n",
+    "        <TargetFramework>net6.0</TargetFramework>\n",
     "        <IQSharpLoadAutomatically>true</IQSharpLoadAutomatically>\n",
     "    </PropertyGroup>\n",
     "    <ItemGroup>\n",


### PR DESCRIPTION
We're migrating the QDK to the most recent Long Time Support version of the .NET framework. For details about this change, refer to the original issue [Q#C:1224](https://github.com/microsoft/qsharp-compiler/issues/1224).

As part of this change, we're:

- Re-targeting all .NetCoreApp3.1 binaries to .NET6.0
- Updating Docker images, samples and templates.
- Libraries using .NetStandard2.1 are not affected by this change.
- The minimum supported .NET version in the QDK will also be updated from 3.1 to 6.0

This is a multi-repo change, and all changes will need to be merged concurrently.