### PR TITLE
Prevent race condition by enforcing concurrency cancellation on issue…

### DIFF
--- a/.github/workflows/gh-sync.yml
+++ b/.github/workflows/gh-sync.yml
@@ -5,6 +5,10 @@ on:
     types: [closed, edited, deleted, reopened, assigned, unassigned, labeled, unlabeled]
   issue_comment:
 
+concurrency: 
+  group: ${{ github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
   sync-issues:
     name: Run gh-sync from GitHub action


### PR DESCRIPTION
There was a race condition in gh-sync when multiple events happened intermittent with adding the "tracking" label. Adding new concurrency settings to prevent more than one event from firing at once.