### PR TITLE
Make Honeywell/Quantinuum backend consistent with shots input argument

### DIFF
--- a/azure-quantum/azure/quantum/qiskit/backends/honeywell.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/honeywell.py
@@ -74,11 +74,14 @@ class HoneywellBackend(Backend):
         :param count: Shot count (deprecated)
         :type count: int
         """
-        if shots is None or count is not None:
+        if count is not None:
+            shots = count
+            warnings.warn(
+                "Input parameter 'count' has been deprecated. Please use 'shots' instead.")
             shots = shots or count
             warnings.warn(
                 "Input parameter 'count' has been deprecated. Please use 'shots' instead.")
-        if shots is None and count is None:
+        if shots is None:
             raise ValueError("Missing input argument 'shots'.")
 
         input_data = circuit.qasm()

--- a/azure-quantum/azure/quantum/qiskit/backends/honeywell.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/honeywell.py
@@ -91,7 +91,7 @@ class HoneywellBackend(Backend):
 
     def run(self, circuit: Union[QuantumCircuit, List[QuantumCircuit]], **kwargs):
         """Submits the given circuit for execution on a Honeywell target."""
-        if "count" in kwargs and "shots" not in kwargs:
+        if "count" in kwargs:
             kwargs["shots"] = kwargs.pop("count")
             warnings.warn(
                 "Input parameter 'count' has been deprecated. Please use 'shots' instead.")

--- a/azure-quantum/azure/quantum/qiskit/backends/honeywell.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/honeywell.py
@@ -77,7 +77,7 @@ class HoneywellBackend(Backend):
         if shots is None or count is not None:
             shots = shots or count
             warnings.warn(
-                "Input parameter 'count' will be deprecated. Please use 'shots' instead.")
+                "Input parameter 'count' has been deprecated. Please use 'shots' instead.")
         if shots is None and count is None:
             raise ValueError("Missing input argument 'shots'.")
 
@@ -91,7 +91,7 @@ class HoneywellBackend(Backend):
         if "count" in kwargs and "shots" not in kwargs:
             kwargs["shots"] = kwargs.pop("count")
             warnings.warn(
-                "Input parameter 'count' will be deprecated. Please use 'shots' instead.")
+                "Input parameter 'count' has been deprecated. Please use 'shots' instead.")
         # Some Qiskit features require passing lists of circuits, so unpack those here.
         # We currently only support single-experiment jobs.
         if isinstance(circuit, (list, tuple)):

--- a/azure-quantum/tests/unit/recordings/test_plugins_retrieve_job.yaml
+++ b/azure-quantum/tests/unit/recordings/test_plugins_retrieve_job.yaml
@@ -5,7 +5,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       Content-Length:
@@ -13,13 +13,13 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - azsdk-python-identity/1.7.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-identity/1.7.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-client-cpu:
       - x64
       x-client-current-telemetry:
       - 4|730,0|
       x-client-os:
-      - win32
+      - darwin
       x-client-sku:
       - MSAL.Python
       x-client-ver:
@@ -44,11 +44,11 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/providerStatus
   response:
@@ -71,18 +71,18 @@ interactions:
         "averageQueueTime": 0, "statusPage": null}, {"id": "microsoft.substochasticmontecarlo-parameterfree.cpu",
         "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
         {"id": "toshiba", "currentAvailability": "Available", "targets": [{"id": "toshiba.sbm.ising",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
+        "currentAvailability": "Available", "averageQueueTime": 4, "statusPage": null}]},
         {"id": "honeywell", "currentAvailability": "Degraded", "targets": [{"id":
         "honeywell.hqs-lt-s1", "currentAvailability": "Unavailable", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-apival", "currentAvailability": "Available", "averageQueueTime":
-        1, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s2", "currentAvailability": "Degraded", "averageQueueTime":
-        518054, "statusPage": "https://www.honeywell.com/en-us/company/quantum"},
-        {"id": "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
+        31272, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-sim", "currentAvailability": "Available", "averageQueueTime":
-        8, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        43, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt", "currentAvailability": "Degraded", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}]}, {"id":
         "Microsoft.Simulator", "currentAvailability": "Available", "targets": [{"id":
@@ -94,12 +94,13 @@ interactions:
         {"id": "1qbit.pticm", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "http://status.1qbit.com/"}]}, {"id": "ionq", "currentAvailability":
         "Available", "targets": [{"id": "ionq.qpu", "currentAvailability": "Available",
-        "averageQueueTime": 648, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
-        "currentAvailability": "Available", "averageQueueTime": 2, "statusPage": "https://status.ionq.co"}]}],
-        "nextLink": null, "access_token": "fake_token"}'
+        "averageQueueTime": 1203, "statusPage": "https://status.ionq.co"}, {"id":
+        "ionq.simulator", "currentAvailability": "Available", "averageQueueTime":
+        3, "statusPage": "https://status.ionq.co"}]}], "nextLink": null, "access_token":
+        "fake_token"}'
     headers:
       content-length:
-      - '3416'
+      - '3417'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -113,7 +114,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       Content-Length:
@@ -121,7 +122,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: POST
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
   response:
@@ -144,13 +145,13 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:19 GMT
+      - Wed, 16 Feb 2022 18:04:39 GMT
       x-ms-version:
       - '2020-10-02'
     method: GET
@@ -158,7 +159,7 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
-        specified container does not exist.\nRequestId:0a37c8dc-c01e-002f-0ae3-1d9226000000\nTime:2022-02-09T18:35:20.1440017Z</Message></Error>"
+        specified container does not exist.\nRequestId:cb1b141d-001e-00a6-7e5f-2328f3000000\nTime:2022-02-16T18:04:40.0811167Z</Message></Error>"
     headers:
       content-length:
       - '225'
@@ -175,15 +176,15 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:20 GMT
+      - Wed, 16 Feb 2022 18:04:40 GMT
       x-ms-version:
       - '2020-10-02'
     method: PUT
@@ -205,13 +206,13 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:20 GMT
+      - Wed, 16 Feb 2022 18:04:40 GMT
       x-ms-version:
       - '2020-10-02'
     method: GET
@@ -239,7 +240,7 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       Content-Length:
@@ -247,11 +248,11 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:20 GMT
+      - Wed, 16 Feb 2022 18:04:40 GMT
       x-ms-version:
       - '2020-10-02'
     method: PUT
@@ -271,7 +272,7 @@ interactions:
     body: 'b''{"id": "00000000-0000-0000-0000-000000000000", "name": "Qiskit Sample
       - 3-qubit GHZ circuit", "containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
       "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData",
-      "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 500}, "providerId":
+      "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 100}, "providerId":
       "ionq", "target": "ionq.simulator", "metadata": {"qiskit": "True", "name": "Qiskit
       Sample - 3-qubit GHZ circuit", "num_qubits": "4", "meas_map": "[0, 1, 2]"},
       "outputDataFormat": "ionq.quantum-results.v1"}'''
@@ -279,7 +280,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       Content-Length:
@@ -287,26 +288,26 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: PUT
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData",
-        "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 500}, "providerId":
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=rcw",
+        "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 100}, "providerId":
         "ionq", "target": "ionq.simulator", "metadata": {"qiskit": "True", "name":
         "Qiskit Sample - 3-qubit GHZ circuit", "num_qubits": "4", "meas_map": "[0,
         1, 2]"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Waiting", "outputDataFormat": "ionq.quantum-results.v1", "outputDataUri":
         "https://e2etests.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "creationTime": "2022-02-09T18:35:20.4362024+00:00", "beginExecutionTime":
+        "creationTime": "2022-02-16T18:04:40.3240033+00:00", "beginExecutionTime":
         null, "endExecutionTime": null, "cancellationTime": null, "costEstimate":
         null, "errorData": null, "isCancelling": false, "tags": [], "access_token":
         "fake_token"}'
     headers:
       content-length:
-      - '1126'
+      - '1233'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -320,25 +321,25 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-082771f7-89d7-11ec-8092-1860247f69ed.input.json",
-        "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 500}, "providerId":
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-e8582498-8f52-11ec-b39c-3c7d0a1d68ec.input.json",
+        "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 100}, "providerId":
         "ionq", "target": "ionq.simulator", "metadata": {"qiskit": "True", "name":
         "Qiskit Sample - 3-qubit GHZ circuit", "num_qubits": "4", "meas_map": "[0,
         1, 2]"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "ionq.quantum-results.v1", "outputDataUri":
-        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-082771f7-89d7-11ec-8092-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:20.4362024+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:23.92Z", "endExecutionTime": "2022-02-09T18:35:23.937Z",
+        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-e8582498-8f52-11ec-b39c-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T18:04:40.3240033+00:00", "beginExecutionTime":
+        "2022-02-16T18:04:42.519Z", "endExecutionTime": "2022-02-16T18:04:42.528Z",
         "cancellationTime": null, "costEstimate": {"currencyCode": "USD", "events":
         [{"dimensionId": "gs1q", "dimensionName": "1Q Gate Shot", "measureUnit": "1q
         gate shot", "amountBilled": 0.0, "amountConsumed": 0.0, "unitPrice": 0.0},
@@ -348,7 +349,7 @@ interactions:
         [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1842'
+      - '1843'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -362,25 +363,25 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-082771f7-89d7-11ec-8092-1860247f69ed.input.json",
-        "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 500}, "providerId":
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-e8582498-8f52-11ec-b39c-3c7d0a1d68ec.input.json",
+        "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 100}, "providerId":
         "ionq", "target": "ionq.simulator", "metadata": {"qiskit": "True", "name":
         "Qiskit Sample - 3-qubit GHZ circuit", "num_qubits": "4", "meas_map": "[0,
         1, 2]"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "ionq.quantum-results.v1", "outputDataUri":
-        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-082771f7-89d7-11ec-8092-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:20.4362024+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:23.92Z", "endExecutionTime": "2022-02-09T18:35:23.937Z",
+        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-e8582498-8f52-11ec-b39c-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T18:04:40.3240033+00:00", "beginExecutionTime":
+        "2022-02-16T18:04:42.519Z", "endExecutionTime": "2022-02-16T18:04:42.528Z",
         "cancellationTime": null, "costEstimate": {"currencyCode": "USD", "events":
         [{"dimensionId": "gs1q", "dimensionName": "1Q Gate Shot", "measureUnit": "1q
         gate shot", "amountBilled": 0.0, "amountConsumed": 0.0, "unitPrice": 0.0},
@@ -390,7 +391,7 @@ interactions:
         [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1842'
+      - '1843'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -404,25 +405,25 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-082771f7-89d7-11ec-8092-1860247f69ed.input.json",
-        "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 500}, "providerId":
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-e8582498-8f52-11ec-b39c-3c7d0a1d68ec.input.json",
+        "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 100}, "providerId":
         "ionq", "target": "ionq.simulator", "metadata": {"qiskit": "True", "name":
         "Qiskit Sample - 3-qubit GHZ circuit", "num_qubits": "4", "meas_map": "[0,
         1, 2]"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "ionq.quantum-results.v1", "outputDataUri":
-        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-082771f7-89d7-11ec-8092-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:20.4362024+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:23.92Z", "endExecutionTime": "2022-02-09T18:35:23.937Z",
+        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-e8582498-8f52-11ec-b39c-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T18:04:40.3240033+00:00", "beginExecutionTime":
+        "2022-02-16T18:04:42.519Z", "endExecutionTime": "2022-02-16T18:04:42.528Z",
         "cancellationTime": null, "costEstimate": {"currencyCode": "USD", "events":
         [{"dimensionId": "gs1q", "dimensionName": "1Q Gate Shot", "measureUnit": "1q
         gate shot", "amountBilled": 0.0, "amountConsumed": 0.0, "unitPrice": 0.0},
@@ -432,7 +433,7 @@ interactions:
         [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1842'
+      - '1843'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -446,11 +447,11 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/providerStatus
   response:
@@ -473,18 +474,18 @@ interactions:
         "averageQueueTime": 0, "statusPage": null}, {"id": "microsoft.substochasticmontecarlo-parameterfree.cpu",
         "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
         {"id": "toshiba", "currentAvailability": "Available", "targets": [{"id": "toshiba.sbm.ising",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
+        "currentAvailability": "Available", "averageQueueTime": 4, "statusPage": null}]},
         {"id": "honeywell", "currentAvailability": "Degraded", "targets": [{"id":
         "honeywell.hqs-lt-s1", "currentAvailability": "Unavailable", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-apival", "currentAvailability": "Available", "averageQueueTime":
-        1, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s2", "currentAvailability": "Degraded", "averageQueueTime":
-        518054, "statusPage": "https://www.honeywell.com/en-us/company/quantum"},
-        {"id": "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
+        31272, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-sim", "currentAvailability": "Available", "averageQueueTime":
-        8, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        43, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt", "currentAvailability": "Degraded", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}]}, {"id":
         "Microsoft.Simulator", "currentAvailability": "Available", "targets": [{"id":
@@ -496,12 +497,13 @@ interactions:
         {"id": "1qbit.pticm", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "http://status.1qbit.com/"}]}, {"id": "ionq", "currentAvailability":
         "Available", "targets": [{"id": "ionq.qpu", "currentAvailability": "Available",
-        "averageQueueTime": 648, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
-        "currentAvailability": "Available", "averageQueueTime": 2, "statusPage": "https://status.ionq.co"}]}],
-        "nextLink": null, "access_token": "fake_token"}'
+        "averageQueueTime": 1203, "statusPage": "https://status.ionq.co"}, {"id":
+        "ionq.simulator", "currentAvailability": "Available", "averageQueueTime":
+        2, "statusPage": "https://status.ionq.co"}]}], "nextLink": null, "access_token":
+        "fake_token"}'
     headers:
       content-length:
-      - '3416'
+      - '3417'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -515,25 +517,25 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-082771f7-89d7-11ec-8092-1860247f69ed.input.json",
-        "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 500}, "providerId":
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-e8582498-8f52-11ec-b39c-3c7d0a1d68ec.input.json",
+        "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 100}, "providerId":
         "ionq", "target": "ionq.simulator", "metadata": {"qiskit": "True", "name":
         "Qiskit Sample - 3-qubit GHZ circuit", "num_qubits": "4", "meas_map": "[0,
         1, 2]"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "ionq.quantum-results.v1", "outputDataUri":
-        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-082771f7-89d7-11ec-8092-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:20.4362024+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:23.92Z", "endExecutionTime": "2022-02-09T18:35:23.937Z",
+        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-e8582498-8f52-11ec-b39c-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T18:04:40.3240033+00:00", "beginExecutionTime":
+        "2022-02-16T18:04:42.519Z", "endExecutionTime": "2022-02-16T18:04:42.528Z",
         "cancellationTime": null, "costEstimate": {"currencyCode": "USD", "events":
         [{"dimensionId": "gs1q", "dimensionName": "1Q Gate Shot", "measureUnit": "1q
         gate shot", "amountBilled": 0.0, "amountConsumed": 0.0, "unitPrice": 0.0},
@@ -543,7 +545,7 @@ interactions:
         [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1842'
+      - '1843'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -557,25 +559,25 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-082771f7-89d7-11ec-8092-1860247f69ed.input.json",
-        "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 500}, "providerId":
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-e8582498-8f52-11ec-b39c-3c7d0a1d68ec.input.json",
+        "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 100}, "providerId":
         "ionq", "target": "ionq.simulator", "metadata": {"qiskit": "True", "name":
         "Qiskit Sample - 3-qubit GHZ circuit", "num_qubits": "4", "meas_map": "[0,
         1, 2]"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "ionq.quantum-results.v1", "outputDataUri":
-        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-082771f7-89d7-11ec-8092-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:20.4362024+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:23.92Z", "endExecutionTime": "2022-02-09T18:35:23.937Z",
+        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-e8582498-8f52-11ec-b39c-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T18:04:40.3240033+00:00", "beginExecutionTime":
+        "2022-02-16T18:04:42.519Z", "endExecutionTime": "2022-02-16T18:04:42.528Z",
         "cancellationTime": null, "costEstimate": {"currencyCode": "USD", "events":
         [{"dimensionId": "gs1q", "dimensionName": "1Q Gate Shot", "measureUnit": "1q
         gate shot", "amountBilled": 0.0, "amountConsumed": 0.0, "unitPrice": 0.0},
@@ -585,7 +587,7 @@ interactions:
         [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1842'
+      - '1843'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -599,25 +601,25 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-082771f7-89d7-11ec-8092-1860247f69ed.input.json",
-        "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 500}, "providerId":
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-e8582498-8f52-11ec-b39c-3c7d0a1d68ec.input.json",
+        "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 100}, "providerId":
         "ionq", "target": "ionq.simulator", "metadata": {"qiskit": "True", "name":
         "Qiskit Sample - 3-qubit GHZ circuit", "num_qubits": "4", "meas_map": "[0,
         1, 2]"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "ionq.quantum-results.v1", "outputDataUri":
-        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-082771f7-89d7-11ec-8092-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:20.4362024+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:23.92Z", "endExecutionTime": "2022-02-09T18:35:23.937Z",
+        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-e8582498-8f52-11ec-b39c-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T18:04:40.3240033+00:00", "beginExecutionTime":
+        "2022-02-16T18:04:42.519Z", "endExecutionTime": "2022-02-16T18:04:42.528Z",
         "cancellationTime": null, "costEstimate": {"currencyCode": "USD", "events":
         [{"dimensionId": "gs1q", "dimensionName": "1Q Gate Shot", "measureUnit": "1q
         gate shot", "amountBilled": 0.0, "amountConsumed": 0.0, "unitPrice": 0.0},
@@ -627,7 +629,7 @@ interactions:
         [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1842'
+      - '1843'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -641,11 +643,11 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/providerStatus
   response:
@@ -668,18 +670,18 @@ interactions:
         "averageQueueTime": 0, "statusPage": null}, {"id": "microsoft.substochasticmontecarlo-parameterfree.cpu",
         "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
         {"id": "toshiba", "currentAvailability": "Available", "targets": [{"id": "toshiba.sbm.ising",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
+        "currentAvailability": "Available", "averageQueueTime": 4, "statusPage": null}]},
         {"id": "honeywell", "currentAvailability": "Degraded", "targets": [{"id":
         "honeywell.hqs-lt-s1", "currentAvailability": "Unavailable", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-apival", "currentAvailability": "Available", "averageQueueTime":
-        1, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s2", "currentAvailability": "Degraded", "averageQueueTime":
-        518054, "statusPage": "https://www.honeywell.com/en-us/company/quantum"},
-        {"id": "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
+        31272, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-sim", "currentAvailability": "Available", "averageQueueTime":
-        8, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        43, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt", "currentAvailability": "Degraded", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}]}, {"id":
         "Microsoft.Simulator", "currentAvailability": "Available", "targets": [{"id":
@@ -691,12 +693,13 @@ interactions:
         {"id": "1qbit.pticm", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "http://status.1qbit.com/"}]}, {"id": "ionq", "currentAvailability":
         "Available", "targets": [{"id": "ionq.qpu", "currentAvailability": "Available",
-        "averageQueueTime": 648, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
-        "currentAvailability": "Available", "averageQueueTime": 2, "statusPage": "https://status.ionq.co"}]}],
-        "nextLink": null, "access_token": "fake_token"}'
+        "averageQueueTime": 1203, "statusPage": "https://status.ionq.co"}, {"id":
+        "ionq.simulator", "currentAvailability": "Available", "averageQueueTime":
+        2, "statusPage": "https://status.ionq.co"}]}], "nextLink": null, "access_token":
+        "fake_token"}'
     headers:
       content-length:
-      - '3416'
+      - '3417'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -710,25 +713,25 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-082771f7-89d7-11ec-8092-1860247f69ed.input.json",
-        "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 500}, "providerId":
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-e8582498-8f52-11ec-b39c-3c7d0a1d68ec.input.json",
+        "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 100}, "providerId":
         "ionq", "target": "ionq.simulator", "metadata": {"qiskit": "True", "name":
         "Qiskit Sample - 3-qubit GHZ circuit", "num_qubits": "4", "meas_map": "[0,
         1, 2]"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "ionq.quantum-results.v1", "outputDataUri":
-        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-082771f7-89d7-11ec-8092-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:20.4362024+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:23.92Z", "endExecutionTime": "2022-02-09T18:35:23.937Z",
+        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-e8582498-8f52-11ec-b39c-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T18:04:40.3240033+00:00", "beginExecutionTime":
+        "2022-02-16T18:04:42.519Z", "endExecutionTime": "2022-02-16T18:04:42.528Z",
         "cancellationTime": null, "costEstimate": {"currencyCode": "USD", "events":
         [{"dimensionId": "gs1q", "dimensionName": "1Q Gate Shot", "measureUnit": "1q
         gate shot", "amountBilled": 0.0, "amountConsumed": 0.0, "unitPrice": 0.0},
@@ -738,7 +741,7 @@ interactions:
         [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1842'
+      - '1843'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -752,38 +755,38 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:27 GMT
+      - Wed, 16 Feb 2022 18:04:45 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
       - '2020-10-02'
     method: GET
-    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-082771f7-89d7-11ec-8092-1860247f69ed.output.json
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-e8582498-8f52-11ec-b39c-3c7d0a1d68ec.output.json
   response:
     body:
-      string: '{"duration": 17244354, "histogram": {"0": 0.25, "7": 0.25, "8": 0.25,
+      string: '{"duration": 9178099, "histogram": {"0": 0.25, "7": 0.25, "8": 0.25,
         "15": 0.25}, "access_token": "fake_token"}'
     headers:
       accept-ranges:
       - bytes
       content-length:
-      - '72'
+      - '71'
       content-range:
-      - bytes 0-71/72
+      - bytes 0-70/71
       content-type:
       - application/json
       x-ms-blob-content-md5:
-      - sYaImVb/JDZjsMbQp69ukA==
+      - 82s6duxUwxHXyBmWPVCxjg==
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 09 Feb 2022 18:35:20 GMT
+      - Wed, 16 Feb 2022 18:04:40 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:

--- a/azure-quantum/tests/unit/recordings/test_plugins_submit_qiskit_circuit_as_list_to_honeywell.yaml
+++ b/azure-quantum/tests/unit/recordings/test_plugins_submit_qiskit_circuit_as_list_to_honeywell.yaml
@@ -5,7 +5,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       Content-Length:
@@ -13,13 +13,13 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - azsdk-python-identity/1.7.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-identity/1.7.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-client-cpu:
       - x64
       x-client-current-telemetry:
       - 4|730,0|
       x-client-os:
-      - win32
+      - darwin
       x-client-sku:
       - MSAL.Python
       x-client-ver:
@@ -44,11 +44,11 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/providerStatus
   response:
@@ -71,18 +71,18 @@ interactions:
         "averageQueueTime": 0, "statusPage": null}, {"id": "microsoft.substochasticmontecarlo-parameterfree.cpu",
         "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
         {"id": "toshiba", "currentAvailability": "Available", "targets": [{"id": "toshiba.sbm.ising",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
+        "currentAvailability": "Available", "averageQueueTime": 4, "statusPage": null}]},
         {"id": "honeywell", "currentAvailability": "Degraded", "targets": [{"id":
         "honeywell.hqs-lt-s1", "currentAvailability": "Unavailable", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-apival", "currentAvailability": "Available", "averageQueueTime":
-        1, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s2", "currentAvailability": "Degraded", "averageQueueTime":
-        518054, "statusPage": "https://www.honeywell.com/en-us/company/quantum"},
-        {"id": "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
+        31272, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-sim", "currentAvailability": "Available", "averageQueueTime":
-        8, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        43, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt", "currentAvailability": "Degraded", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}]}, {"id":
         "Microsoft.Simulator", "currentAvailability": "Available", "targets": [{"id":
@@ -94,7 +94,7 @@ interactions:
         {"id": "1qbit.pticm", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "http://status.1qbit.com/"}]}, {"id": "ionq", "currentAvailability":
         "Available", "targets": [{"id": "ionq.qpu", "currentAvailability": "Available",
-        "averageQueueTime": 648, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
+        "averageQueueTime": 217, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
         "currentAvailability": "Available", "averageQueueTime": 2, "statusPage": "https://status.ionq.co"}]}],
         "nextLink": null, "access_token": "fake_token"}'
     headers:
@@ -113,11 +113,11 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/providerStatus
   response:
@@ -140,18 +140,18 @@ interactions:
         "averageQueueTime": 0, "statusPage": null}, {"id": "microsoft.substochasticmontecarlo-parameterfree.cpu",
         "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
         {"id": "toshiba", "currentAvailability": "Available", "targets": [{"id": "toshiba.sbm.ising",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
+        "currentAvailability": "Available", "averageQueueTime": 4, "statusPage": null}]},
         {"id": "honeywell", "currentAvailability": "Degraded", "targets": [{"id":
         "honeywell.hqs-lt-s1", "currentAvailability": "Unavailable", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-apival", "currentAvailability": "Available", "averageQueueTime":
-        1, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s2", "currentAvailability": "Degraded", "averageQueueTime":
-        518054, "statusPage": "https://www.honeywell.com/en-us/company/quantum"},
-        {"id": "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
+        31272, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-sim", "currentAvailability": "Available", "averageQueueTime":
-        8, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        43, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt", "currentAvailability": "Degraded", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}]}, {"id":
         "Microsoft.Simulator", "currentAvailability": "Available", "targets": [{"id":
@@ -163,7 +163,7 @@ interactions:
         {"id": "1qbit.pticm", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "http://status.1qbit.com/"}]}, {"id": "ionq", "currentAvailability":
         "Available", "targets": [{"id": "ionq.qpu", "currentAvailability": "Available",
-        "averageQueueTime": 648, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
+        "averageQueueTime": 217, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
         "currentAvailability": "Available", "averageQueueTime": 2, "statusPage": "https://status.ionq.co"}]}],
         "nextLink": null, "access_token": "fake_token"}'
     headers:
@@ -182,7 +182,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       Content-Length:
@@ -190,7 +190,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: POST
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
   response:
@@ -199,7 +199,7 @@ interactions:
         "access_token": "fake_token"}'
     headers:
       content-length:
-      - '207'
+      - '215'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -213,13 +213,13 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:28 GMT
+      - Wed, 16 Feb 2022 17:59:51 GMT
       x-ms-version:
       - '2020-10-02'
     method: GET
@@ -227,7 +227,7 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
-        specified container does not exist.\nRequestId:eef29e18-901e-0040-5ce3-1d98d5000000\nTime:2022-02-09T18:35:28.9238106Z</Message></Error>"
+        specified container does not exist.\nRequestId:e608b88a-301e-003b-465e-23da49000000\nTime:2022-02-16T17:59:51.8672695Z</Message></Error>"
     headers:
       content-length:
       - '225'
@@ -244,15 +244,15 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:28 GMT
+      - Wed, 16 Feb 2022 17:59:51 GMT
       x-ms-version:
       - '2020-10-02'
     method: PUT
@@ -274,13 +274,13 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:28 GMT
+      - Wed, 16 Feb 2022 17:59:51 GMT
       x-ms-version:
       - '2020-10-02'
     method: GET
@@ -308,7 +308,7 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       Content-Length:
@@ -316,11 +316,11 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:29 GMT
+      - Wed, 16 Feb 2022 17:59:51 GMT
       x-ms-version:
       - '2020-10-02'
     method: PUT
@@ -347,33 +347,33 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       Content-Length:
-      - '639'
+      - '647'
       Content-Type:
       - application/json
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: PUT
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=rcw",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData",
         "inputDataFormat": "honeywell.openqasm.v1", "inputParams": {"count": 500},
         "providerId": "honeywell", "target": "honeywell.hqs-lt-s1-apival", "metadata":
         {"qubits": "4"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Waiting", "outputDataFormat": "honeywell.quantum-results.v1", "outputDataUri":
         "https://e2etests.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "creationTime": "2022-02-09T18:35:29.1681693+00:00", "beginExecutionTime":
+        "creationTime": "2022-02-16T17:59:52.1516028+00:00", "beginExecutionTime":
         null, "endExecutionTime": null, "cancellationTime": null, "costEstimate":
         null, "errorData": null, "isCancelling": false, "tags": [], "access_token":
         "fake_token"}'
     headers:
       content-length:
-      - '1167'
+      - '1074'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -387,29 +387,29 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-0d7cb28b-89d7-11ec-a233-1860247f69ed.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-3bafd11e-8f52-11ec-8732-3c7d0a1d68ec.input.json",
         "inputDataFormat": "honeywell.openqasm.v1", "inputParams": {"count": 500},
         "providerId": "honeywell", "target": "honeywell.hqs-lt-s1-apival", "metadata":
         {"qubits": "4"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "honeywell.quantum-results.v1",
-        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-0d7cb28b-89d7-11ec-a233-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:29.1681693+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:32.036156+00:00", "endExecutionTime": "2022-02-09T18:35:32.036814+00:00",
+        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-3bafd11e-8f52-11ec-8732-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T17:59:52.1516028+00:00", "beginExecutionTime":
+        "2022-02-16T17:59:54.287895+00:00", "endExecutionTime": "2022-02-16T17:59:54.288559+00:00",
         "cancellationTime": null, "costEstimate": null, "errorData": null, "isCancelling":
         false, "tags": [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1465'
+      - '1479'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -423,29 +423,29 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-0d7cb28b-89d7-11ec-a233-1860247f69ed.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-3bafd11e-8f52-11ec-8732-3c7d0a1d68ec.input.json",
         "inputDataFormat": "honeywell.openqasm.v1", "inputParams": {"count": 500},
         "providerId": "honeywell", "target": "honeywell.hqs-lt-s1-apival", "metadata":
         {"qubits": "4"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "honeywell.quantum-results.v1",
-        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-0d7cb28b-89d7-11ec-a233-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:29.1681693+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:32.036156+00:00", "endExecutionTime": "2022-02-09T18:35:32.036814+00:00",
+        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-3bafd11e-8f52-11ec-8732-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T17:59:52.1516028+00:00", "beginExecutionTime":
+        "2022-02-16T17:59:54.287895+00:00", "endExecutionTime": "2022-02-16T17:59:54.288559+00:00",
         "cancellationTime": null, "costEstimate": null, "errorData": null, "isCancelling":
         false, "tags": [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1465'
+      - '1479'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -459,29 +459,29 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-0d7cb28b-89d7-11ec-a233-1860247f69ed.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-3bafd11e-8f52-11ec-8732-3c7d0a1d68ec.input.json",
         "inputDataFormat": "honeywell.openqasm.v1", "inputParams": {"count": 500},
         "providerId": "honeywell", "target": "honeywell.hqs-lt-s1-apival", "metadata":
         {"qubits": "4"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "honeywell.quantum-results.v1",
-        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-0d7cb28b-89d7-11ec-a233-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:29.1681693+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:32.036156+00:00", "endExecutionTime": "2022-02-09T18:35:32.036814+00:00",
+        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-3bafd11e-8f52-11ec-8732-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T17:59:52.1516028+00:00", "beginExecutionTime":
+        "2022-02-16T17:59:54.287895+00:00", "endExecutionTime": "2022-02-16T17:59:54.288559+00:00",
         "cancellationTime": null, "costEstimate": null, "errorData": null, "isCancelling":
         false, "tags": [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1465'
+      - '1479'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -495,11 +495,11 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/providerStatus
   response:
@@ -522,18 +522,18 @@ interactions:
         "averageQueueTime": 0, "statusPage": null}, {"id": "microsoft.substochasticmontecarlo-parameterfree.cpu",
         "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
         {"id": "toshiba", "currentAvailability": "Available", "targets": [{"id": "toshiba.sbm.ising",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
+        "currentAvailability": "Available", "averageQueueTime": 4, "statusPage": null}]},
         {"id": "honeywell", "currentAvailability": "Degraded", "targets": [{"id":
         "honeywell.hqs-lt-s1", "currentAvailability": "Unavailable", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-apival", "currentAvailability": "Available", "averageQueueTime":
-        1, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s2", "currentAvailability": "Degraded", "averageQueueTime":
-        518054, "statusPage": "https://www.honeywell.com/en-us/company/quantum"},
-        {"id": "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
+        31272, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-sim", "currentAvailability": "Available", "averageQueueTime":
-        8, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        43, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt", "currentAvailability": "Degraded", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}]}, {"id":
         "Microsoft.Simulator", "currentAvailability": "Available", "targets": [{"id":
@@ -545,7 +545,7 @@ interactions:
         {"id": "1qbit.pticm", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "http://status.1qbit.com/"}]}, {"id": "ionq", "currentAvailability":
         "Available", "targets": [{"id": "ionq.qpu", "currentAvailability": "Available",
-        "averageQueueTime": 648, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
+        "averageQueueTime": 217, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
         "currentAvailability": "Available", "averageQueueTime": 2, "statusPage": "https://status.ionq.co"}]}],
         "nextLink": null, "access_token": "fake_token"}'
     headers:
@@ -564,29 +564,29 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-0d7cb28b-89d7-11ec-a233-1860247f69ed.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-3bafd11e-8f52-11ec-8732-3c7d0a1d68ec.input.json",
         "inputDataFormat": "honeywell.openqasm.v1", "inputParams": {"count": 500},
         "providerId": "honeywell", "target": "honeywell.hqs-lt-s1-apival", "metadata":
         {"qubits": "4"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "honeywell.quantum-results.v1",
-        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-0d7cb28b-89d7-11ec-a233-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:29.1681693+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:32.036156+00:00", "endExecutionTime": "2022-02-09T18:35:32.036814+00:00",
+        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-3bafd11e-8f52-11ec-8732-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T17:59:52.1516028+00:00", "beginExecutionTime":
+        "2022-02-16T17:59:54.287895+00:00", "endExecutionTime": "2022-02-16T17:59:54.288559+00:00",
         "cancellationTime": null, "costEstimate": null, "errorData": null, "isCancelling":
         false, "tags": [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1465'
+      - '1471'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -600,29 +600,29 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-0d7cb28b-89d7-11ec-a233-1860247f69ed.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-3bafd11e-8f52-11ec-8732-3c7d0a1d68ec.input.json",
         "inputDataFormat": "honeywell.openqasm.v1", "inputParams": {"count": 500},
         "providerId": "honeywell", "target": "honeywell.hqs-lt-s1-apival", "metadata":
         {"qubits": "4"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "honeywell.quantum-results.v1",
-        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-0d7cb28b-89d7-11ec-a233-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:29.1681693+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:32.036156+00:00", "endExecutionTime": "2022-02-09T18:35:32.036814+00:00",
+        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-3bafd11e-8f52-11ec-8732-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T17:59:52.1516028+00:00", "beginExecutionTime":
+        "2022-02-16T17:59:54.287895+00:00", "endExecutionTime": "2022-02-16T17:59:54.288559+00:00",
         "cancellationTime": null, "costEstimate": null, "errorData": null, "isCancelling":
         false, "tags": [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1465'
+      - '1471'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -636,29 +636,29 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-0d7cb28b-89d7-11ec-a233-1860247f69ed.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-3bafd11e-8f52-11ec-8732-3c7d0a1d68ec.input.json",
         "inputDataFormat": "honeywell.openqasm.v1", "inputParams": {"count": 500},
         "providerId": "honeywell", "target": "honeywell.hqs-lt-s1-apival", "metadata":
         {"qubits": "4"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "honeywell.quantum-results.v1",
-        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-0d7cb28b-89d7-11ec-a233-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:29.1681693+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:32.036156+00:00", "endExecutionTime": "2022-02-09T18:35:32.036814+00:00",
+        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-3bafd11e-8f52-11ec-8732-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T17:59:52.1516028+00:00", "beginExecutionTime":
+        "2022-02-16T17:59:54.287895+00:00", "endExecutionTime": "2022-02-16T17:59:54.288559+00:00",
         "cancellationTime": null, "costEstimate": null, "errorData": null, "isCancelling":
         false, "tags": [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1465'
+      - '1471'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -672,19 +672,19 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:36 GMT
+      - Wed, 16 Feb 2022 17:59:57 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
       - '2020-10-02'
     method: GET
-    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-0d7cb28b-89d7-11ec-a233-1860247f69ed.output.json
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-3bafd11e-8f52-11ec-8732-3c7d0a1d68ec.output.json
   response:
     body:
       string: '{"c": ["000", "000", "000", "000", "000", "000", "000", "000", "000",
@@ -747,7 +747,7 @@ interactions:
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 09 Feb 2022 18:35:29 GMT
+      - Wed, 16 Feb 2022 17:59:52 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:

--- a/azure-quantum/tests/unit/recordings/test_plugins_submit_qiskit_circuit_as_list_to_ionq.yaml
+++ b/azure-quantum/tests/unit/recordings/test_plugins_submit_qiskit_circuit_as_list_to_ionq.yaml
@@ -5,7 +5,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       Content-Length:
@@ -13,13 +13,13 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - azsdk-python-identity/1.7.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-identity/1.7.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-client-cpu:
       - x64
       x-client-current-telemetry:
       - 4|730,0|
       x-client-os:
-      - win32
+      - darwin
       x-client-sku:
       - MSAL.Python
       x-client-ver:
@@ -44,11 +44,11 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/providerStatus
   response:
@@ -71,18 +71,18 @@ interactions:
         "averageQueueTime": 0, "statusPage": null}, {"id": "microsoft.substochasticmontecarlo-parameterfree.cpu",
         "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
         {"id": "toshiba", "currentAvailability": "Available", "targets": [{"id": "toshiba.sbm.ising",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
+        "currentAvailability": "Available", "averageQueueTime": 4, "statusPage": null}]},
         {"id": "honeywell", "currentAvailability": "Degraded", "targets": [{"id":
         "honeywell.hqs-lt-s1", "currentAvailability": "Unavailable", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-apival", "currentAvailability": "Available", "averageQueueTime":
-        1, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s2", "currentAvailability": "Degraded", "averageQueueTime":
-        518054, "statusPage": "https://www.honeywell.com/en-us/company/quantum"},
-        {"id": "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
+        31272, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-sim", "currentAvailability": "Available", "averageQueueTime":
-        8, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        43, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt", "currentAvailability": "Degraded", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}]}, {"id":
         "Microsoft.Simulator", "currentAvailability": "Available", "targets": [{"id":
@@ -94,7 +94,7 @@ interactions:
         {"id": "1qbit.pticm", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "http://status.1qbit.com/"}]}, {"id": "ionq", "currentAvailability":
         "Available", "targets": [{"id": "ionq.qpu", "currentAvailability": "Available",
-        "averageQueueTime": 648, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
+        "averageQueueTime": 217, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
         "currentAvailability": "Available", "averageQueueTime": 2, "statusPage": "https://status.ionq.co"}]}],
         "nextLink": null, "access_token": "fake_token"}'
     headers:
@@ -113,7 +113,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       Content-Length:
@@ -121,7 +121,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: POST
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
   response:
@@ -130,7 +130,7 @@ interactions:
         "access_token": "fake_token"}'
     headers:
       content-length:
-      - '207'
+      - '205'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -144,13 +144,13 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:37 GMT
+      - Wed, 16 Feb 2022 17:59:57 GMT
       x-ms-version:
       - '2020-10-02'
     method: GET
@@ -158,7 +158,7 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
-        specified container does not exist.\nRequestId:637c7625-a01e-0064-6ee3-1d6e75000000\nTime:2022-02-09T18:35:37.8116538Z</Message></Error>"
+        specified container does not exist.\nRequestId:bcbeec34-a01e-0039-285f-2364f1000000\nTime:2022-02-16T17:59:58.1383163Z</Message></Error>"
     headers:
       content-length:
       - '225'
@@ -175,15 +175,15 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:37 GMT
+      - Wed, 16 Feb 2022 17:59:58 GMT
       x-ms-version:
       - '2020-10-02'
     method: PUT
@@ -205,13 +205,13 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:37 GMT
+      - Wed, 16 Feb 2022 17:59:58 GMT
       x-ms-version:
       - '2020-10-02'
     method: GET
@@ -239,7 +239,7 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       Content-Length:
@@ -247,11 +247,11 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:37 GMT
+      - Wed, 16 Feb 2022 17:59:58 GMT
       x-ms-version:
       - '2020-10-02'
     method: PUT
@@ -279,15 +279,15 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       Content-Length:
-      - '705'
+      - '703'
       Content-Type:
       - application/json
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: PUT
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
@@ -300,13 +300,13 @@ interactions:
         1, 2]"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Waiting", "outputDataFormat": "ionq.quantum-results.v1", "outputDataUri":
         "https://e2etests.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "creationTime": "2022-02-09T18:35:38.0128632+00:00", "beginExecutionTime":
+        "creationTime": "2022-02-16T17:59:58.3444344+00:00", "beginExecutionTime":
         null, "endExecutionTime": null, "cancellationTime": null, "costEstimate":
         null, "errorData": null, "isCancelling": false, "tags": [], "access_token":
         "fake_token"}'
     headers:
       content-length:
-      - '1118'
+      - '1114'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -320,25 +320,25 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-12d297f2-89d7-11ec-a6aa-1860247f69ed.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-405b40b8-8f52-11ec-8732-3c7d0a1d68ec.input.json",
         "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 500}, "providerId":
         "ionq", "target": "ionq.simulator", "metadata": {"qiskit": "True", "name":
         "Qiskit Sample - 3-qubit GHZ circuit", "num_qubits": "4", "meas_map": "[0,
         1, 2]"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "ionq.quantum-results.v1", "outputDataUri":
-        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-12d297f2-89d7-11ec-a6aa-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:38.0128632+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:40.93Z", "endExecutionTime": "2022-02-09T18:35:41.278Z",
+        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-405b40b8-8f52-11ec-8732-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T17:59:58.3444344+00:00", "beginExecutionTime":
+        "2022-02-16T18:00:01.202Z", "endExecutionTime": "2022-02-16T18:00:01.211Z",
         "cancellationTime": null, "costEstimate": {"currencyCode": "USD", "events":
         [{"dimensionId": "gs1q", "dimensionName": "1Q Gate Shot", "measureUnit": "1q
         gate shot", "amountBilled": 0.0, "amountConsumed": 0.0, "unitPrice": 0.0},
@@ -348,7 +348,7 @@ interactions:
         [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1836'
+      - '1843'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -362,25 +362,25 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-12d297f2-89d7-11ec-a6aa-1860247f69ed.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-405b40b8-8f52-11ec-8732-3c7d0a1d68ec.input.json",
         "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 500}, "providerId":
         "ionq", "target": "ionq.simulator", "metadata": {"qiskit": "True", "name":
         "Qiskit Sample - 3-qubit GHZ circuit", "num_qubits": "4", "meas_map": "[0,
         1, 2]"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "ionq.quantum-results.v1", "outputDataUri":
-        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-12d297f2-89d7-11ec-a6aa-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:38.0128632+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:40.93Z", "endExecutionTime": "2022-02-09T18:35:41.278Z",
+        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-405b40b8-8f52-11ec-8732-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T17:59:58.3444344+00:00", "beginExecutionTime":
+        "2022-02-16T18:00:01.202Z", "endExecutionTime": "2022-02-16T18:00:01.211Z",
         "cancellationTime": null, "costEstimate": {"currencyCode": "USD", "events":
         [{"dimensionId": "gs1q", "dimensionName": "1Q Gate Shot", "measureUnit": "1q
         gate shot", "amountBilled": 0.0, "amountConsumed": 0.0, "unitPrice": 0.0},
@@ -390,7 +390,7 @@ interactions:
         [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1836'
+      - '1843'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -404,25 +404,25 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-12d297f2-89d7-11ec-a6aa-1860247f69ed.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-405b40b8-8f52-11ec-8732-3c7d0a1d68ec.input.json",
         "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 500}, "providerId":
         "ionq", "target": "ionq.simulator", "metadata": {"qiskit": "True", "name":
         "Qiskit Sample - 3-qubit GHZ circuit", "num_qubits": "4", "meas_map": "[0,
         1, 2]"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "ionq.quantum-results.v1", "outputDataUri":
-        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-12d297f2-89d7-11ec-a6aa-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:38.0128632+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:40.93Z", "endExecutionTime": "2022-02-09T18:35:41.278Z",
+        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-405b40b8-8f52-11ec-8732-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T17:59:58.3444344+00:00", "beginExecutionTime":
+        "2022-02-16T18:00:01.202Z", "endExecutionTime": "2022-02-16T18:00:01.211Z",
         "cancellationTime": null, "costEstimate": {"currencyCode": "USD", "events":
         [{"dimensionId": "gs1q", "dimensionName": "1Q Gate Shot", "measureUnit": "1q
         gate shot", "amountBilled": 0.0, "amountConsumed": 0.0, "unitPrice": 0.0},
@@ -432,7 +432,7 @@ interactions:
         [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1836'
+      - '1843'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -446,11 +446,11 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/providerStatus
   response:
@@ -473,18 +473,18 @@ interactions:
         "averageQueueTime": 0, "statusPage": null}, {"id": "microsoft.substochasticmontecarlo-parameterfree.cpu",
         "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
         {"id": "toshiba", "currentAvailability": "Available", "targets": [{"id": "toshiba.sbm.ising",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
+        "currentAvailability": "Available", "averageQueueTime": 4, "statusPage": null}]},
         {"id": "honeywell", "currentAvailability": "Degraded", "targets": [{"id":
         "honeywell.hqs-lt-s1", "currentAvailability": "Unavailable", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-apival", "currentAvailability": "Available", "averageQueueTime":
-        1, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s2", "currentAvailability": "Degraded", "averageQueueTime":
-        518054, "statusPage": "https://www.honeywell.com/en-us/company/quantum"},
-        {"id": "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
+        31272, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-sim", "currentAvailability": "Available", "averageQueueTime":
-        8, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        43, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt", "currentAvailability": "Degraded", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}]}, {"id":
         "Microsoft.Simulator", "currentAvailability": "Available", "targets": [{"id":
@@ -496,7 +496,7 @@ interactions:
         {"id": "1qbit.pticm", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "http://status.1qbit.com/"}]}, {"id": "ionq", "currentAvailability":
         "Available", "targets": [{"id": "ionq.qpu", "currentAvailability": "Available",
-        "averageQueueTime": 648, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
+        "averageQueueTime": 217, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
         "currentAvailability": "Available", "averageQueueTime": 2, "statusPage": "https://status.ionq.co"}]}],
         "nextLink": null, "access_token": "fake_token"}'
     headers:
@@ -515,25 +515,25 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-12d297f2-89d7-11ec-a6aa-1860247f69ed.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-405b40b8-8f52-11ec-8732-3c7d0a1d68ec.input.json",
         "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 500}, "providerId":
         "ionq", "target": "ionq.simulator", "metadata": {"qiskit": "True", "name":
         "Qiskit Sample - 3-qubit GHZ circuit", "num_qubits": "4", "meas_map": "[0,
         1, 2]"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "ionq.quantum-results.v1", "outputDataUri":
-        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-12d297f2-89d7-11ec-a6aa-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:38.0128632+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:40.93Z", "endExecutionTime": "2022-02-09T18:35:41.278Z",
+        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-405b40b8-8f52-11ec-8732-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T17:59:58.3444344+00:00", "beginExecutionTime":
+        "2022-02-16T18:00:01.202Z", "endExecutionTime": "2022-02-16T18:00:01.211Z",
         "cancellationTime": null, "costEstimate": {"currencyCode": "USD", "events":
         [{"dimensionId": "gs1q", "dimensionName": "1Q Gate Shot", "measureUnit": "1q
         gate shot", "amountBilled": 0.0, "amountConsumed": 0.0, "unitPrice": 0.0},
@@ -543,7 +543,7 @@ interactions:
         [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1846'
+      - '1843'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -557,25 +557,25 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-12d297f2-89d7-11ec-a6aa-1860247f69ed.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-405b40b8-8f52-11ec-8732-3c7d0a1d68ec.input.json",
         "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 500}, "providerId":
         "ionq", "target": "ionq.simulator", "metadata": {"qiskit": "True", "name":
         "Qiskit Sample - 3-qubit GHZ circuit", "num_qubits": "4", "meas_map": "[0,
         1, 2]"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "ionq.quantum-results.v1", "outputDataUri":
-        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-12d297f2-89d7-11ec-a6aa-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:38.0128632+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:40.93Z", "endExecutionTime": "2022-02-09T18:35:41.278Z",
+        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-405b40b8-8f52-11ec-8732-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T17:59:58.3444344+00:00", "beginExecutionTime":
+        "2022-02-16T18:00:01.202Z", "endExecutionTime": "2022-02-16T18:00:01.211Z",
         "cancellationTime": null, "costEstimate": {"currencyCode": "USD", "events":
         [{"dimensionId": "gs1q", "dimensionName": "1Q Gate Shot", "measureUnit": "1q
         gate shot", "amountBilled": 0.0, "amountConsumed": 0.0, "unitPrice": 0.0},
@@ -585,7 +585,7 @@ interactions:
         [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1846'
+      - '1843'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -599,25 +599,25 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-12d297f2-89d7-11ec-a6aa-1860247f69ed.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-405b40b8-8f52-11ec-8732-3c7d0a1d68ec.input.json",
         "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 500}, "providerId":
         "ionq", "target": "ionq.simulator", "metadata": {"qiskit": "True", "name":
         "Qiskit Sample - 3-qubit GHZ circuit", "num_qubits": "4", "meas_map": "[0,
         1, 2]"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "ionq.quantum-results.v1", "outputDataUri":
-        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-12d297f2-89d7-11ec-a6aa-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:38.0128632+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:40.93Z", "endExecutionTime": "2022-02-09T18:35:41.278Z",
+        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-405b40b8-8f52-11ec-8732-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T17:59:58.3444344+00:00", "beginExecutionTime":
+        "2022-02-16T18:00:01.202Z", "endExecutionTime": "2022-02-16T18:00:01.211Z",
         "cancellationTime": null, "costEstimate": {"currencyCode": "USD", "events":
         [{"dimensionId": "gs1q", "dimensionName": "1Q Gate Shot", "measureUnit": "1q
         gate shot", "amountBilled": 0.0, "amountConsumed": 0.0, "unitPrice": 0.0},
@@ -627,7 +627,7 @@ interactions:
         [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1846'
+      - '1843'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -641,38 +641,38 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:43 GMT
+      - Wed, 16 Feb 2022 18:00:05 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
       - '2020-10-02'
     method: GET
-    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-12d297f2-89d7-11ec-a6aa-1860247f69ed.output.json
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-405b40b8-8f52-11ec-8732-3c7d0a1d68ec.output.json
   response:
     body:
-      string: '{"duration": 348302115, "histogram": {"0": 0.25, "7": 0.25, "8": 0.25,
+      string: '{"duration": 9001517, "histogram": {"0": 0.25, "7": 0.25, "8": 0.25,
         "15": 0.25}, "access_token": "fake_token"}'
     headers:
       accept-ranges:
       - bytes
       content-length:
-      - '73'
+      - '71'
       content-range:
-      - bytes 0-72/73
+      - bytes 0-70/71
       content-type:
       - application/json
       x-ms-blob-content-md5:
-      - g4Q6Hwi4YlAH/xSsZ3tQlA==
+      - jtj9tTg9yKVJtNBZ/9Jvbg==
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 09 Feb 2022 18:35:38 GMT
+      - Wed, 16 Feb 2022 17:59:58 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:

--- a/azure-quantum/tests/unit/recordings/test_plugins_submit_qiskit_multi_circuit_experiment_to_honeywell.yaml
+++ b/azure-quantum/tests/unit/recordings/test_plugins_submit_qiskit_multi_circuit_experiment_to_honeywell.yaml
@@ -5,7 +5,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       Content-Length:
@@ -13,13 +13,13 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - azsdk-python-identity/1.7.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-identity/1.7.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-client-cpu:
       - x64
       x-client-current-telemetry:
       - 4|730,0|
       x-client-os:
-      - win32
+      - darwin
       x-client-sku:
       - MSAL.Python
       x-client-ver:
@@ -44,11 +44,11 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/providerStatus
   response:
@@ -71,18 +71,18 @@ interactions:
         "averageQueueTime": 0, "statusPage": null}, {"id": "microsoft.substochasticmontecarlo-parameterfree.cpu",
         "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
         {"id": "toshiba", "currentAvailability": "Available", "targets": [{"id": "toshiba.sbm.ising",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
+        "currentAvailability": "Available", "averageQueueTime": 4, "statusPage": null}]},
         {"id": "honeywell", "currentAvailability": "Degraded", "targets": [{"id":
         "honeywell.hqs-lt-s1", "currentAvailability": "Unavailable", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-apival", "currentAvailability": "Available", "averageQueueTime":
-        1, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s2", "currentAvailability": "Degraded", "averageQueueTime":
-        518054, "statusPage": "https://www.honeywell.com/en-us/company/quantum"},
-        {"id": "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
+        31272, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-sim", "currentAvailability": "Available", "averageQueueTime":
-        8, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        43, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt", "currentAvailability": "Degraded", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}]}, {"id":
         "Microsoft.Simulator", "currentAvailability": "Available", "targets": [{"id":
@@ -94,7 +94,7 @@ interactions:
         {"id": "1qbit.pticm", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "http://status.1qbit.com/"}]}, {"id": "ionq", "currentAvailability":
         "Available", "targets": [{"id": "ionq.qpu", "currentAvailability": "Available",
-        "averageQueueTime": 648, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
+        "averageQueueTime": 217, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
         "currentAvailability": "Available", "averageQueueTime": 2, "statusPage": "https://status.ionq.co"}]}],
         "nextLink": null, "access_token": "fake_token"}'
     headers:
@@ -113,11 +113,11 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/providerStatus
   response:
@@ -140,18 +140,18 @@ interactions:
         "averageQueueTime": 0, "statusPage": null}, {"id": "microsoft.substochasticmontecarlo-parameterfree.cpu",
         "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
         {"id": "toshiba", "currentAvailability": "Available", "targets": [{"id": "toshiba.sbm.ising",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
+        "currentAvailability": "Available", "averageQueueTime": 4, "statusPage": null}]},
         {"id": "honeywell", "currentAvailability": "Degraded", "targets": [{"id":
         "honeywell.hqs-lt-s1", "currentAvailability": "Unavailable", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-apival", "currentAvailability": "Available", "averageQueueTime":
-        1, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s2", "currentAvailability": "Degraded", "averageQueueTime":
-        518054, "statusPage": "https://www.honeywell.com/en-us/company/quantum"},
-        {"id": "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
+        31272, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-sim", "currentAvailability": "Available", "averageQueueTime":
-        8, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        43, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt", "currentAvailability": "Degraded", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}]}, {"id":
         "Microsoft.Simulator", "currentAvailability": "Available", "targets": [{"id":
@@ -163,7 +163,7 @@ interactions:
         {"id": "1qbit.pticm", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "http://status.1qbit.com/"}]}, {"id": "ionq", "currentAvailability":
         "Available", "targets": [{"id": "ionq.qpu", "currentAvailability": "Available",
-        "averageQueueTime": 648, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
+        "averageQueueTime": 217, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
         "currentAvailability": "Available", "averageQueueTime": 2, "statusPage": "https://status.ionq.co"}]}],
         "nextLink": null, "access_token": "fake_token"}'
     headers:

--- a/azure-quantum/tests/unit/recordings/test_plugins_submit_qiskit_multi_circuit_experiment_to_ionq.yaml
+++ b/azure-quantum/tests/unit/recordings/test_plugins_submit_qiskit_multi_circuit_experiment_to_ionq.yaml
@@ -5,7 +5,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       Content-Length:
@@ -13,13 +13,13 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - azsdk-python-identity/1.7.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-identity/1.7.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-client-cpu:
       - x64
       x-client-current-telemetry:
       - 4|730,0|
       x-client-os:
-      - win32
+      - darwin
       x-client-sku:
       - MSAL.Python
       x-client-ver:
@@ -44,11 +44,11 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/providerStatus
   response:
@@ -71,18 +71,18 @@ interactions:
         "averageQueueTime": 0, "statusPage": null}, {"id": "microsoft.substochasticmontecarlo-parameterfree.cpu",
         "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
         {"id": "toshiba", "currentAvailability": "Available", "targets": [{"id": "toshiba.sbm.ising",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
+        "currentAvailability": "Available", "averageQueueTime": 4, "statusPage": null}]},
         {"id": "honeywell", "currentAvailability": "Degraded", "targets": [{"id":
         "honeywell.hqs-lt-s1", "currentAvailability": "Unavailable", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-apival", "currentAvailability": "Available", "averageQueueTime":
-        1, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s2", "currentAvailability": "Degraded", "averageQueueTime":
-        518054, "statusPage": "https://www.honeywell.com/en-us/company/quantum"},
-        {"id": "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
+        31272, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-sim", "currentAvailability": "Available", "averageQueueTime":
-        8, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        43, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt", "currentAvailability": "Degraded", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}]}, {"id":
         "Microsoft.Simulator", "currentAvailability": "Available", "targets": [{"id":
@@ -94,7 +94,7 @@ interactions:
         {"id": "1qbit.pticm", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "http://status.1qbit.com/"}]}, {"id": "ionq", "currentAvailability":
         "Available", "targets": [{"id": "ionq.qpu", "currentAvailability": "Available",
-        "averageQueueTime": 648, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
+        "averageQueueTime": 217, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
         "currentAvailability": "Available", "averageQueueTime": 2, "statusPage": "https://status.ionq.co"}]}],
         "nextLink": null, "access_token": "fake_token"}'
     headers:

--- a/azure-quantum/tests/unit/recordings/test_plugins_submit_qiskit_qobj_to_ionq.yaml
+++ b/azure-quantum/tests/unit/recordings/test_plugins_submit_qiskit_qobj_to_ionq.yaml
@@ -5,7 +5,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       Content-Length:
@@ -13,13 +13,13 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - azsdk-python-identity/1.7.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-identity/1.7.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-client-cpu:
       - x64
       x-client-current-telemetry:
       - 4|730,0|
       x-client-os:
-      - win32
+      - darwin
       x-client-sku:
       - MSAL.Python
       x-client-ver:
@@ -44,11 +44,11 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/providerStatus
   response:
@@ -71,18 +71,18 @@ interactions:
         "averageQueueTime": 0, "statusPage": null}, {"id": "microsoft.substochasticmontecarlo-parameterfree.cpu",
         "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
         {"id": "toshiba", "currentAvailability": "Available", "targets": [{"id": "toshiba.sbm.ising",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
+        "currentAvailability": "Available", "averageQueueTime": 4, "statusPage": null}]},
         {"id": "honeywell", "currentAvailability": "Degraded", "targets": [{"id":
         "honeywell.hqs-lt-s1", "currentAvailability": "Unavailable", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-apival", "currentAvailability": "Available", "averageQueueTime":
-        1, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s2", "currentAvailability": "Degraded", "averageQueueTime":
-        518054, "statusPage": "https://www.honeywell.com/en-us/company/quantum"},
-        {"id": "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
+        31272, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-sim", "currentAvailability": "Available", "averageQueueTime":
-        8, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        43, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt", "currentAvailability": "Degraded", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}]}, {"id":
         "Microsoft.Simulator", "currentAvailability": "Available", "targets": [{"id":
@@ -94,7 +94,7 @@ interactions:
         {"id": "1qbit.pticm", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "http://status.1qbit.com/"}]}, {"id": "ionq", "currentAvailability":
         "Available", "targets": [{"id": "ionq.qpu", "currentAvailability": "Available",
-        "averageQueueTime": 648, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
+        "averageQueueTime": 217, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
         "currentAvailability": "Available", "averageQueueTime": 2, "statusPage": "https://status.ionq.co"}]}],
         "nextLink": null, "access_token": "fake_token"}'
     headers:
@@ -113,7 +113,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       Content-Length:
@@ -121,7 +121,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: POST
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
   response:
@@ -130,7 +130,7 @@ interactions:
         "access_token": "fake_token"}'
     headers:
       content-length:
-      - '209'
+      - '211'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -144,13 +144,13 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:45 GMT
+      - Wed, 16 Feb 2022 18:00:08 GMT
       x-ms-version:
       - '2020-10-02'
     method: GET
@@ -158,7 +158,7 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
-        specified container does not exist.\nRequestId:0ebf28da-501e-0060-22e3-1de372000000\nTime:2022-02-09T18:35:45.2790900Z</Message></Error>"
+        specified container does not exist.\nRequestId:c12daf3e-001e-0020-665f-23e44a000000\nTime:2022-02-16T18:00:08.4291681Z</Message></Error>"
     headers:
       content-length:
       - '225'
@@ -175,15 +175,15 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:45 GMT
+      - Wed, 16 Feb 2022 18:00:08 GMT
       x-ms-version:
       - '2020-10-02'
     method: PUT
@@ -205,13 +205,13 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:45 GMT
+      - Wed, 16 Feb 2022 18:00:08 GMT
       x-ms-version:
       - '2020-10-02'
     method: GET
@@ -239,7 +239,7 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       Content-Length:
@@ -247,11 +247,11 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:45 GMT
+      - Wed, 16 Feb 2022 18:00:08 GMT
       x-ms-version:
       - '2020-10-02'
     method: PUT
@@ -279,15 +279,15 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       Content-Length:
-      - '708'
+      - '710'
       Content-Type:
       - application/json
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: PUT
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
@@ -300,13 +300,13 @@ interactions:
         1, 2]"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Waiting", "outputDataFormat": "ionq.quantum-results.v1", "outputDataUri":
         "https://e2etests.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "creationTime": "2022-02-09T18:35:45.502046+00:00", "beginExecutionTime":
+        "creationTime": "2022-02-16T18:00:08.7868312+00:00", "beginExecutionTime":
         null, "endExecutionTime": null, "cancellationTime": null, "costEstimate":
         null, "errorData": null, "isCancelling": false, "tags": [], "access_token":
         "fake_token"}'
     headers:
       content-length:
-      - '1231'
+      - '1236'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -320,25 +320,25 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-177d0a2f-89d7-11ec-81f0-1860247f69ed.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-466f0412-8f52-11ec-8732-3c7d0a1d68ec.input.json",
         "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 1024}, "providerId":
         "ionq", "target": "ionq.simulator", "metadata": {"qiskit": "True", "name":
         "Qiskit Sample - 3-qubit GHZ circuit", "num_qubits": "4", "meas_map": "[0,
         1, 2]"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "ionq.quantum-results.v1", "outputDataUri":
-        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-177d0a2f-89d7-11ec-81f0-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:45.502046+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:48.023Z", "endExecutionTime": "2022-02-09T18:35:48.035Z",
+        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-466f0412-8f52-11ec-8732-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T18:00:08.7868312+00:00", "beginExecutionTime":
+        "2022-02-16T18:00:11.508Z", "endExecutionTime": "2022-02-16T18:00:11.52Z",
         "cancellationTime": null, "costEstimate": {"currencyCode": "USD", "events":
         [{"dimensionId": "gs1q", "dimensionName": "1Q Gate Shot", "measureUnit": "1q
         gate shot", "amountBilled": 0.0, "amountConsumed": 0.0, "unitPrice": 0.0},
@@ -362,25 +362,25 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-177d0a2f-89d7-11ec-81f0-1860247f69ed.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-466f0412-8f52-11ec-8732-3c7d0a1d68ec.input.json",
         "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 1024}, "providerId":
         "ionq", "target": "ionq.simulator", "metadata": {"qiskit": "True", "name":
         "Qiskit Sample - 3-qubit GHZ circuit", "num_qubits": "4", "meas_map": "[0,
         1, 2]"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "ionq.quantum-results.v1", "outputDataUri":
-        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-177d0a2f-89d7-11ec-81f0-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:45.502046+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:48.023Z", "endExecutionTime": "2022-02-09T18:35:48.035Z",
+        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-466f0412-8f52-11ec-8732-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T18:00:08.7868312+00:00", "beginExecutionTime":
+        "2022-02-16T18:00:11.508Z", "endExecutionTime": "2022-02-16T18:00:11.52Z",
         "cancellationTime": null, "costEstimate": {"currencyCode": "USD", "events":
         [{"dimensionId": "gs1q", "dimensionName": "1Q Gate Shot", "measureUnit": "1q
         gate shot", "amountBilled": 0.0, "amountConsumed": 0.0, "unitPrice": 0.0},
@@ -404,25 +404,25 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-177d0a2f-89d7-11ec-81f0-1860247f69ed.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-466f0412-8f52-11ec-8732-3c7d0a1d68ec.input.json",
         "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 1024}, "providerId":
         "ionq", "target": "ionq.simulator", "metadata": {"qiskit": "True", "name":
         "Qiskit Sample - 3-qubit GHZ circuit", "num_qubits": "4", "meas_map": "[0,
         1, 2]"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "ionq.quantum-results.v1", "outputDataUri":
-        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-177d0a2f-89d7-11ec-81f0-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:45.502046+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:48.023Z", "endExecutionTime": "2022-02-09T18:35:48.035Z",
+        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-466f0412-8f52-11ec-8732-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T18:00:08.7868312+00:00", "beginExecutionTime":
+        "2022-02-16T18:00:11.508Z", "endExecutionTime": "2022-02-16T18:00:11.52Z",
         "cancellationTime": null, "costEstimate": {"currencyCode": "USD", "events":
         [{"dimensionId": "gs1q", "dimensionName": "1Q Gate Shot", "measureUnit": "1q
         gate shot", "amountBilled": 0.0, "amountConsumed": 0.0, "unitPrice": 0.0},
@@ -446,11 +446,11 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/providerStatus
   response:
@@ -473,18 +473,18 @@ interactions:
         "averageQueueTime": 0, "statusPage": null}, {"id": "microsoft.substochasticmontecarlo-parameterfree.cpu",
         "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
         {"id": "toshiba", "currentAvailability": "Available", "targets": [{"id": "toshiba.sbm.ising",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
+        "currentAvailability": "Available", "averageQueueTime": 4, "statusPage": null}]},
         {"id": "honeywell", "currentAvailability": "Degraded", "targets": [{"id":
         "honeywell.hqs-lt-s1", "currentAvailability": "Unavailable", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-apival", "currentAvailability": "Available", "averageQueueTime":
-        1, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s2", "currentAvailability": "Degraded", "averageQueueTime":
-        518054, "statusPage": "https://www.honeywell.com/en-us/company/quantum"},
-        {"id": "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
+        31272, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-sim", "currentAvailability": "Available", "averageQueueTime":
-        8, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        43, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt", "currentAvailability": "Degraded", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}]}, {"id":
         "Microsoft.Simulator", "currentAvailability": "Available", "targets": [{"id":
@@ -496,7 +496,7 @@ interactions:
         {"id": "1qbit.pticm", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "http://status.1qbit.com/"}]}, {"id": "ionq", "currentAvailability":
         "Available", "targets": [{"id": "ionq.qpu", "currentAvailability": "Available",
-        "averageQueueTime": 648, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
+        "averageQueueTime": 217, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
         "currentAvailability": "Available", "averageQueueTime": 2, "statusPage": "https://status.ionq.co"}]}],
         "nextLink": null, "access_token": "fake_token"}'
     headers:
@@ -515,25 +515,25 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-177d0a2f-89d7-11ec-81f0-1860247f69ed.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-466f0412-8f52-11ec-8732-3c7d0a1d68ec.input.json",
         "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 1024}, "providerId":
         "ionq", "target": "ionq.simulator", "metadata": {"qiskit": "True", "name":
         "Qiskit Sample - 3-qubit GHZ circuit", "num_qubits": "4", "meas_map": "[0,
         1, 2]"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "ionq.quantum-results.v1", "outputDataUri":
-        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-177d0a2f-89d7-11ec-81f0-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:45.502046+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:48.023Z", "endExecutionTime": "2022-02-09T18:35:48.035Z",
+        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-466f0412-8f52-11ec-8732-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T18:00:08.7868312+00:00", "beginExecutionTime":
+        "2022-02-16T18:00:11.508Z", "endExecutionTime": "2022-02-16T18:00:11.52Z",
         "cancellationTime": null, "costEstimate": {"currencyCode": "USD", "events":
         [{"dimensionId": "gs1q", "dimensionName": "1Q Gate Shot", "measureUnit": "1q
         gate shot", "amountBilled": 0.0, "amountConsumed": 0.0, "unitPrice": 0.0},
@@ -557,25 +557,25 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-177d0a2f-89d7-11ec-81f0-1860247f69ed.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-466f0412-8f52-11ec-8732-3c7d0a1d68ec.input.json",
         "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 1024}, "providerId":
         "ionq", "target": "ionq.simulator", "metadata": {"qiskit": "True", "name":
         "Qiskit Sample - 3-qubit GHZ circuit", "num_qubits": "4", "meas_map": "[0,
         1, 2]"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "ionq.quantum-results.v1", "outputDataUri":
-        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-177d0a2f-89d7-11ec-81f0-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:45.502046+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:48.023Z", "endExecutionTime": "2022-02-09T18:35:48.035Z",
+        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-466f0412-8f52-11ec-8732-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T18:00:08.7868312+00:00", "beginExecutionTime":
+        "2022-02-16T18:00:11.508Z", "endExecutionTime": "2022-02-16T18:00:11.52Z",
         "cancellationTime": null, "costEstimate": {"currencyCode": "USD", "events":
         [{"dimensionId": "gs1q", "dimensionName": "1Q Gate Shot", "measureUnit": "1q
         gate shot", "amountBilled": 0.0, "amountConsumed": 0.0, "unitPrice": 0.0},
@@ -599,25 +599,25 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-177d0a2f-89d7-11ec-81f0-1860247f69ed.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-466f0412-8f52-11ec-8732-3c7d0a1d68ec.input.json",
         "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 1024}, "providerId":
         "ionq", "target": "ionq.simulator", "metadata": {"qiskit": "True", "name":
         "Qiskit Sample - 3-qubit GHZ circuit", "num_qubits": "4", "meas_map": "[0,
         1, 2]"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "ionq.quantum-results.v1", "outputDataUri":
-        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-177d0a2f-89d7-11ec-81f0-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:45.502046+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:48.023Z", "endExecutionTime": "2022-02-09T18:35:48.035Z",
+        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-466f0412-8f52-11ec-8732-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T18:00:08.7868312+00:00", "beginExecutionTime":
+        "2022-02-16T18:00:11.508Z", "endExecutionTime": "2022-02-16T18:00:11.52Z",
         "cancellationTime": null, "costEstimate": {"currencyCode": "USD", "events":
         [{"dimensionId": "gs1q", "dimensionName": "1Q Gate Shot", "measureUnit": "1q
         gate shot", "amountBilled": 0.0, "amountConsumed": 0.0, "unitPrice": 0.0},
@@ -641,22 +641,22 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:50 GMT
+      - Wed, 16 Feb 2022 18:00:12 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
       - '2020-10-02'
     method: GET
-    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-177d0a2f-89d7-11ec-81f0-1860247f69ed.output.json
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-466f0412-8f52-11ec-8732-3c7d0a1d68ec.output.json
   response:
     body:
-      string: '{"duration": 11957453, "histogram": {"0": 0.25, "7": 0.25, "8": 0.25,
+      string: '{"duration": 11767486, "histogram": {"0": 0.25, "7": 0.25, "8": 0.25,
         "15": 0.25}, "access_token": "fake_token"}'
     headers:
       accept-ranges:
@@ -668,11 +668,11 @@ interactions:
       content-type:
       - application/json
       x-ms-blob-content-md5:
-      - ++k3eE21A+1Hb+zxzQ9rrw==
+      - VtswX0VDw0/7equWMX3UfA==
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 09 Feb 2022 18:35:45 GMT
+      - Wed, 16 Feb 2022 18:00:09 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:

--- a/azure-quantum/tests/unit/recordings/test_plugins_submit_qiskit_to_honeywell.yaml
+++ b/azure-quantum/tests/unit/recordings/test_plugins_submit_qiskit_to_honeywell.yaml
@@ -5,7 +5,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       Content-Length:
@@ -13,13 +13,13 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - azsdk-python-identity/1.7.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-identity/1.7.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-client-cpu:
       - x64
       x-client-current-telemetry:
       - 4|730,0|
       x-client-os:
-      - win32
+      - darwin
       x-client-sku:
       - MSAL.Python
       x-client-ver:
@@ -44,11 +44,11 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/providerStatus
   response:
@@ -71,18 +71,18 @@ interactions:
         "averageQueueTime": 0, "statusPage": null}, {"id": "microsoft.substochasticmontecarlo-parameterfree.cpu",
         "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
         {"id": "toshiba", "currentAvailability": "Available", "targets": [{"id": "toshiba.sbm.ising",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
+        "currentAvailability": "Available", "averageQueueTime": 4, "statusPage": null}]},
         {"id": "honeywell", "currentAvailability": "Degraded", "targets": [{"id":
         "honeywell.hqs-lt-s1", "currentAvailability": "Unavailable", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-apival", "currentAvailability": "Available", "averageQueueTime":
-        1, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s2", "currentAvailability": "Degraded", "averageQueueTime":
-        518054, "statusPage": "https://www.honeywell.com/en-us/company/quantum"},
-        {"id": "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
+        31272, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-sim", "currentAvailability": "Available", "averageQueueTime":
-        8, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        43, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt", "currentAvailability": "Degraded", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}]}, {"id":
         "Microsoft.Simulator", "currentAvailability": "Available", "targets": [{"id":
@@ -94,7 +94,7 @@ interactions:
         {"id": "1qbit.pticm", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "http://status.1qbit.com/"}]}, {"id": "ionq", "currentAvailability":
         "Available", "targets": [{"id": "ionq.qpu", "currentAvailability": "Available",
-        "averageQueueTime": 648, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
+        "averageQueueTime": 217, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
         "currentAvailability": "Available", "averageQueueTime": 2, "statusPage": "https://status.ionq.co"}]}],
         "nextLink": null, "access_token": "fake_token"}'
     headers:
@@ -113,11 +113,11 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/providerStatus
   response:
@@ -140,18 +140,18 @@ interactions:
         "averageQueueTime": 0, "statusPage": null}, {"id": "microsoft.substochasticmontecarlo-parameterfree.cpu",
         "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
         {"id": "toshiba", "currentAvailability": "Available", "targets": [{"id": "toshiba.sbm.ising",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
+        "currentAvailability": "Available", "averageQueueTime": 4, "statusPage": null}]},
         {"id": "honeywell", "currentAvailability": "Degraded", "targets": [{"id":
         "honeywell.hqs-lt-s1", "currentAvailability": "Unavailable", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-apival", "currentAvailability": "Available", "averageQueueTime":
-        1, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s2", "currentAvailability": "Degraded", "averageQueueTime":
-        518054, "statusPage": "https://www.honeywell.com/en-us/company/quantum"},
-        {"id": "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
+        31272, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-sim", "currentAvailability": "Available", "averageQueueTime":
-        8, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        43, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt", "currentAvailability": "Degraded", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}]}, {"id":
         "Microsoft.Simulator", "currentAvailability": "Available", "targets": [{"id":
@@ -163,7 +163,7 @@ interactions:
         {"id": "1qbit.pticm", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "http://status.1qbit.com/"}]}, {"id": "ionq", "currentAvailability":
         "Available", "targets": [{"id": "ionq.qpu", "currentAvailability": "Available",
-        "averageQueueTime": 648, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
+        "averageQueueTime": 217, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
         "currentAvailability": "Available", "averageQueueTime": 2, "statusPage": "https://status.ionq.co"}]}],
         "nextLink": null, "access_token": "fake_token"}'
     headers:
@@ -182,7 +182,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       Content-Length:
@@ -190,7 +190,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: POST
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
   response:
@@ -199,7 +199,7 @@ interactions:
         "access_token": "fake_token"}'
     headers:
       content-length:
-      - '209'
+      - '207'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -213,13 +213,13 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:51 GMT
+      - Wed, 16 Feb 2022 18:00:13 GMT
       x-ms-version:
       - '2020-10-02'
     method: GET
@@ -227,7 +227,7 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
-        specified container does not exist.\nRequestId:720d25b2-401e-0088-56e3-1d7ae4000000\nTime:2022-02-09T18:35:51.5620734Z</Message></Error>"
+        specified container does not exist.\nRequestId:eecd0c61-b01e-008c-775f-23f7e3000000\nTime:2022-02-16T18:00:13.7616058Z</Message></Error>"
     headers:
       content-length:
       - '225'
@@ -244,15 +244,15 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:51 GMT
+      - Wed, 16 Feb 2022 18:00:13 GMT
       x-ms-version:
       - '2020-10-02'
     method: PUT
@@ -274,13 +274,13 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:51 GMT
+      - Wed, 16 Feb 2022 18:00:13 GMT
       x-ms-version:
       - '2020-10-02'
     method: GET
@@ -308,7 +308,7 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       Content-Length:
@@ -316,11 +316,11 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:51 GMT
+      - Wed, 16 Feb 2022 18:00:13 GMT
       x-ms-version:
       - '2020-10-02'
     method: PUT
@@ -347,15 +347,15 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       Content-Length:
-      - '641'
+      - '639'
       Content-Type:
       - application/json
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: PUT
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
@@ -367,13 +367,13 @@ interactions:
         {"qubits": "4"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Waiting", "outputDataFormat": "honeywell.quantum-results.v1", "outputDataUri":
         "https://e2etests.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "creationTime": "2022-02-09T18:35:51.8454965+00:00", "beginExecutionTime":
+        "creationTime": "2022-02-16T18:00:13.9726835+00:00", "beginExecutionTime":
         null, "endExecutionTime": null, "cancellationTime": null, "costEstimate":
         null, "errorData": null, "isCancelling": false, "tags": [], "access_token":
         "fake_token"}'
     headers:
       content-length:
-      - '1171'
+      - '1165'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -387,29 +387,29 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-1b04486c-89d7-11ec-9e44-1860247f69ed.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-49c90d42-8f52-11ec-8732-3c7d0a1d68ec.input.json",
         "inputDataFormat": "honeywell.openqasm.v1", "inputParams": {"count": 500},
         "providerId": "honeywell", "target": "honeywell.hqs-lt-s1-apival", "metadata":
         {"qubits": "4"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "honeywell.quantum-results.v1",
-        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-1b04486c-89d7-11ec-9e44-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:51.8454965+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:53.052515+00:00", "endExecutionTime": "2022-02-09T18:35:53.053068+00:00",
+        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-49c90d42-8f52-11ec-8732-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T18:00:13.9726835+00:00", "beginExecutionTime":
+        "2022-02-16T18:00:15.167297+00:00", "endExecutionTime": "2022-02-16T18:00:15.168119+00:00",
         "cancellationTime": null, "costEstimate": null, "errorData": null, "isCancelling":
         false, "tags": [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1471'
+      - '1465'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -423,29 +423,29 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-1b04486c-89d7-11ec-9e44-1860247f69ed.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-49c90d42-8f52-11ec-8732-3c7d0a1d68ec.input.json",
         "inputDataFormat": "honeywell.openqasm.v1", "inputParams": {"count": 500},
         "providerId": "honeywell", "target": "honeywell.hqs-lt-s1-apival", "metadata":
         {"qubits": "4"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "honeywell.quantum-results.v1",
-        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-1b04486c-89d7-11ec-9e44-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:51.8454965+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:53.052515+00:00", "endExecutionTime": "2022-02-09T18:35:53.053068+00:00",
+        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-49c90d42-8f52-11ec-8732-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T18:00:13.9726835+00:00", "beginExecutionTime":
+        "2022-02-16T18:00:15.167297+00:00", "endExecutionTime": "2022-02-16T18:00:15.168119+00:00",
         "cancellationTime": null, "costEstimate": null, "errorData": null, "isCancelling":
         false, "tags": [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1471'
+      - '1465'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -459,29 +459,29 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-1b04486c-89d7-11ec-9e44-1860247f69ed.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-49c90d42-8f52-11ec-8732-3c7d0a1d68ec.input.json",
         "inputDataFormat": "honeywell.openqasm.v1", "inputParams": {"count": 500},
         "providerId": "honeywell", "target": "honeywell.hqs-lt-s1-apival", "metadata":
         {"qubits": "4"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "honeywell.quantum-results.v1",
-        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-1b04486c-89d7-11ec-9e44-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:51.8454965+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:53.052515+00:00", "endExecutionTime": "2022-02-09T18:35:53.053068+00:00",
+        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-49c90d42-8f52-11ec-8732-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T18:00:13.9726835+00:00", "beginExecutionTime":
+        "2022-02-16T18:00:15.167297+00:00", "endExecutionTime": "2022-02-16T18:00:15.168119+00:00",
         "cancellationTime": null, "costEstimate": null, "errorData": null, "isCancelling":
         false, "tags": [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1471'
+      - '1465'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -495,11 +495,11 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/providerStatus
   response:
@@ -522,18 +522,18 @@ interactions:
         "averageQueueTime": 0, "statusPage": null}, {"id": "microsoft.substochasticmontecarlo-parameterfree.cpu",
         "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
         {"id": "toshiba", "currentAvailability": "Available", "targets": [{"id": "toshiba.sbm.ising",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
+        "currentAvailability": "Available", "averageQueueTime": 4, "statusPage": null}]},
         {"id": "honeywell", "currentAvailability": "Degraded", "targets": [{"id":
         "honeywell.hqs-lt-s1", "currentAvailability": "Unavailable", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-apival", "currentAvailability": "Available", "averageQueueTime":
-        1, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s2", "currentAvailability": "Degraded", "averageQueueTime":
-        518054, "statusPage": "https://www.honeywell.com/en-us/company/quantum"},
-        {"id": "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
+        31272, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-sim", "currentAvailability": "Available", "averageQueueTime":
-        8, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        43, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt", "currentAvailability": "Degraded", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}]}, {"id":
         "Microsoft.Simulator", "currentAvailability": "Available", "targets": [{"id":
@@ -545,7 +545,7 @@ interactions:
         {"id": "1qbit.pticm", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "http://status.1qbit.com/"}]}, {"id": "ionq", "currentAvailability":
         "Available", "targets": [{"id": "ionq.qpu", "currentAvailability": "Available",
-        "averageQueueTime": 648, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
+        "averageQueueTime": 217, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
         "currentAvailability": "Available", "averageQueueTime": 2, "statusPage": "https://status.ionq.co"}]}],
         "nextLink": null, "access_token": "fake_token"}'
     headers:
@@ -564,29 +564,29 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-1b04486c-89d7-11ec-9e44-1860247f69ed.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-49c90d42-8f52-11ec-8732-3c7d0a1d68ec.input.json",
         "inputDataFormat": "honeywell.openqasm.v1", "inputParams": {"count": 500},
         "providerId": "honeywell", "target": "honeywell.hqs-lt-s1-apival", "metadata":
         {"qubits": "4"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "honeywell.quantum-results.v1",
-        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-1b04486c-89d7-11ec-9e44-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:51.8454965+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:53.052515+00:00", "endExecutionTime": "2022-02-09T18:35:53.053068+00:00",
+        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-49c90d42-8f52-11ec-8732-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T18:00:13.9726835+00:00", "beginExecutionTime":
+        "2022-02-16T18:00:15.167297+00:00", "endExecutionTime": "2022-02-16T18:00:15.168119+00:00",
         "cancellationTime": null, "costEstimate": null, "errorData": null, "isCancelling":
         false, "tags": [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1471'
+      - '1465'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -600,29 +600,29 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-1b04486c-89d7-11ec-9e44-1860247f69ed.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-49c90d42-8f52-11ec-8732-3c7d0a1d68ec.input.json",
         "inputDataFormat": "honeywell.openqasm.v1", "inputParams": {"count": 500},
         "providerId": "honeywell", "target": "honeywell.hqs-lt-s1-apival", "metadata":
         {"qubits": "4"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "honeywell.quantum-results.v1",
-        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-1b04486c-89d7-11ec-9e44-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:51.8454965+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:53.052515+00:00", "endExecutionTime": "2022-02-09T18:35:53.053068+00:00",
+        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-49c90d42-8f52-11ec-8732-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T18:00:13.9726835+00:00", "beginExecutionTime":
+        "2022-02-16T18:00:15.167297+00:00", "endExecutionTime": "2022-02-16T18:00:15.168119+00:00",
         "cancellationTime": null, "costEstimate": null, "errorData": null, "isCancelling":
         false, "tags": [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1471'
+      - '1465'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -636,29 +636,29 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-1b04486c-89d7-11ec-9e44-1860247f69ed.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-49c90d42-8f52-11ec-8732-3c7d0a1d68ec.input.json",
         "inputDataFormat": "honeywell.openqasm.v1", "inputParams": {"count": 500},
         "providerId": "honeywell", "target": "honeywell.hqs-lt-s1-apival", "metadata":
         {"qubits": "4"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "honeywell.quantum-results.v1",
-        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-1b04486c-89d7-11ec-9e44-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:51.8454965+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:53.052515+00:00", "endExecutionTime": "2022-02-09T18:35:53.053068+00:00",
+        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-49c90d42-8f52-11ec-8732-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T18:00:13.9726835+00:00", "beginExecutionTime":
+        "2022-02-16T18:00:15.167297+00:00", "endExecutionTime": "2022-02-16T18:00:15.168119+00:00",
         "cancellationTime": null, "costEstimate": null, "errorData": null, "isCancelling":
         false, "tags": [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1471'
+      - '1465'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -672,19 +672,19 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:55 GMT
+      - Wed, 16 Feb 2022 18:00:17 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
       - '2020-10-02'
     method: GET
-    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-1b04486c-89d7-11ec-9e44-1860247f69ed.output.json
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-49c90d42-8f52-11ec-8732-3c7d0a1d68ec.output.json
   response:
     body:
       string: '{"c": ["000", "000", "000", "000", "000", "000", "000", "000", "000",
@@ -747,7 +747,7 @@ interactions:
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 09 Feb 2022 18:35:52 GMT
+      - Wed, 16 Feb 2022 18:00:14 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:

--- a/azure-quantum/tests/unit/recordings/test_plugins_submit_qiskit_to_ionq.yaml
+++ b/azure-quantum/tests/unit/recordings/test_plugins_submit_qiskit_to_ionq.yaml
@@ -5,7 +5,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       Content-Length:
@@ -13,13 +13,13 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - azsdk-python-identity/1.7.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-identity/1.7.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-client-cpu:
       - x64
       x-client-current-telemetry:
       - 4|730,0|
       x-client-os:
-      - win32
+      - darwin
       x-client-sku:
       - MSAL.Python
       x-client-ver:
@@ -44,11 +44,11 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/providerStatus
   response:
@@ -71,18 +71,18 @@ interactions:
         "averageQueueTime": 0, "statusPage": null}, {"id": "microsoft.substochasticmontecarlo-parameterfree.cpu",
         "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
         {"id": "toshiba", "currentAvailability": "Available", "targets": [{"id": "toshiba.sbm.ising",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
+        "currentAvailability": "Available", "averageQueueTime": 4, "statusPage": null}]},
         {"id": "honeywell", "currentAvailability": "Degraded", "targets": [{"id":
         "honeywell.hqs-lt-s1", "currentAvailability": "Unavailable", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-apival", "currentAvailability": "Available", "averageQueueTime":
-        1, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s2", "currentAvailability": "Degraded", "averageQueueTime":
-        518054, "statusPage": "https://www.honeywell.com/en-us/company/quantum"},
-        {"id": "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
+        31272, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-sim", "currentAvailability": "Available", "averageQueueTime":
-        8, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        43, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt", "currentAvailability": "Degraded", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}]}, {"id":
         "Microsoft.Simulator", "currentAvailability": "Available", "targets": [{"id":
@@ -94,7 +94,7 @@ interactions:
         {"id": "1qbit.pticm", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "http://status.1qbit.com/"}]}, {"id": "ionq", "currentAvailability":
         "Available", "targets": [{"id": "ionq.qpu", "currentAvailability": "Available",
-        "averageQueueTime": 392, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
+        "averageQueueTime": 217, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
         "currentAvailability": "Available", "averageQueueTime": 2, "statusPage": "https://status.ionq.co"}]}],
         "nextLink": null, "access_token": "fake_token"}'
     headers:
@@ -113,7 +113,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       Content-Length:
@@ -121,7 +121,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: POST
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
   response:
@@ -144,13 +144,13 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:56 GMT
+      - Wed, 16 Feb 2022 18:00:18 GMT
       x-ms-version:
       - '2020-10-02'
     method: GET
@@ -158,7 +158,7 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
-        specified container does not exist.\nRequestId:b882f780-b01e-001a-29e3-1dfe32000000\nTime:2022-02-09T18:35:56.1330938Z</Message></Error>"
+        specified container does not exist.\nRequestId:bcbf4432-a01e-0039-385f-2364f1000000\nTime:2022-02-16T18:00:18.7063417Z</Message></Error>"
     headers:
       content-length:
       - '225'
@@ -175,15 +175,15 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:56 GMT
+      - Wed, 16 Feb 2022 18:00:18 GMT
       x-ms-version:
       - '2020-10-02'
     method: PUT
@@ -205,13 +205,13 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:56 GMT
+      - Wed, 16 Feb 2022 18:00:18 GMT
       x-ms-version:
       - '2020-10-02'
     method: GET
@@ -239,7 +239,7 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       Content-Length:
@@ -247,11 +247,11 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:56 GMT
+      - Wed, 16 Feb 2022 18:00:18 GMT
       x-ms-version:
       - '2020-10-02'
     method: PUT
@@ -279,7 +279,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       Content-Length:
@@ -287,7 +287,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: PUT
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
@@ -300,7 +300,7 @@ interactions:
         1, 2]"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Waiting", "outputDataFormat": "ionq.quantum-results.v1", "outputDataUri":
         "https://e2etests.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "creationTime": "2022-02-09T18:35:56.3668507+00:00", "beginExecutionTime":
+        "creationTime": "2022-02-16T18:00:19.1015971+00:00", "beginExecutionTime":
         null, "endExecutionTime": null, "cancellationTime": null, "costEstimate":
         null, "errorData": null, "isCancelling": false, "tags": [], "access_token":
         "fake_token"}'
@@ -320,25 +320,25 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-1deba31a-89d7-11ec-b297-1860247f69ed.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-4c923b16-8f52-11ec-8732-3c7d0a1d68ec.input.json",
         "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 500}, "providerId":
         "ionq", "target": "ionq.simulator", "metadata": {"qiskit": "True", "name":
         "Qiskit Sample - 3-qubit GHZ circuit", "num_qubits": "4", "meas_map": "[0,
         1, 2]"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "ionq.quantum-results.v1", "outputDataUri":
-        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-1deba31a-89d7-11ec-b297-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:56.3668507+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:58.8Z", "endExecutionTime": "2022-02-09T18:35:58.813Z",
+        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-4c923b16-8f52-11ec-8732-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T18:00:19.1015971+00:00", "beginExecutionTime":
+        "2022-02-16T18:00:22.352Z", "endExecutionTime": "2022-02-16T18:00:22.365Z",
         "cancellationTime": null, "costEstimate": {"currencyCode": "USD", "events":
         [{"dimensionId": "gs1q", "dimensionName": "1Q Gate Shot", "measureUnit": "1q
         gate shot", "amountBilled": 0.0, "amountConsumed": 0.0, "unitPrice": 0.0},
@@ -348,7 +348,7 @@ interactions:
         [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1837'
+      - '1839'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -362,25 +362,25 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-1deba31a-89d7-11ec-b297-1860247f69ed.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-4c923b16-8f52-11ec-8732-3c7d0a1d68ec.input.json",
         "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 500}, "providerId":
         "ionq", "target": "ionq.simulator", "metadata": {"qiskit": "True", "name":
         "Qiskit Sample - 3-qubit GHZ circuit", "num_qubits": "4", "meas_map": "[0,
         1, 2]"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "ionq.quantum-results.v1", "outputDataUri":
-        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-1deba31a-89d7-11ec-b297-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:56.3668507+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:58.8Z", "endExecutionTime": "2022-02-09T18:35:58.813Z",
+        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-4c923b16-8f52-11ec-8732-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T18:00:19.1015971+00:00", "beginExecutionTime":
+        "2022-02-16T18:00:22.352Z", "endExecutionTime": "2022-02-16T18:00:22.365Z",
         "cancellationTime": null, "costEstimate": {"currencyCode": "USD", "events":
         [{"dimensionId": "gs1q", "dimensionName": "1Q Gate Shot", "measureUnit": "1q
         gate shot", "amountBilled": 0.0, "amountConsumed": 0.0, "unitPrice": 0.0},
@@ -390,7 +390,7 @@ interactions:
         [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1837'
+      - '1839'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -404,25 +404,25 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-1deba31a-89d7-11ec-b297-1860247f69ed.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-4c923b16-8f52-11ec-8732-3c7d0a1d68ec.input.json",
         "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 500}, "providerId":
         "ionq", "target": "ionq.simulator", "metadata": {"qiskit": "True", "name":
         "Qiskit Sample - 3-qubit GHZ circuit", "num_qubits": "4", "meas_map": "[0,
         1, 2]"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "ionq.quantum-results.v1", "outputDataUri":
-        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-1deba31a-89d7-11ec-b297-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:56.3668507+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:58.8Z", "endExecutionTime": "2022-02-09T18:35:58.813Z",
+        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-4c923b16-8f52-11ec-8732-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T18:00:19.1015971+00:00", "beginExecutionTime":
+        "2022-02-16T18:00:22.352Z", "endExecutionTime": "2022-02-16T18:00:22.365Z",
         "cancellationTime": null, "costEstimate": {"currencyCode": "USD", "events":
         [{"dimensionId": "gs1q", "dimensionName": "1Q Gate Shot", "measureUnit": "1q
         gate shot", "amountBilled": 0.0, "amountConsumed": 0.0, "unitPrice": 0.0},
@@ -432,7 +432,7 @@ interactions:
         [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1837'
+      - '1839'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -446,11 +446,11 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/providerStatus
   response:
@@ -473,18 +473,18 @@ interactions:
         "averageQueueTime": 0, "statusPage": null}, {"id": "microsoft.substochasticmontecarlo-parameterfree.cpu",
         "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
         {"id": "toshiba", "currentAvailability": "Available", "targets": [{"id": "toshiba.sbm.ising",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
+        "currentAvailability": "Available", "averageQueueTime": 4, "statusPage": null}]},
         {"id": "honeywell", "currentAvailability": "Degraded", "targets": [{"id":
         "honeywell.hqs-lt-s1", "currentAvailability": "Unavailable", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-apival", "currentAvailability": "Available", "averageQueueTime":
-        1, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s2", "currentAvailability": "Degraded", "averageQueueTime":
-        518054, "statusPage": "https://www.honeywell.com/en-us/company/quantum"},
-        {"id": "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
+        31272, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt-s1-sim", "currentAvailability": "Available", "averageQueueTime":
-        8, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        43, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
         "honeywell.hqs-lt", "currentAvailability": "Degraded", "averageQueueTime":
         0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}]}, {"id":
         "Microsoft.Simulator", "currentAvailability": "Available", "targets": [{"id":
@@ -496,7 +496,7 @@ interactions:
         {"id": "1qbit.pticm", "currentAvailability": "Available", "averageQueueTime":
         0, "statusPage": "http://status.1qbit.com/"}]}, {"id": "ionq", "currentAvailability":
         "Available", "targets": [{"id": "ionq.qpu", "currentAvailability": "Available",
-        "averageQueueTime": 392, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
+        "averageQueueTime": 217, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
         "currentAvailability": "Available", "averageQueueTime": 2, "statusPage": "https://status.ionq.co"}]}],
         "nextLink": null, "access_token": "fake_token"}'
     headers:
@@ -515,25 +515,25 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-1deba31a-89d7-11ec-b297-1860247f69ed.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-4c923b16-8f52-11ec-8732-3c7d0a1d68ec.input.json",
         "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 500}, "providerId":
         "ionq", "target": "ionq.simulator", "metadata": {"qiskit": "True", "name":
         "Qiskit Sample - 3-qubit GHZ circuit", "num_qubits": "4", "meas_map": "[0,
         1, 2]"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "ionq.quantum-results.v1", "outputDataUri":
-        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-1deba31a-89d7-11ec-b297-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:56.3668507+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:58.8Z", "endExecutionTime": "2022-02-09T18:35:58.813Z",
+        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-4c923b16-8f52-11ec-8732-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T18:00:19.1015971+00:00", "beginExecutionTime":
+        "2022-02-16T18:00:22.352Z", "endExecutionTime": "2022-02-16T18:00:22.365Z",
         "cancellationTime": null, "costEstimate": {"currencyCode": "USD", "events":
         [{"dimensionId": "gs1q", "dimensionName": "1Q Gate Shot", "measureUnit": "1q
         gate shot", "amountBilled": 0.0, "amountConsumed": 0.0, "unitPrice": 0.0},
@@ -543,7 +543,7 @@ interactions:
         [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1837'
+      - '1839'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -557,25 +557,25 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-1deba31a-89d7-11ec-b297-1860247f69ed.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-4c923b16-8f52-11ec-8732-3c7d0a1d68ec.input.json",
         "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 500}, "providerId":
         "ionq", "target": "ionq.simulator", "metadata": {"qiskit": "True", "name":
         "Qiskit Sample - 3-qubit GHZ circuit", "num_qubits": "4", "meas_map": "[0,
         1, 2]"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "ionq.quantum-results.v1", "outputDataUri":
-        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-1deba31a-89d7-11ec-b297-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:56.3668507+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:58.8Z", "endExecutionTime": "2022-02-09T18:35:58.813Z",
+        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-4c923b16-8f52-11ec-8732-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T18:00:19.1015971+00:00", "beginExecutionTime":
+        "2022-02-16T18:00:22.352Z", "endExecutionTime": "2022-02-16T18:00:22.365Z",
         "cancellationTime": null, "costEstimate": {"currencyCode": "USD", "events":
         [{"dimensionId": "gs1q", "dimensionName": "1Q Gate Shot", "measureUnit": "1q
         gate shot", "amountBilled": 0.0, "amountConsumed": 0.0, "unitPrice": 0.0},
@@ -585,7 +585,7 @@ interactions:
         [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1837'
+      - '1839'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -599,25 +599,25 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-1deba31a-89d7-11ec-b297-1860247f69ed.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-4c923b16-8f52-11ec-8732-3c7d0a1d68ec.input.json",
         "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 500}, "providerId":
         "ionq", "target": "ionq.simulator", "metadata": {"qiskit": "True", "name":
         "Qiskit Sample - 3-qubit GHZ circuit", "num_qubits": "4", "meas_map": "[0,
         1, 2]"}, "name": "Qiskit Sample - 3-qubit GHZ circuit", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "ionq.quantum-results.v1", "outputDataUri":
-        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-1deba31a-89d7-11ec-b297-1860247f69ed.output.json",
-        "creationTime": "2022-02-09T18:35:56.3668507+00:00", "beginExecutionTime":
-        "2022-02-09T18:35:58.8Z", "endExecutionTime": "2022-02-09T18:35:58.813Z",
+        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-4c923b16-8f52-11ec-8732-3c7d0a1d68ec.output.json",
+        "creationTime": "2022-02-16T18:00:19.1015971+00:00", "beginExecutionTime":
+        "2022-02-16T18:00:22.352Z", "endExecutionTime": "2022-02-16T18:00:22.365Z",
         "cancellationTime": null, "costEstimate": {"currencyCode": "USD", "events":
         [{"dimensionId": "gs1q", "dimensionName": "1Q Gate Shot", "measureUnit": "1q
         gate shot", "amountBilled": 0.0, "amountConsumed": 0.0, "unitPrice": 0.0},
@@ -627,7 +627,7 @@ interactions:
         [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1837'
+      - '1839'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -641,22 +641,22 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Wed, 09 Feb 2022 18:36:01 GMT
+      - Wed, 16 Feb 2022 18:00:26 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
       - '2020-10-02'
     method: GET
-    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-1deba31a-89d7-11ec-b297-1860247f69ed.output.json
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DQiskit%2BSample%2B-%2B3-qubit%2BGHZ%2Bcircuit-4c923b16-8f52-11ec-8732-3c7d0a1d68ec.output.json
   response:
     body:
-      string: '{"duration": 13207753, "histogram": {"0": 0.25, "7": 0.25, "8": 0.25,
+      string: '{"duration": 12539122, "histogram": {"0": 0.25, "7": 0.25, "8": 0.25,
         "15": 0.25}, "access_token": "fake_token"}'
     headers:
       accept-ranges:
@@ -668,11 +668,11 @@ interactions:
       content-type:
       - application/json
       x-ms-blob-content-md5:
-      - ASSZ7nHjfU/g+J9yc1LIdg==
+      - MQ8mPTKYZMGoW2IhmnliEw==
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 09 Feb 2022 18:35:56 GMT
+      - Wed, 16 Feb 2022 18:00:19 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:

--- a/azure-quantum/tests/unit/test_qiskit.py
+++ b/azure-quantum/tests/unit/test_qiskit.py
@@ -162,7 +162,7 @@ class TestQiskit(QuantumTestBase):
             circuit = self._3_qubit_ghz()
             qiskit_job = backend.run(
                 circuit=circuit,
-                num_shots=100
+                shots=100
             )
 
             # Make sure the job is completed before fetching the results
@@ -190,24 +190,24 @@ class TestQiskit(QuantumTestBase):
         provider = AzureQuantumProvider(workspace=workspace)
         assert "azure-quantum-qiskit" in provider._workspace.user_agent
         backend = provider.get_backend("honeywell.hqs-lt-s1-apival")
-        cost = backend.estimate_cost(circuit, count=100e3)
+        cost = backend.estimate_cost(circuit, shots=100e3)
         assert cost.estimated_total == 0.0
 
         backend = provider.get_backend("honeywell.hqs-lt-s1")
-        cost = backend.estimate_cost(circuit, count=100e3)
+        cost = backend.estimate_cost(circuit, shots=100e3)
         assert cost.estimated_total == 745.0
 
     @pytest.mark.honeywell
     @pytest.mark.live_test
     def test_plugins_submit_qiskit_to_honeywell(self):
         circuit = self._3_qubit_ghz()
-        self._test_qiskit_submit_honeywell(circuit=circuit, num_shots=None)
+        self._test_qiskit_submit_honeywell(circuit=circuit, shots=None)
 
     @pytest.mark.honeywell
     @pytest.mark.live_test
     def test_plugins_submit_qiskit_circuit_as_list_to_honeywell(self):
         circuit = self._3_qubit_ghz()
-        self._test_qiskit_submit_honeywell(circuit=[circuit], num_shots=None)
+        self._test_qiskit_submit_honeywell(circuit=[circuit], shots=None)
 
     @pytest.mark.ionq
     @pytest.mark.live_test
@@ -227,7 +227,7 @@ class TestQiskit(QuantumTestBase):
             )
         assert str(exc.value) == "Multi-experiment jobs are not supported!"
 
-    def _test_qiskit_submit_honeywell(self, circuit, num_shots):
+    def _test_qiskit_submit_honeywell(self, circuit, shots):
 
         with unittest.mock.patch.object(
             Job,
@@ -240,10 +240,16 @@ class TestQiskit(QuantumTestBase):
             assert "honeywell.hqs-lt-s1-apival" in backend.backend_names
             assert backend.backend_names[0] in [t.name for t in workspace.get_targets(provider_id="honeywell")]
 
-            qiskit_job = backend.run(
-                circuit=circuit,
-                num_shots=num_shots
-            )
+            if shots is None:
+                qiskit_job = backend.run(
+                    circuit=circuit
+                )
+
+            else:
+                qiskit_job = backend.run(
+                    circuit=circuit,
+                    shots=shots
+                )
 
             # Make sure the job is completed before fetching the results
             self._qiskit_wait_to_complete(qiskit_job, provider)

--- a/azure-quantum/tests/unit/test_qiskit.py
+++ b/azure-quantum/tests/unit/test_qiskit.py
@@ -174,8 +174,8 @@ class TestQiskit(QuantumTestBase):
                 result = fetched_job.result()
                 assert result.data() == {
                     'counts': {
-                        '000': 250,
-                        '111': 250
+                        '000': 50,
+                        '111': 50
                     },
                     'probabilities': {
                         '000': 0.5,


### PR DESCRIPTION
`backend.run` and `backend.estimate_cost` should take `shots` as input argument; for the Honeywell backend, this is currently `count`.
This PR changes the input argument to `shots` and adds a deprecation warning for `count`.