### PR TITLE
Fixing job filter test

### DIFF
--- a/azure-quantum/tests/unit/aio/test_aio_job.py
+++ b/azure-quantum/tests/unit/aio/test_aio_job.py
@@ -216,15 +216,14 @@ class TestJob(QuantumTestBase):
             # don't run these on playback mode, as the recordings might expire
             # since we're checking against datetime.now()
             if not self.is_playback:
-                # There is a few hundred ms difference in time between local machine
-                # and server, so add 2 seconds to take that into account
-                after_time = datetime.now(tz=timezone.utc) + timedelta(seconds=2)
+                # Make sure the job creation time is before tomorrow:
+                after_time = datetime.now() + timedelta(days=1)
                 self.assertEqual(False, job.matches_filter(created_after=after_time))
 
-                before_time = datetime.now() - timedelta(days=100)
+                # Make sure the job creation time is after yesterday:
+                before_time = datetime.now() - timedelta(days=1)
                 self.assertEqual(True, job.matches_filter(created_after=before_time))
-
-                before_date = date.today() - timedelta(days=100)
+                before_date = date.today() - timedelta(days=1)
                 self.assertEqual(True, job.matches_filter(created_after=before_date))
 
     async def _test_job_submit(self, solver_name: str, solver_type: Type[Solver]):

--- a/azure-quantum/tests/unit/recordings/test_job_submit_microsoft_simulated_annealing.yaml
+++ b/azure-quantum/tests/unit/recordings/test_job_submit_microsoft_simulated_annealing.yaml
@@ -5,7 +5,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate, br
+      - gzip, deflate
       Connection:
       - keep-alive
       Content-Length:
@@ -13,7 +13,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - azsdk-python-identity/1.7.1 Python/3.7.12 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-identity/1.10.0 Python/3.7.8 (Windows-10-10.0.19041-SP0)
       x-client-cpu:
       - x64
       x-client-current-telemetry:
@@ -23,7 +23,7 @@ interactions:
       x-client-sku:
       - MSAL.Python
       x-client-ver:
-      - 1.16.0
+      - 1.17.0
     method: POST
     uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
   response:
@@ -44,7 +44,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate, br
+      - gzip, deflate
       Connection:
       - keep-alive
       Content-Length:
@@ -52,7 +52,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Windows-10-10.0.19041-SP0)
+      - testapp azsdk-python-quantum/0.0.0.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
   response:
@@ -61,7 +61,7 @@ interactions:
         "access_token": "fake_token"}'
     headers:
       content-length:
-      - '205'
+      - '207'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -75,28 +75,28 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate, br
+      - gzip, deflate
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.11.0 Python/3.7.8 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Thu, 17 Feb 2022 01:07:46 GMT
+      - Wed, 04 May 2022 19:44:01 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
-        specified container does not exist.\nRequestId:6b9930e1-501e-003d-4a9a-23e9f6000000\nTime:2022-02-17T01:07:46.2121933Z</Message></Error>"
+        specified container does not exist.\nRequestId:5f7fe4b5-801e-00a8-7cef-5f0143000000\nTime:2022-05-04T19:44:01.3428581Z</Message></Error>"
     headers:
       content-length:
       - '225'
       content-type:
       - application/xml
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 404
       message: The specified container does not exist.
@@ -106,17 +106,17 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate, br
+      - gzip, deflate
       Connection:
       - keep-alive
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.11.0 Python/3.7.8 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Thu, 17 Feb 2022 01:07:46 GMT
+      - Wed, 04 May 2022 19:44:01 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -126,7 +126,7 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -136,15 +136,15 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate, br
+      - gzip, deflate
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.11.0 Python/3.7.8 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Thu, 17 Feb 2022 01:07:46 GMT
+      - Wed, 04 May 2022 19:44:01 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -158,18 +158,17 @@ interactions:
       x-ms-lease-status:
       - unlocked
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 200
       message: OK
 - request:
-    body: b'\x1f\x8b\x08\x00\xe1\x9f\rb\x02\xffU\x8c\xc1\n\x830\x10D\x7fE\xf6lJ\x12\xb5\xd2\xde\xfa\r\xed\xadJIu[\x02&\x8aY\x0bE\xf2\xef\r\xf1`\x03\x0b;;ogV0H\xaaW\xa4\xe0\x9c\xad`\x95\xc1
-      \xe0\x86\x8e\xd8U\x9beP\x84\xfd\xc5ZT\x83\xb6o\xd6\x80\xe42\x8c82Q\xf3\xba\xac\x1a\x00\x9fg\xd0\x8d\x8e\x1e\xaf\xc5v\xa4G\x1b\x9b>8\xbbM\x838p\x08?\xf4\x9db\xf7\xb4<\xc7x\xe3l\\0\xee+ta\xb1"x\xba\x8f\x8e\xc83\xde\x86\xde\x8dT;\x90\t8%@\xec@\xee\xa0H\x12\xacL\xc8_$\x05\xb2\xf5\xad\xf7?m_\xe9\xa9\x1d\x01\x00\x00'
+    body: b'\x1f\x8b\x08\x00\x7f\xd7rb\x02\xffU\xccA\x0e\x83 \x10\x05\xd0\xab\x98YK\x03\xa8\x0b\xbb\xeb\x19\xda]5\r\xd5iC"`dl\xd2\x18\xee^\x82\x0b\xcb\x8a\xe1\xbf\x99\xbf\x81AR\xa3"\x05\xe7b\x03\xab\x0c\xc6\x01n\xe8\x89]\xb5Y\'E8^\xacE5i\xfbf\x1dH.%ox\xcd\x84\xac\xab\xa6\xed\x00BY\xc0\xe0<=^\xab\x1dH;\x9b\x9a>\xb8\xf8}\x06q\xe2\x10w\xe8;\xa7\xeey}\xba\xf4\xc7\xc5\xf8\x18\xdc7\x18\xe2\xc3\xaa\x98\xe91%\xa2,x\x1f{wi\x0e\x90\x19\xb4\x19\x88\x03\xe4\x01Uv\xc1\xeaL\xfeNr\x90}\xe8C\xf8\x01B\xbc\x8f\x8b\x1d\x01\x00\x00'
     headers:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate, br
+      - gzip, deflate
       Connection:
       - keep-alive
       Content-Length:
@@ -177,13 +176,13 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.11.0 Python/3.7.8 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Thu, 17 Feb 2022 01:07:46 GMT
+      - Wed, 04 May 2022 19:44:01 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -193,7 +192,7 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -208,15 +207,15 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate, br
+      - gzip, deflate
       Connection:
       - keep-alive
       Content-Length:
-      - '628'
+      - '630'
       Content-Type:
       - application/json
       User-Agent:
-      - testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Windows-10-10.0.19041-SP0)
+      - testapp azsdk-python-quantum/0.0.0.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
     method: PUT
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
@@ -228,13 +227,13 @@ interactions:
         "metadata": null, "name": "Test-SimulatedAnnealing-\"20210101-000000\"", "id":
         "00000000-0000-0000-0000-000000000000", "status": "Waiting", "outputDataFormat":
         "microsoft.qio-results.v2", "outputDataUri": "https://e2etests.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "creationTime": "2022-02-17T01:07:46.7885285+00:00", "beginExecutionTime":
+        "creationTime": "2022-05-04T19:44:01.8204343+00:00", "beginExecutionTime":
         null, "endExecutionTime": null, "cancellationTime": null, "costEstimate":
         null, "errorData": null, "isCancelling": false, "tags": [], "access_token":
         "fake_token"}'
     headers:
       content-length:
-      - '1170'
+      - '1174'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -248,29 +247,29 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate, br
+      - gzip, deflate
       Connection:
       - keep-alive
       User-Agent:
-      - testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Windows-10-10.0.19041-SP0)
+      - testapp azsdk-python-quantum/0.0.0.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-03c108c0-8f8e-11ec-9594-1860247f69ed.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-8ac0cc1a-cbe2-11ec-989f-2a16a847b8a3.input.json",
         "inputDataFormat": "microsoft.qio.v2", "inputParams": {"params": {"beta_start":
         0}}, "providerId": "microsoft", "target": "microsoft.simulatedannealing.cpu",
         "metadata": null, "name": "Test-SimulatedAnnealing-\"20210101-000000\"", "id":
         "00000000-0000-0000-0000-000000000000", "status": "Succeeded", "outputDataFormat":
-        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-03c108c0-8f8e-11ec-9594-1860247f69ed.output.json",
-        "creationTime": "2022-02-17T01:07:46.7885285+00:00", "beginExecutionTime":
-        "2022-02-17T01:07:47.4994969Z", "endExecutionTime": "2022-02-17T01:07:51.9179923Z",
+        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-8ac0cc1a-cbe2-11ec-989f-2a16a847b8a3.output.json",
+        "creationTime": "2022-05-04T19:44:01.8204343+00:00", "beginExecutionTime":
+        "2022-05-04T19:43:58.752045Z", "endExecutionTime": "2022-05-04T19:44:02.5000253Z",
         "cancellationTime": null, "costEstimate": null, "errorData": null, "isCancelling":
         false, "tags": [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1476'
+      - '1477'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -284,19 +283,19 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate, br
+      - gzip, deflate
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.11.0 Python/3.7.8 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Thu, 17 Feb 2022 01:07:53 GMT
+      - Wed, 04 May 2022 19:44:09 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
-    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-03c108c0-8f8e-11ec-9594-1860247f69ed.output.json
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-8ac0cc1a-cbe2-11ec-989f-2a16a847b8a3.output.json
   response:
     body:
       string: '{"version": "1.0", "configuration": {"1": 1, "0": 1, "2": 0, "3": 1},
@@ -316,7 +315,7 @@ interactions:
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Thu, 17 Feb 2022 01:07:47 GMT
+      - Wed, 04 May 2022 19:44:02 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -324,7 +323,7 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 206
       message: Partial Content
@@ -334,29 +333,29 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate, br
+      - gzip, deflate
       Connection:
       - keep-alive
       User-Agent:
-      - testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Windows-10-10.0.19041-SP0)
+      - testapp azsdk-python-quantum/0.0.0.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-03c108c0-8f8e-11ec-9594-1860247f69ed.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-8ac0cc1a-cbe2-11ec-989f-2a16a847b8a3.input.json",
         "inputDataFormat": "microsoft.qio.v2", "inputParams": {"params": {"beta_start":
         0}}, "providerId": "microsoft", "target": "microsoft.simulatedannealing.cpu",
         "metadata": null, "name": "Test-SimulatedAnnealing-\"20210101-000000\"", "id":
         "00000000-0000-0000-0000-000000000000", "status": "Succeeded", "outputDataFormat":
-        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-03c108c0-8f8e-11ec-9594-1860247f69ed.output.json",
-        "creationTime": "2022-02-17T01:07:46.7885285+00:00", "beginExecutionTime":
-        "2022-02-17T01:07:47.4994969Z", "endExecutionTime": "2022-02-17T01:07:51.9179923Z",
+        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-8ac0cc1a-cbe2-11ec-989f-2a16a847b8a3.output.json",
+        "creationTime": "2022-05-04T19:44:01.8204343+00:00", "beginExecutionTime":
+        "2022-05-04T19:43:58.752045Z", "endExecutionTime": "2022-05-04T19:44:02.5000253Z",
         "cancellationTime": null, "costEstimate": null, "errorData": null, "isCancelling":
         false, "tags": [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1476'
+      - '1477'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -370,7 +369,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate, br
+      - gzip, deflate
       Connection:
       - keep-alive
       Content-Length:
@@ -378,7 +377,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - azsdk-python-identity/1.7.1 Python/3.7.12 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-identity/1.10.0 Python/3.7.8 (Windows-10-10.0.19041-SP0)
       x-client-cpu:
       - x64
       x-client-current-telemetry:
@@ -388,7 +387,7 @@ interactions:
       x-client-sku:
       - MSAL.Python
       x-client-ver:
-      - 1.16.0
+      - 1.17.0
     method: POST
     uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
   response:
@@ -409,7 +408,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate, br
+      - gzip, deflate
       Connection:
       - keep-alive
       Content-Length:
@@ -417,7 +416,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Windows-10-10.0.19041-SP0)
+      - testapp azsdk-python-quantum/0.0.0.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
   response:
@@ -426,7 +425,7 @@ interactions:
         "access_token": "fake_token"}'
     headers:
       content-length:
-      - '205'
+      - '207'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -440,28 +439,28 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate, br
+      - gzip, deflate
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.11.0 Python/3.7.8 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Thu, 17 Feb 2022 01:07:54 GMT
+      - Wed, 04 May 2022 19:44:10 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
-        specified container does not exist.\nRequestId:fc07afd2-201e-0008-469a-2385e2000000\nTime:2022-02-17T01:07:55.0583447Z</Message></Error>"
+        specified container does not exist.\nRequestId:ed496226-101e-0085-21ef-5fb230000000\nTime:2022-05-04T19:44:10.8361943Z</Message></Error>"
     headers:
       content-length:
       - '225'
       content-type:
       - application/xml
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 404
       message: The specified container does not exist.
@@ -471,17 +470,17 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate, br
+      - gzip, deflate
       Connection:
       - keep-alive
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.11.0 Python/3.7.8 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Thu, 17 Feb 2022 01:07:55 GMT
+      - Wed, 04 May 2022 19:44:10 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -491,7 +490,7 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -501,15 +500,15 @@ interactions:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate, br
+      - gzip, deflate
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.11.0 Python/3.7.8 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Thu, 17 Feb 2022 01:07:55 GMT
+      - Wed, 04 May 2022 19:44:10 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -523,17 +522,17 @@ interactions:
       x-ms-lease-status:
       - unlocked
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 200
       message: OK
 - request:
-    body: b'\x1f\x8b\x08\x00\xea\x9f\rb\x02\xffU\xcc\xb1\x0e\xc2 \x10\x06\xe0W!7\x17\xd3R\x1d\xf4\x01\x1c\x9c\xbb\x19b(EC"\xd0\xc0\xd5\xc4\x10\xde]B\x07d\xe2\xf8\xbf\xfb/\x82Q(\x16\x81\x02.$\x82\x15F\xe5\x01&\x15\x90\xde\xdcL\xaf\xfa\x8d\xcak\xfb\x82\xd4\x11\x90.\xe0\xe3\xb9Y\x89\xda\xd9R\xf8(\x1f\xf6\x19\x86C\x0fy\x07\xbfk9\xb1n\xb3+\x7f\xe5M\xc8\xc1=\x82\xcc\x0f\x1ds\xa6\x97\x92\x0c\x1d\xe9y\xbe\xbb\xcb\xa9\x02k\xe0\xdc\xc0P\x81U\x18\x9b\x06=6\xf2Wi\x81\xf1\xc4S\xfa\x01\xae\xc4lL\x04\x01\x00\x00'
+    body: b'\x1f\x8b\x08\x00\x89\xd7rb\x02\xffU\xcc\xb1\x0e\xc2 \x10\x06\xe0W!7\x17\xd3R\x1d\xf4\x01\x1c\x9c\xbb\x19b(EC"\xd0\xc0\xd5\xc4\x10\xde]B\x07d\xe2\xf8\xbf\xfb/\x82Q(\x16\x81\x02.$\x82\x15F\xe5\x01&\x15\x90\xde\xdcL\xaf\xfa\x8d\xcak\xfb\x82\xd4\x11\x90.\xe0\xe3\xb9Y\x89\xda\xd9R\xf8(\x1f\xf6\x19\x86C\x0fy\x07\xbfk9\xb1n\xb3+\x7f\xe5M\xc8\xc1=\x82\xcc\x0f\x1ds\xa6\x97\x92\x0c\x1d\xe9y\xbe\xbb\xcb\xa9\x02k\xe0\xdc\xc0P\x81U\x18\x9b\x06=6\xf2Wi\x81\xf1\xc4S\xfa\x01\xae\xc4lL\x04\x01\x00\x00'
     headers:
       Accept:
       - application/xml
       Accept-Encoding:
-      - gzip, deflate, br
+      - gzip, deflate
       Connection:
       - keep-alive
       Content-Length:
@@ -541,13 +540,13 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.11.0 Python/3.7.8 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Thu, 17 Feb 2022 01:07:55 GMT
+      - Wed, 04 May 2022 19:44:11 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -557,7 +556,7 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -572,15 +571,15 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate, br
+      - gzip, deflate
       Connection:
       - keep-alive
       Content-Length:
-      - '603'
+      - '605'
       Content-Type:
       - application/json
       User-Agent:
-      - testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Windows-10-10.0.19041-SP0)
+      - testapp azsdk-python-quantum/0.0.0.1 Python/3.7.8 (Windows-10-10.0.19041-SP0)
     method: PUT
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
@@ -592,13 +591,13 @@ interactions:
         "metadata": null, "name": "Test-Job-Filtering", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Waiting", "outputDataFormat": "microsoft.qio-results.v2", "outputDataUri":
         "https://e2etests.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "creationTime": "2022-02-17T01:07:55.2580353+00:00", "beginExecutionTime":
+        "creationTime": "2022-05-04T19:44:11.189153+00:00", "beginExecutionTime":
         null, "endExecutionTime": null, "cancellationTime": null, "costEstimate":
         null, "errorData": null, "isCancelling": false, "tags": [], "access_token":
         "fake_token"}'
     headers:
       content-length:
-      - '1145'
+      - '1148'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:

--- a/azure-quantum/tests/unit/test_job.py
+++ b/azure-quantum/tests/unit/test_job.py
@@ -296,15 +296,14 @@ class TestJob(QuantumTestBase):
             # don't run these on playback mode, as the recordings might expire
             # since we're checking against datetime.now()
             if not self.is_playback:
-                # There is a few hundred ms difference in time between local machine
-                # and server, so add 2 seconds to take that into account
-                after_time = datetime.now() + timedelta(seconds=2)
+                # Make sure the job creation time is before tomorrow:
+                after_time = datetime.now() + timedelta(days=1)
                 self.assertEqual(False, job.matches_filter(created_after=after_time))
 
-                before_time = datetime.now() - timedelta(days=100)
+                # Make sure the job creation time is after yesterday:
+                before_time = datetime.now() - timedelta(days=1)
                 self.assertEqual(True, job.matches_filter(created_after=before_time))
-
-                before_date = date.today() - timedelta(days=100)
+                before_date = date.today() - timedelta(days=1)
                 self.assertEqual(True, job.matches_filter(created_after=before_date))
 
     def _test_job_submit(


### PR DESCRIPTION
In #309 I disabled the job filter tests when run with recordings as they would fail if the job creation time became stale, but now when they run live, the test fails as it was doing the wrong checks.
This fixes the test when run live.