### PR TITLE
Job attachments

### DIFF
--- a/azure-quantum/azure/quantum/aio/job/base_job.py
+++ b/azure-quantum/azure/quantum/aio/job/base_job.py
@@ -252,7 +252,7 @@ class BaseJob(SyncBaseJob):
             blob_client = BlobClient.from_blob_url(
                 blob_uri
             )
-            blob_uri = self.workspace._get_linked_storage_sas_uri(
+            blob_uri = await self.workspace._get_linked_storage_sas_uri(
                 blob_client.container_name, blob_client.blob_name
             )
             payload = await download_blob(blob_uri)
@@ -262,3 +262,65 @@ class BaseJob(SyncBaseJob):
             payload = await download_blob(blob_uri)
 
         return payload
+
+    async def upload_attachment(
+        self,
+        blob_name: str,
+        data: bytes,
+        container_uri: str = None,
+        **kwargs
+    ) -> str:
+        """Uploads an attachment to the job's container file. Attachment's are identified by name.
+        Uploading to an existing attachment overrides its previous content.
+
+        :param name: Attachment name
+        :type name: str
+        :param data: Attachment data in binary format
+        :type input_data: bytes
+        :param container_uri: Container URI, defaults to the job's linked container.
+        :type container_uri: str, Optional
+
+        :return: Uploaded data URI
+        :rtype: str
+        """
+
+        # Use Job's default container if not specified
+        if container_uri is None:
+            container_uri = await self.workspace.get_container_uri(job_id=self.id)
+
+        uploaded_blob_uri = await cls.upload_input_data(
+            container_uri = container_uri,
+            blob_name = name,
+            input_data = data,
+            **kwargs
+        )
+        return uploaded_blob_uri
+
+    async def download_attachment(
+        self,
+        name: str,
+        container_uri: str = None
+    ):
+        """ Downloads an attachment from job's container in Azure Storage. Attachments are blobs of data
+            created as part of the Job's execution, or they can be created by uploading directly from Python
+            using the upload_attachment method.
+            
+        :param name: Attachment name
+        :type name: str
+        :param container_uri: Container URI, defaults to the job's linked container.
+        :type container_uri: str, Optional
+
+        :return: Attachment data
+        :rtype: bytes
+        """
+        # Use Job's default container if not specified
+        if container_uri is None:
+            container_uri = await self.workspace.get_container_uri(job_id=self.id)
+        
+        container_client = ContainerClient.from_container_url(container_uri)
+        blob_client = container_client.get_blob_client(name)
+        response = await (await blob_client.download_blob()).readall()
+        await blob_client.close()
+
+        return response
+

--- a/azure-quantum/azure/quantum/job/job.py
+++ b/azure-quantum/azure/quantum/job/job.py
@@ -122,3 +122,18 @@ class Job(BaseJob, FilteredJob):
         payload = self.download_data(self.details.output_data_uri)
         results = json.loads(payload.decode("utf8"))
         return results
+
+    def download_blob(self, blob_name):
+        """ Downloads a blob from Azure Storage. The blob is downloaded from the default container associated with this job."""
+        from azure.quantum.storage import ContainerClient
+
+        # Create container if it does not yet exist
+        container_uri = self.workspace.get_container_uri(job_id=self.id)
+        logger.debug(f"Container URI: {container_uri}")
+        
+        container_client = ContainerClient.from_container_url(container_uri)
+        blob_client = container_client.get_blob_client(blob_name)
+        response = blob_client.download_blob().readall()
+        return response
+
+

--- a/azure-quantum/azure/quantum/job/job.py
+++ b/azure-quantum/azure/quantum/job/job.py
@@ -96,15 +96,14 @@ class Job(BaseJob, FilteredJob):
                 else poll_wait * 1.5
             )
 
-    def get_results(self, timeout_secs: float = DEFAULT_TIMEOUT) -> dict:
+    def get_results(self, timeout_secs: float = DEFAULT_TIMEOUT):
         """Get job results by downloading the results blob from the
         storage container linked via the workspace.
 
         :param timeout_secs: Timeout in seconds, defaults to 300
         :type timeout_secs: int
-        :raises RuntimeError: [description]
-        :return: [description]
-        :rtype: dict
+        :raises RuntimeError: Raises RuntimeError if job execution failed
+        :return: Results dictionary with histogram shots, or raw results if not a json object.
         """
         if self.results is not None:
             return self.results
@@ -120,6 +119,8 @@ class Job(BaseJob, FilteredJob):
             )
 
         payload = self.download_data(self.details.output_data_uri)
-        results = json.loads(payload.decode("utf8"))
-        return results
-
+        payload = payload.decode("utf8")
+        try:
+            return json.loads(payload)
+        except json.JSONDecodeError:
+            return payload

--- a/azure-quantum/azure/quantum/job/job.py
+++ b/azure-quantum/azure/quantum/job/job.py
@@ -123,17 +123,3 @@ class Job(BaseJob, FilteredJob):
         results = json.loads(payload.decode("utf8"))
         return results
 
-    def download_blob(self, blob_name):
-        """ Downloads a blob from Azure Storage. The blob is downloaded from the default container associated with this job."""
-        from azure.quantum.storage import ContainerClient
-
-        # Create container if it does not yet exist
-        container_uri = self.workspace.get_container_uri(job_id=self.id)
-        logger.debug(f"Container URI: {container_uri}")
-        
-        container_client = ContainerClient.from_container_url(container_uri)
-        blob_client = container_client.get_blob_client(blob_name)
-        response = blob_client.download_blob().readall()
-        return response
-
-

--- a/azure-quantum/tests/unit/recordings/test_job_attachments.yaml
+++ b/azure-quantum/tests/unit/recordings/test_job_attachments.yaml
@@ -1,0 +1,839 @@
+interactions:
+- request:
+    body: client_id=PLACEHOLDER&grant_type=client_credentials&client_info=1&client_secret=PLACEHOLDER&scope=https%3A%2F%2Fquantum.microsoft.com%2F.default
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '192'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - azsdk-python-identity/1.6.0 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+      x-client-cpu:
+      - x64
+      x-client-current-telemetry:
+      - 4|730,0|
+      x-client-os:
+      - win32
+      x-client-sku:
+      - MSAL.Python
+      x-client-ver:
+      - 1.13.0
+    method: POST
+    uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 86399, "ext_expires_in": 86399,
+        "refresh_in": 43199, "access_token": "fake_token"}'
+    headers:
+      content-length:
+      - '1741'
+      content-type:
+      - application/json; charset=utf-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: 'b''{"containerName": "job-00000000-0000-0000-0000-000000000000"}'''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '61'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - testapp azsdk-python-quantum/0.0.0.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
+  response:
+    body:
+      string: '{"sasUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "access_token": "fake_token"}'
+    headers:
+      content-length:
+      - '209'
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-storage-blob/12.8.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Fri, 29 Apr 2022 17:34:56 GMT
+      x-ms-version:
+      - '2020-06-12'
+    method: GET
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
+        specified container does not exist.\nRequestId:4060c64a-401e-007c-1aef-5bb112000000\nTime:2022-04-29T17:34:56.6904836Z</Message></Error>"
+    headers:
+      content-length:
+      - '225'
+      content-type:
+      - application/xml
+      x-ms-version:
+      - '2020-06-12'
+    status:
+      code: 404
+      message: The specified container does not exist.
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-storage-blob/12.8.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Fri, 29 Apr 2022 17:34:56 GMT
+      x-ms-version:
+      - '2020-06-12'
+    method: PUT
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      x-ms-version:
+      - '2020-06-12'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-storage-blob/12.8.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Fri, 29 Apr 2022 17:34:56 GMT
+      x-ms-version:
+      - '2020-06-12'
+    method: GET
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-version:
+      - '2020-06-12'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: b'\x1f\x8b\x08\x00\xbf!lb\x02\xffU\xcc\xc1\n\xc3 \x0c\x06\xe0W\x91\x9c\xdbQ\xedv\xd8^e\x94bm\xc6:PKM\x0bC|\xf7\x05{p\x9e\x8c\xff\x97?\x11,\x92\x9e5ix\x88\x08N[\xe4\x01\x08\x03\x8d\x1f?\x8d\x9aH\x9b\xb7EG\x01R#\xc0x\x86\xd7\xee\x0c-\xde\xe5\xca\x81[8g\x90\x97\x0ex\x87\xbek>\xb2\xee\x93\xcf\x7f\xdcl\xe0\xe0\x19\xc1\xf0\xd3\xf6\x9c-sNd#\xba\x81\xef\x9er+\xa0*\xb8W
+      \x0b\xa8\x02}\xd5h\xaf\x95\xfcUjPC\x1aR\xfa\x01\xcc\xacx\xfb\x06\x01\x00\x00'
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '155'
+      Content-Type:
+      - application/octet-stream
+      User-Agent:
+      - azsdk-python-storage-blob/12.8.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Fri, 29 Apr 2022 17:34:56 GMT
+      x-ms-version:
+      - '2020-06-12'
+    method: PUT
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      x-ms-version:
+      - '2020-06-12'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: 'b''{"id": "00000000-0000-0000-0000-000000000000", "name": "test_job_attachments",
+      "containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+      "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData",
+      "inputDataFormat": "microsoft.qio.v2", "inputParams": {"params": {}}, "providerId":
+      "Microsoft", "target": "microsoft.simulatedannealing-parameterfree.cpu", "outputDataFormat":
+      "microsoft.qio-results.v2"}'''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '608'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - testapp azsdk-python-quantum/0.0.0.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+    method: PUT
+    uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
+  response:
+    body:
+      string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData",
+        "inputDataFormat": "microsoft.qio.v2", "inputParams": {"params": {}}, "providerId":
+        "microsoft", "target": "microsoft.simulatedannealing-parameterfree.cpu", "metadata":
+        null, "name": "test_job_attachments", "id": "00000000-0000-0000-0000-000000000000",
+        "status": "Waiting", "outputDataFormat": "microsoft.qio-results.v2", "outputDataUri":
+        "https://e2etests.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "creationTime": "2022-04-29T17:34:57.254047+00:00", "beginExecutionTime":
+        null, "endExecutionTime": null, "cancellationTime": null, "costEstimate":
+        null, "errorData": null, "isCancelling": false, "tags": [], "access_token":
+        "fake_token"}'
+    headers:
+      content-length:
+      - '1047'
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: 'b''{"containerName": "job-00000000-0000-0000-0000-000000000000"}'''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '61'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - testapp azsdk-python-quantum/0.0.0.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
+  response:
+    body:
+      string: '{"sasUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "access_token": "fake_token"}'
+    headers:
+      content-length:
+      - '207'
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-storage-blob/12.8.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Fri, 29 Apr 2022 17:34:57 GMT
+      x-ms-version:
+      - '2020-06-12'
+    method: GET
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-version:
+      - '2020-06-12'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-storage-blob/12.8.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Fri, 29 Apr 2022 17:34:57 GMT
+      x-ms-version:
+      - '2020-06-12'
+    method: GET
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-version:
+      - '2020-06-12'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: b'Some data 1'
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '11'
+      Content-Type:
+      - application/octet-stream
+      User-Agent:
+      - azsdk-python-storage-blob/12.8.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Fri, 29 Apr 2022 17:34:57 GMT
+      x-ms-version:
+      - '2020-06-12'
+    method: PUT
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/test-1?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      x-ms-version:
+      - '2020-06-12'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: 'b''{"containerName": "job-00000000-0000-0000-0000-000000000000"}'''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '61'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - testapp azsdk-python-quantum/0.0.0.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
+  response:
+    body:
+      string: '{"sasUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "access_token": "fake_token"}'
+    headers:
+      content-length:
+      - '207'
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-storage-blob/12.8.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Fri, 29 Apr 2022 17:34:57 GMT
+      x-ms-version:
+      - '2020-06-12'
+    method: GET
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-version:
+      - '2020-06-12'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-storage-blob/12.8.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Fri, 29 Apr 2022 17:34:57 GMT
+      x-ms-version:
+      - '2020-06-12'
+    method: GET
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-version:
+      - '2020-06-12'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: b'Some other random data 2'
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '24'
+      Content-Type:
+      - application/octet-stream
+      User-Agent:
+      - azsdk-python-storage-blob/12.8.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Fri, 29 Apr 2022 17:34:58 GMT
+      x-ms-version:
+      - '2020-06-12'
+    method: PUT
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/test-2?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      x-ms-version:
+      - '2020-06-12'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: 'b''{"containerName": "job-00000000-0000-0000-0000-000000000000"}'''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '61'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - testapp azsdk-python-quantum/0.0.0.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
+  response:
+    body:
+      string: '{"sasUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "access_token": "fake_token"}'
+    headers:
+      content-length:
+      - '209'
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-storage-blob/12.8.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Fri, 29 Apr 2022 17:34:58 GMT
+      x-ms-version:
+      - '2020-06-12'
+    method: GET
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-version:
+      - '2020-06-12'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-storage-blob/12.8.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Fri, 29 Apr 2022 17:34:58 GMT
+      x-ms-range:
+      - bytes=0-33554431
+      x-ms-version:
+      - '2020-06-12'
+    method: GET
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/test-1?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+  response:
+    body:
+      string: Some data 1
+    headers:
+      accept-ranges:
+      - bytes
+      content-length:
+      - '11'
+      content-range:
+      - bytes 0-10/11
+      content-type:
+      - application/json
+      x-ms-blob-content-md5:
+      - QnAClf+ua713+IKfs7VTRw==
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-creation-time:
+      - Fri, 29 Apr 2022 17:34:57 GMT
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-06-12'
+    status:
+      code: 206
+      message: Partial Content
+- request:
+    body: 'b''{"containerName": "job-00000000-0000-0000-0000-000000000000"}'''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '61'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - testapp azsdk-python-quantum/0.0.0.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
+  response:
+    body:
+      string: '{"sasUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "access_token": "fake_token"}'
+    headers:
+      content-length:
+      - '209'
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-storage-blob/12.8.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Fri, 29 Apr 2022 17:34:58 GMT
+      x-ms-version:
+      - '2020-06-12'
+    method: GET
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-version:
+      - '2020-06-12'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-storage-blob/12.8.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Fri, 29 Apr 2022 17:34:58 GMT
+      x-ms-range:
+      - bytes=0-33554431
+      x-ms-version:
+      - '2020-06-12'
+    method: GET
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/test-2?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+  response:
+    body:
+      string: Some other random data 2
+    headers:
+      accept-ranges:
+      - bytes
+      content-length:
+      - '24'
+      content-range:
+      - bytes 0-23/24
+      content-type:
+      - application/json
+      x-ms-blob-content-md5:
+      - SEhuUjLQu3v65oxzR1n73Q==
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-creation-time:
+      - Fri, 29 Apr 2022 17:34:58 GMT
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-06-12'
+    status:
+      code: 206
+      message: Partial Content
+- request:
+    body: 'b''{"containerName": "job-00000000-0000-0000-0000-000000000000"}'''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '61'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - testapp azsdk-python-quantum/0.0.0.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
+  response:
+    body:
+      string: '{"sasUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "access_token": "fake_token"}'
+    headers:
+      content-length:
+      - '209'
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-storage-blob/12.8.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Fri, 29 Apr 2022 17:34:58 GMT
+      x-ms-version:
+      - '2020-06-12'
+    method: GET
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-version:
+      - '2020-06-12'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-storage-blob/12.8.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Fri, 29 Apr 2022 17:34:59 GMT
+      x-ms-range:
+      - bytes=0-33554431
+      x-ms-version:
+      - '2020-06-12'
+    method: GET
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+  response:
+    body:
+      string: '{"metadata": {"name": "test_job_attachments"}, "cost_function": {"version":
+        "1.0", "type": "pubo", "terms": [{"c": -3, "ids": [1, 0]}, {"c": 5, "ids":
+        [2, 0]}, {"c": 9, "ids": [2, 1]}, {"c": 2, "ids": [3, 0]}, {"c": -4, "ids":
+        [3, 1]}, {"c": 4, "ids": [3, 2]}]}, "access_token": "fake_token"}'
+    headers:
+      accept-ranges:
+      - bytes
+      content-length:
+      - '262'
+      content-range:
+      - bytes 0-154/155
+      content-type:
+      - application/json
+      x-ms-blob-content-md5:
+      - xyB/cKZt4qgHFlw8XmYzGQ==
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-creation-time:
+      - Fri, 29 Apr 2022 17:34:56 GMT
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-06-12'
+    status:
+      code: 206
+      message: Partial Content
+version: 1

--- a/azure-quantum/tests/unit/recordings/test_problem_upload_download.yaml
+++ b/azure-quantum/tests/unit/recordings/test_problem_upload_download.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: client_id=PLACEHOLDER&grant_type=client_credentials&client_info=1&client_secret=PLACEHOLDER&claims=PLACEHOLDER&scope=https%3A%2F%2Fquantum.microsoft.com%2F.default
+    body: client_id=PLACEHOLDER&grant_type=client_credentials&client_info=1&client_secret=PLACEHOLDER&scope=https%3A%2F%2Fquantum.microsoft.com%2F.default
     headers:
       Accept:
       - application/json
@@ -9,11 +9,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '287'
+      - '192'
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - azsdk-python-identity/1.7.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-identity/1.6.0 Python/3.7.8 (Windows-10-10.0.19041-SP0)
       x-client-cpu:
       - x64
       x-client-current-telemetry:
@@ -23,7 +23,7 @@ interactions:
       x-client-sku:
       - MSAL.Python
       x-client-ver:
-      - 1.16.0
+      - 1.13.0
     method: POST
     uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
   response:
@@ -52,7 +52,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - testapp azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp azsdk-python-quantum/0.0.0.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
   response:
@@ -61,7 +61,7 @@ interactions:
         "access_token": "fake_token"}'
     headers:
       content-length:
-      - '209'
+      - '207'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -79,24 +79,24 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.8.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:00 GMT
+      - Fri, 29 Apr 2022 01:32:43 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2020-06-12'
     method: GET
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
-        specified container does not exist.\nRequestId:67326ae5-201e-008e-16e3-1d495b000000\nTime:2022-02-09T18:35:00.3988916Z</Message></Error>"
+        specified container does not exist.\nRequestId:5de53f5f-801e-0087-6569-5b0c88000000\nTime:2022-04-29T01:32:43.6090458Z</Message></Error>"
     headers:
       content-length:
       - '225'
       content-type:
       - application/xml
       x-ms-version:
-      - '2020-10-02'
+      - '2020-06-12'
     status:
       code: 404
       message: The specified container does not exist.
@@ -112,11 +112,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.8.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:00 GMT
+      - Fri, 29 Apr 2022 01:32:43 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2020-06-12'
     method: PUT
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -126,7 +126,7 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -140,11 +140,11 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.8.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:00 GMT
+      - Fri, 29 Apr 2022 01:32:43 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2020-06-12'
     method: GET
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -158,12 +158,12 @@ interactions:
       x-ms-lease-status:
       - unlocked
       x-ms-version:
-      - '2020-10-02'
+      - '2020-06-12'
     status:
       code: 200
       message: OK
 - request:
-    body: b'\x1f\x8b\x08\x00S\t\x04b\x02\xffU\x8c\xc1\n\x830\x10D\x7fE\xf6lJ\x12\xf5`o\xfd\x86\xf6V\xa5\xa4\xba-\x01\x93\x88\x89\x85"\xf9\xf7.\xf1`\x03\x0b;;og60\x18\xd4\xa8\x82\x82s\xb1\x81U\x06I\xc0\r}`Wm\xd6I\x05\x1c/\xd6\xa2\x9a\xb4}\xb3\x0e$\x974\xbce\x82Wu\xd3v\x00\xb1,`p><^\xab\x1d\x82v65}p\xf1\xbb\x06q\xe2@?\xe1;\xa7\xeey}\xbat\xe3b<\x19\xf7\r\x06Z\xac"O\x8f\xc9\x11e\xc1{\xea\xddIs\x00\x99\x816\x03\xe2\x00\xf2\x00U\x96`uF\xfe"9\x90}\xecc\xfc\x01\n,\x7fN\x1d\x01\x00\x00'
+    body: b'\x1f\x8b\x08\x008@kb\x02\xffU\xccA\x0e\x83 \x10\x05\xd0\xab\x98YK\x03\xa3Mlw=C\xbb\xab\xa6\xa1:mH\x04\x8c`\x93\xc6p\xf7\x12\\XV\x0c\xff\xcd\xfc\x154y9H/\xe1\\\xac`\xa4\xa68\xc0\x8d\x9cgW\xa5\x97Qz\x1a.\xc6\x90\x1c\x95y\xb3\x16\x90#\xf2\x1a\x1b&\x9a\nk\xde\x02\x84\xb2\x80\xde:\xffx-\xa6\xf7\xca\x9a\xd4\xf4\xa1\xd9m3\x88\x03\x87\xb8\xe3\xbfS\xea\x9e\x96\xa7M\x7f\x9a\xb5\x8b\xc1}\x85>>\xac\x8a\x99\x1aR"\xca\x82w\xb1w\x93\xe3\x0e\x98\xc1)\x03\xb1\x03\xeePe\x17\xac\xce\xe4\xef$\x07\xecB\x17\xc2\x0f\tM\xec\xa6\x1d\x01\x00\x00'
     headers:
       Accept:
       - application/xml
@@ -176,13 +176,13 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.8.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:00 GMT
+      - Fri, 29 Apr 2022 01:32:44 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2020-06-12'
     method: PUT
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -192,7 +192,7 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -211,11 +211,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '632'
+      - '630'
       Content-Type:
       - application/json
       User-Agent:
-      - testapp azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - testapp azsdk-python-quantum/0.0.0.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
     method: PUT
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
@@ -227,13 +227,44 @@ interactions:
         "metadata": null, "name": "Test-SimulatedAnnealing-\"20210101-000000\"", "id":
         "00000000-0000-0000-0000-000000000000", "status": "Waiting", "outputDataFormat":
         "microsoft.qio-results.v2", "outputDataUri": "https://e2etests.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "creationTime": "2022-02-09T18:35:00.6497055+00:00", "beginExecutionTime":
+        "creationTime": "2022-04-29T01:32:44.9275051+00:00", "beginExecutionTime":
         null, "endExecutionTime": null, "cancellationTime": null, "costEstimate":
         null, "errorData": null, "isCancelling": false, "tags": [], "access_token":
         "fake_token"}'
     headers:
       content-length:
-      - '1178'
+      - '1176'
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: 'b''{"containerName": "job-00000000-0000-0000-0000-000000000000"}'''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '61'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - testapp azsdk-python-quantum/0.0.0.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
+  response:
+    body:
+      string: '{"sasUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "access_token": "fake_token"}'
+    headers:
+      content-length:
+      - '205'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -251,15 +282,47 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
+      - azsdk-python-storage-blob/12.8.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 09 Feb 2022 18:35:00 GMT
+      - Fri, 29 Apr 2022 01:32:48 GMT
+      x-ms-version:
+      - '2020-06-12'
+    method: GET
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-version:
+      - '2020-06-12'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-storage-blob/12.8.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Fri, 29 Apr 2022 01:32:49 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
-      - '2020-10-02'
+      - '2020-06-12'
     method: GET
-    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=rcw
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: '{"metadata": {"name": "Test-SimulatedAnnealing-\"20210101-000000\""},
@@ -277,11 +340,11 @@ interactions:
       content-type:
       - application/json
       x-ms-blob-content-md5:
-      - YdbpdlaFWz1BwPHVHL+2Dg==
+      - 6PZyeZvIU8MyRtyp9aTGug==
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 09 Feb 2022 18:35:00 GMT
+      - Fri, 29 Apr 2022 01:32:44 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -289,7 +352,7 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-10-02'
+      - '2020-06-12'
     status:
       code: 206
       message: Partial Content

--- a/azure-quantum/tests/unit/recordings/test_problem_upload_download.yaml
+++ b/azure-quantum/tests/unit/recordings/test_problem_upload_download.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: client_id=PLACEHOLDER&grant_type=client_credentials&client_info=1&client_secret=PLACEHOLDER&scope=https%3A%2F%2Fquantum.microsoft.com%2F.default
+    body: client_id=PLACEHOLDER&grant_type=client_credentials&client_info=1&client_secret=PLACEHOLDER&claims=PLACEHOLDER&scope=https%3A%2F%2Fquantum.microsoft.com%2F.default
     headers:
       Accept:
       - application/json
@@ -9,11 +9,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '192'
+      - '287'
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - azsdk-python-identity/1.6.0 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-identity/1.7.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
       x-client-cpu:
       - x64
       x-client-current-telemetry:
@@ -23,7 +23,7 @@ interactions:
       x-client-sku:
       - MSAL.Python
       x-client-ver:
-      - 1.13.0
+      - 1.16.0
     method: POST
     uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
   response:
@@ -52,7 +52,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - testapp azsdk-python-quantum/0.0.0.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+      - testapp azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
     method: POST
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
   response:
@@ -61,7 +61,7 @@ interactions:
         "access_token": "fake_token"}'
     headers:
       content-length:
-      - '207'
+      - '209'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -79,24 +79,24 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.8.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 29 Apr 2022 01:32:43 GMT
+      - Wed, 09 Feb 2022 18:35:00 GMT
       x-ms-version:
-      - '2020-06-12'
+      - '2020-10-02'
     method: GET
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
-        specified container does not exist.\nRequestId:5de53f5f-801e-0087-6569-5b0c88000000\nTime:2022-04-29T01:32:43.6090458Z</Message></Error>"
+        specified container does not exist.\nRequestId:67326ae5-201e-008e-16e3-1d495b000000\nTime:2022-02-09T18:35:00.3988916Z</Message></Error>"
     headers:
       content-length:
       - '225'
       content-type:
       - application/xml
       x-ms-version:
-      - '2020-06-12'
+      - '2020-10-02'
     status:
       code: 404
       message: The specified container does not exist.
@@ -112,11 +112,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.8.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 29 Apr 2022 01:32:43 GMT
+      - Wed, 09 Feb 2022 18:35:00 GMT
       x-ms-version:
-      - '2020-06-12'
+      - '2020-10-02'
     method: PUT
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -126,7 +126,7 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-06-12'
+      - '2020-10-02'
     status:
       code: 201
       message: Created
@@ -140,11 +140,11 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.8.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 29 Apr 2022 01:32:43 GMT
+      - Wed, 09 Feb 2022 18:35:00 GMT
       x-ms-version:
-      - '2020-06-12'
+      - '2020-10-02'
     method: GET
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -158,12 +158,12 @@ interactions:
       x-ms-lease-status:
       - unlocked
       x-ms-version:
-      - '2020-06-12'
+      - '2020-10-02'
     status:
       code: 200
       message: OK
 - request:
-    body: b'\x1f\x8b\x08\x008@kb\x02\xffU\xccA\x0e\x83 \x10\x05\xd0\xab\x98YK\x03\xa3Mlw=C\xbb\xab\xa6\xa1:mH\x04\x8c`\x93\xc6p\xf7\x12\\XV\x0c\xff\xcd\xfc\x154y9H/\xe1\\\xac`\xa4\xa68\xc0\x8d\x9cgW\xa5\x97Qz\x1a.\xc6\x90\x1c\x95y\xb3\x16\x90#\xf2\x1a\x1b&\x9a\nk\xde\x02\x84\xb2\x80\xde:\xffx-\xa6\xf7\xca\x9a\xd4\xf4\xa1\xd9m3\x88\x03\x87\xb8\xe3\xbfS\xea\x9e\x96\xa7M\x7f\x9a\xb5\x8b\xc1}\x85>>\xac\x8a\x99\x1aR"\xca\x82w\xb1w\x93\xe3\x0e\x98\xc1)\x03\xb1\x03\xeePe\x17\xac\xce\xe4\xef$\x07\xecB\x17\xc2\x0f\tM\xec\xa6\x1d\x01\x00\x00'
+    body: b'\x1f\x8b\x08\x00S\t\x04b\x02\xffU\x8c\xc1\n\x830\x10D\x7fE\xf6lJ\x12\xf5`o\xfd\x86\xf6V\xa5\xa4\xba-\x01\x93\x88\x89\x85"\xf9\xf7.\xf1`\x03\x0b;;og60\x18\xd4\xa8\x82\x82s\xb1\x81U\x06I\xc0\r}`Wm\xd6I\x05\x1c/\xd6\xa2\x9a\xb4}\xb3\x0e$\x974\xbce\x82Wu\xd3v\x00\xb1,`p><^\xab\x1d\x82v65}p\xf1\xbb\x06q\xe2@?\xe1;\xa7\xeey}\xbat\xe3b<\x19\xf7\r\x06Z\xac"O\x8f\xc9\x11e\xc1{\xea\xddIs\x00\x99\x816\x03\xe2\x00\xf2\x00U\x96`uF\xfe"9\x90}\xecc\xfc\x01\n,\x7fN\x1d\x01\x00\x00'
     headers:
       Accept:
       - application/xml
@@ -176,13 +176,13 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.8.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Fri, 29 Apr 2022 01:32:44 GMT
+      - Wed, 09 Feb 2022 18:35:00 GMT
       x-ms-version:
-      - '2020-06-12'
+      - '2020-10-02'
     method: PUT
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -192,7 +192,7 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-06-12'
+      - '2020-10-02'
     status:
       code: 201
       message: Created
@@ -211,11 +211,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '630'
+      - '632'
       Content-Type:
       - application/json
       User-Agent:
-      - testapp azsdk-python-quantum/0.0.0.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+      - testapp azsdk-python-quantum/0.0.0.1 Python/3.9.5 (Windows-10-10.0.19044-SP0)
     method: PUT
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
@@ -227,44 +227,13 @@ interactions:
         "metadata": null, "name": "Test-SimulatedAnnealing-\"20210101-000000\"", "id":
         "00000000-0000-0000-0000-000000000000", "status": "Waiting", "outputDataFormat":
         "microsoft.qio-results.v2", "outputDataUri": "https://e2etests.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "creationTime": "2022-04-29T01:32:44.9275051+00:00", "beginExecutionTime":
+        "creationTime": "2022-02-09T18:35:00.6497055+00:00", "beginExecutionTime":
         null, "endExecutionTime": null, "cancellationTime": null, "costEstimate":
         null, "errorData": null, "isCancelling": false, "tags": [], "access_token":
         "fake_token"}'
     headers:
       content-length:
-      - '1176'
-      content-type:
-      - application/json; charset=utf-8
-      transfer-encoding:
-      - chunked
-    status:
-      code: 200
-      message: OK
-- request:
-    body: 'b''{"containerName": "job-00000000-0000-0000-0000-000000000000"}'''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '61'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - testapp azsdk-python-quantum/0.0.0.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
-    method: POST
-    uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
-  response:
-    body:
-      string: '{"sasUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "access_token": "fake_token"}'
-    headers:
-      content-length:
-      - '205'
+      - '1178'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -282,47 +251,15 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.8.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.9.0 Python/3.9.5 (Windows-10-10.0.19044-SP0)
       x-ms-date:
-      - Fri, 29 Apr 2022 01:32:48 GMT
-      x-ms-version:
-      - '2020-06-12'
-    method: GET
-    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-  response:
-    body:
-      string: ''
-    headers:
-      content-length:
-      - '0'
-      x-ms-lease-state:
-      - available
-      x-ms-lease-status:
-      - unlocked
-      x-ms-version:
-      - '2020-06-12'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/xml
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-storage-blob/12.8.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
-      x-ms-date:
-      - Fri, 29 Apr 2022 01:32:49 GMT
+      - Wed, 09 Feb 2022 18:35:00 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
-      - '2020-06-12'
+      - '2020-10-02'
     method: GET
-    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=rcw
   response:
     body:
       string: '{"metadata": {"name": "Test-SimulatedAnnealing-\"20210101-000000\""},
@@ -340,11 +277,11 @@ interactions:
       content-type:
       - application/json
       x-ms-blob-content-md5:
-      - 6PZyeZvIU8MyRtyp9aTGug==
+      - YdbpdlaFWz1BwPHVHL+2Dg==
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Fri, 29 Apr 2022 01:32:44 GMT
+      - Wed, 09 Feb 2022 18:35:00 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -352,7 +289,7 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-06-12'
+      - '2020-10-02'
     status:
       code: 206
       message: Partial Content

--- a/azure-quantum/tests/unit/test_job.py
+++ b/azure-quantum/tests/unit/test_job.py
@@ -394,6 +394,45 @@ class TestJob(QuantumTestBase):
             expected = problem.serialize()
             self.assertEqual(expected, actual)
 
+    @pytest.mark.live_test
+    @pytest.mark.qio
+    def test_job_attachments(self):
+        workspace = self.create_workspace()
+        solver = microsoft.SimulatedAnnealing(workspace)
+
+        with unittest.mock.patch.object(
+            Job,
+            self.mock_create_job_id_name,
+            return_value=self.get_test_job_id(),
+        ):
+            expected_1 = "Some data 1".encode('utf-8')
+            expected_2 = "Some other random data 2".encode('utf-8')
+            problem = self.create_problem(name="test_job_attachments")
+
+            job = solver.submit(problem)
+
+            url1 = job.upload_attachment("test-1", expected_1)
+            self.assertTrue(job.id in url1)
+            self.assertTrue("test-1" in url1)
+
+            url2 = job.upload_attachment("test-2", expected_2)
+            self.assertTrue(job.id in url2)
+            self.assertTrue("test-2" in url2)
+
+            actual_1 = job.download_attachment("test-1")
+            self.assertEqual(expected_1, actual_1)
+
+            actual_2 = job.download_attachment("test-2")
+            self.assertEqual(expected_2, actual_2)
+
+            # Check if download_attachment can successfully download other blobs 
+            # automatically created
+            problem_as_json = job.download_attachment("inputData")
+            downloaded_problem = Problem.deserialize(input_problem=problem_as_json)
+            actual = downloaded_problem.serialize()
+            expected = problem.serialize()
+            self.assertEqual(expected, actual)
+
 
     def create_problem(
             self,

--- a/azure-quantum/tests/unit/test_job.py
+++ b/azure-quantum/tests/unit/test_job.py
@@ -387,12 +387,13 @@ class TestJob(QuantumTestBase):
             problem = self.create_problem(name=problem_name)
             job = solver.submit(problem)
             # Check if problem can be successfully downloaded and deserialized
-            problem_as_json = job.download_data(job.details.input_data_uri)
+            problem_as_json = job.download_blob("inputData")
             downloaded_problem = Problem.deserialize(input_problem=problem_as_json)
 
             actual = downloaded_problem.serialize()
             expected = problem.serialize()
             self.assertEqual(expected, actual)
+
 
 
     def create_problem(

--- a/azure-quantum/tests/unit/test_job.py
+++ b/azure-quantum/tests/unit/test_job.py
@@ -387,13 +387,12 @@ class TestJob(QuantumTestBase):
             problem = self.create_problem(name=problem_name)
             job = solver.submit(problem)
             # Check if problem can be successfully downloaded and deserialized
-            problem_as_json = job.download_blob("inputData")
+            problem_as_json = job.download_data(job.details.input_data_uri)
             downloaded_problem = Problem.deserialize(input_problem=problem_as_json)
 
             actual = downloaded_problem.serialize()
             expected = problem.serialize()
             self.assertEqual(expected, actual)
-
 
 
     def create_problem(


### PR DESCRIPTION
We provide methods to attach arbitrary data to a Job. This data is uploaded to an Azure Job container (by default, the same container linked by default to a Job). The data can later be retrieved using the `download_attachment` method.

This method can also be used to download the intermediate blobs generated for an azure-quantum job by the service. This can be useful for debugging purpose.