### PR TITLE
remove compress flag from solvers.py as it is no longer required for …

### DIFF
--- a/azure-quantum/azure/quantum/target/solvers.py
+++ b/azure-quantum/azure/quantum/target/solvers.py
@@ -107,8 +107,7 @@ class Solver(Target):
         return data.to_blob(compress=True)
 
     def submit(
-        self, problem: Union[str, "Problem"], compress: bool = True
-    ) -> Job:
+        self, problem: Union[str, "Problem"]) -> Job:
         """Submits a job to execution to the associated
         Azure Quantum Workspace.
 
@@ -116,16 +115,8 @@ class Solver(Target):
             The Problem to solve. It can be an instance of a Problem,
             or the URL of an Azure Storage Blob where the serialized version
             of a Problem has been uploaded.
-        :param compress:
-            Whether or not to compress the problem when uploading it
-            the Blob Storage. This input param is not used and will be
-            deprecated.
         """
-        if compress == False:
-            import warnings
-            warnings.warn("The service no longer accepts payloads that \
-are not compressed with gzip encoding. Ignoring compress flag.")
-
+        
         from azure.quantum.optimization import Problem
         if isinstance(problem, Problem):
             self.check_valid_problem(problem)

--- a/azure-quantum/azure/quantum/target/toshiba/solvers.py
+++ b/azure-quantum/azure/quantum/target/toshiba/solvers.py
@@ -128,23 +128,3 @@ class SimulatedBifurcationMachine(Solver):
         self.set_one_param("algo", algo)
         self.set_one_param("auto", auto)
 
-    # We are temporarily disabling the
-    # compression of problems for the Toshiba
-    # solver to mitigate an issue downloading
-    # gzip files using the Blob Storage SDK
-    # Issue: https://github.com/Azure/azure-storage-python/issues/548
-    def submit(
-        self, problem: Union[str, "Problem"], compress: bool = True
-    ) -> Job:
-        """Submits a job to execution to
-        the associated Azure Quantum Workspace.
-
-        :param problem:
-            The Problem to solve. It can be an instance of a Problem,
-            or the URL of an Azure Storage Blob where the serialized version
-            of a Problem has been uploaded.
-        :param compress:
-            Whether or not to compress the problem when uploading it
-            the Blob Storage.
-        """
-        return super().submit(problem=problem, compress=False)


### PR DESCRIPTION
This PR removes the compress flag from the solvers submit method as this is no longer required to support toshiba. 
Please see this request: https://github.com/microsoft/qdk-python/issues/235