### PR TITLE
Remove year:month from pipeline name field

### DIFF
--- a/build/ci.yml
+++ b/build/ci.yml
@@ -1,4 +1,4 @@
-name: $(Build.Major).$(Build.Minor).$(date:yyMM).$(DayOfMonth)$(rev:rr)
+name: $(Build.Major).$(Build.Minor).$(DayOfMonth)$(rev:rr)
 
 trigger:
 - main


### PR DESCRIPTION
This PR removes the $(yy:MM) field from all pipelines to keep consistency with the new qdk package version format.