### PR TITLE
Fix version of jupyter_client to match qdk

### DIFF
--- a/qdk/environment.yml
+++ b/qdk/environment.yml
@@ -16,3 +16,5 @@ dependencies:
   - pip:
     - basis_set_exchange
     - jupyter_jsmol
+    - jupyter_client<7.0
+    - pyzmq<20.0.0


### PR DESCRIPTION
Conda install has started to fail on e2e due to a missmatch in the jupyter_client