### PR TITLE
Decouple Quantinuum tests from Honeywell.

### DIFF
--- a/azure-quantum/pytest.ini
+++ b/azure-quantum/pytest.ini
@@ -9,4 +9,5 @@ markers =
     toshiba: mark a test as requiring access to toshiba.
     qio: mark a test as requiring access to qio targets.
     fpga: mark a test as requiring access to fpga targets.
+    quantinuum: mark a test as requiring access to quantinuum.
     rigetti: mark a test as requiring access to Rigetti targets.

--- a/azure-quantum/tests.live/Run.ps1
+++ b/azure-quantum/tests.live/Run.ps1
@@ -54,6 +54,9 @@ function PyTestMarkExpr() {
     if ($AzureQuantumCapabilities -notcontains "submit.rigetti") {
         $MarkExpr += " and not rigetti"
     }
+    if ($AzureQuantumCapabilities -notcontains "submit.quantinuum") {
+        $MarkExpr += " and not quantinuum"
+    }
 
     return $MarkExpr
 }

--- a/azure-quantum/tests/unit/test_cirq.py
+++ b/azure-quantum/tests/unit/test_cirq.py
@@ -61,6 +61,7 @@ class TestCirq(QuantumTestBase):
             assert app_id in service._workspace.user_agent
             assert "-azure-quantum-cirq" in service._workspace.user_agent
 
+    @pytest.mark.quantinuum
     @pytest.mark.honeywell
     @pytest.mark.ionq
     @pytest.mark.live_test
@@ -73,8 +74,7 @@ class TestCirq(QuantumTestBase):
         assert all([isinstance(t, Target) for t in targets])
         assert "honeywell.hqs-lt-s1-apival" in target_names
         assert "ionq.simulator" in target_names
-        if self.get_test_quantinuum_enabled():
-            assert "quantinuum.hqs-lt-s1-apival" in target_names
+        assert "quantinuum.hqs-lt-s1-apival" in target_names
 
     def test_plugins_estimate_cost_cirq_ionq(self):
         workspace = self.create_workspace()
@@ -271,8 +271,7 @@ class TestCirq(QuantumTestBase):
                     assert result.measurements["q0"].sum() == result.measurements["q1"].sum()
                     assert result.measurements["q1"].sum() == result.measurements["q2"].sum()
 
-    @pytest.mark.honeywell
+    @pytest.mark.quantinuum
     @pytest.mark.live_test
     def test_plugins_quantinuum_cirq(self):
-        if self.get_test_quantinuum_enabled():
-            self.test_plugins_honeywell_cirq(provider_id="quantinuum")
+        self.test_plugins_honeywell_cirq(provider_id="quantinuum")

--- a/azure-quantum/tests/unit/test_qiskit.py
+++ b/azure-quantum/tests/unit/test_qiskit.py
@@ -300,25 +300,21 @@ class TestQiskit(QuantumTestBase):
                 assert result.data()["counts"] == {'000': 500}
                 assert result.data()["probabilities"] == {'000': 1.0}
 
-    @pytest.mark.honeywell
+    @pytest.mark.quantinuum
     def test_plugins_estimate_cost_qiskit_quantinuum(self):
-        if self.get_test_quantinuum_enabled():
-            self.test_plugins_estimate_cost_qiskit_honeywell(provider_id="quantinuum")
+        self.test_plugins_estimate_cost_qiskit_honeywell(provider_id="quantinuum")
 
-    @pytest.mark.honeywell
+    @pytest.mark.quantinuum
     @pytest.mark.live_test
     def test_plugins_submit_qiskit_to_quantinuum(self):
-        if self.get_test_quantinuum_enabled():
-            self.test_plugins_submit_qiskit_to_honeywell(provider_id="quantinuum")
+        self.test_plugins_submit_qiskit_to_honeywell(provider_id="quantinuum")
 
-    @pytest.mark.honeywell
+    @pytest.mark.quantinuum
     @pytest.mark.live_test
     def test_plugins_submit_qiskit_circuit_as_list_to_quantinuum(self):
-        if self.get_test_quantinuum_enabled():
-            self.test_plugins_submit_qiskit_circuit_as_list_to_honeywell(provider_id="quantinuum")
+        self.test_plugins_submit_qiskit_circuit_as_list_to_honeywell(provider_id="quantinuum")
 
-    @pytest.mark.ionq
+    @pytest.mark.quantinuum
     @pytest.mark.live_test
     def test_plugins_submit_qiskit_multi_circuit_experiment_to_quantinuum(self):
-        if self.get_test_quantinuum_enabled():
-            self.test_plugins_submit_qiskit_multi_circuit_experiment_to_honeywell(provider_id="quantinuum")
+        self.test_plugins_submit_qiskit_multi_circuit_experiment_to_honeywell(provider_id="quantinuum")

--- a/azure-quantum/tests/unit/test_quantinuum.py
+++ b/azure-quantum/tests/unit/test_quantinuum.py
@@ -1,0 +1,116 @@
+#!/bin/env python
+# -*- coding: utf-8 -*-
+##
+# test_qiskit.py: Tests for Qiskit plugin
+##
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+##
+import unittest
+import warnings
+import pytest
+
+import numpy as np
+
+from azure.core.exceptions import HttpResponseError
+from azure.quantum.job.job import Job
+from azure.quantum._client.models import CostEstimate, UsageEvent
+from azure.quantum.target import Quantinuum
+
+from common import QuantumTestBase, ZERO_UID
+
+
+class TestQuantinuum(QuantumTestBase):
+    mock_create_job_id_name = "create_job_id"
+    create_job_id = Job.create_job_id
+
+    def get_test_job_id(self):
+        return ZERO_UID if self.is_playback \
+               else Job.create_job_id()
+
+    def _teleport(self):
+        return """OPENQASM 2.0;
+        include "qelib1.inc";
+
+        qreg q[3];
+        creg c0[1];
+        creg c1[1];
+        creg c2[1];
+
+        h q[0];
+        cx q[0], q[1];
+        x q[2];
+        h q[2];
+        cx q[2], q[0];
+        h q[2];
+        measure q[0] -> c0[0];
+        if (c0==1) x q[1];
+        measure q[2] -> c1[0];
+        if (c1==1) z q[1];
+        h q[1];
+        measure q[1] -> c2[0];
+        """
+
+    @pytest.mark.quantinuum
+    def test_job_estimate_cost_quantinuum(self):
+        with unittest.mock.patch.object(
+            Job,
+            self.mock_create_job_id_name,
+            return_value=self.get_test_job_id(),
+        ):
+            workspace = self.create_workspace()
+            circuit = self._teleport()
+
+            target = Quantinuum(workspace=workspace, name="quantinuum.hqs-lt-s1-apival")
+
+            cost = target.estimate_cost(circuit, num_shots=100e3)
+            assert cost.estimated_total == 0.0
+
+            target = Quantinuum(workspace=workspace, name="quantinuum.hqs-lt-s1")
+
+            cost = target.estimate_cost(circuit, num_shots=100e3)
+            assert cost.estimated_total == 845.0
+
+    @pytest.mark.quantinuum
+    @pytest.mark.live_test
+    def test_job_submit_quantinuum(self):
+        with unittest.mock.patch.object(
+            Job,
+            self.mock_create_job_id_name,
+            return_value=self.get_test_job_id(),
+        ):
+            workspace = self.create_workspace()
+            circuit = self._teleport()
+            target = Quantinuum(workspace=workspace)
+            try:
+                job = target.submit(circuit)
+            except HttpResponseError as e:
+                if "InvalidJobDefinition" not in e.message \
+                and "The provider specified does not exist" not in e.message:
+                    raise(e)
+                warnings.warn(e.message)
+            else:
+                # Make sure the job is completed before fetching the results
+                # playback currently does not work for repeated calls
+                if not self.is_playback:
+                    self.pause_recording()
+                    self.assertEqual(False, job.has_completed())
+                    try:
+                        # Set a timeout for recording
+                        job.wait_until_completed(timeout_secs=60)
+                    except TimeoutError:
+                        warnings.warn("Quantinuum execution exceeded timeout. Skipping fetching results.")
+                    else:
+                        # Check if job succeeded
+                        self.assertEqual(True, job.has_completed())
+                        assert job.details.status == "Succeeded"
+                    self.resume_recording()
+
+                job = workspace.get_job(job.id)
+                self.assertEqual(True, job.has_completed())
+
+                if job.has_completed():
+                    results = job.get_results()
+                    assert results["c0"] == ["0"]
+                    assert results["c1"] == ["0"]
+

--- a/azure-quantum/tests/unit/test_target.py
+++ b/azure-quantum/tests/unit/test_target.py
@@ -1,3 +1,11 @@
+#!/bin/env python
+# -*- coding: utf-8 -*-
+##
+# test_qiskit.py: Tests for Qiskit plugin
+##
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+##
 import unittest
 import warnings
 import pytest
@@ -191,11 +199,6 @@ class TestHoneywell(QuantumTestBase):
             assert cost.estimated_total == 845.0
 
     @pytest.mark.honeywell
-    def test_job_estimate_cost_quantinuum(self):
-        if self.get_test_quantinuum_enabled():
-            self.test_job_estimate_cost_honeywell(provider_id="quantinuum")
-
-    @pytest.mark.honeywell
     @pytest.mark.live_test
     def test_job_submit_honeywell(self, provider_id="honeywell"):
         with unittest.mock.patch.object(
@@ -239,7 +242,3 @@ class TestHoneywell(QuantumTestBase):
                     assert results["c0"] == ["0"]
                     assert results["c1"] == ["0"]
 
-    @pytest.mark.honeywell
-    def test_job_submit_quantinuum(self):
-        if self.get_test_quantinuum_enabled():
-            self.test_job_submit_honeywell(provider_id="quantinuum")


### PR DESCRIPTION
Quantinuum is now the official name for what used to be Honeywell.
The tests, however, were still using the Honeywell mark. 
These changes create a new quantinuum mark, and moves Quantinuum tests to a different file so they are easier to manage.
