### PR TITLE
Missed Rigetti from live tests filter

### DIFF
--- a/azure-quantum/tests.live/Run.ps1
+++ b/azure-quantum/tests.live/Run.ps1
@@ -48,6 +48,9 @@ function PyTestMarkExpr() {
     if ($AzureQuantumCapabilities -notcontains "submit.fpga") {
         $MarkExpr += " and not fpga"
     }
+    if ($AzureQuantumCapabilities -notcontains "submit.rigetti") {
+        $MarkExpr += " and not rigetti"
+    }
 
     return $MarkExpr
 }

--- a/azure-quantum/tests.live/Run.ps1
+++ b/azure-quantum/tests.live/Run.ps1
@@ -10,6 +10,9 @@ param (
   [bool] $SkipInstall
 )
 
+# For debug, print all relevant environment variables:
+Get-ChildItem env:AZURE*, env:*VERSION, env:*OUTDIR | Format-Table | Out-String | Write-Host
+
 $PackageDir = Split-Path -parent $PSScriptRoot;
 $PackageName = $PackageDir | Split-Path -Leaf;
 $RootDir = Split-Path -parent $PackageDir;
@@ -20,9 +23,6 @@ if ($True -eq $SkipInstall) {
 } else {
     & (Join-Path $PSScriptRoot Install-Artifacts.ps1)
 }
-
-# For debug, print all relevant environment variables:
-Get-ChildItem env:AZURE*, env:*VERSION, env:*OUTDIR | Format-Table | Out-String | Write-Host
 
 # Activate env
 $EnvName = GetEnvName -PackageName $PackageName

--- a/azure-quantum/tests.live/Run.ps1
+++ b/azure-quantum/tests.live/Run.ps1
@@ -21,6 +21,9 @@ if ($True -eq $SkipInstall) {
     & (Join-Path $PSScriptRoot Install-Artifacts.ps1)
 }
 
+# For debug, print all relevant environment variables:
+Get-ChildItem env:AZURE*, env:*VERSION, env:*OUTDIR | Format-Table | Out-String | Write-Host
+
 # Activate env
 $EnvName = GetEnvName -PackageName $PackageName
 Use-CondaEnv $EnvName


### PR DESCRIPTION
We have a mechanism to select which providers are run on Live tests, as not all providers are available on all locations/workspaces.
The new Rigetti tests had the correct tags to filter them out, but were not in the script that selects the flag based on envrionment variables. This is a quick fix for that.