### PR TITLE
Azure quantum aio (async) fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -402,15 +402,14 @@ temp/
 
 # azure-quantum
 version.py
-!recordings/*.yaml
 azure-quantum/azure/quantum/version.py
 azure-quantum/dist
 azure-quantum/temp
 azure-quantum/build
 !azure-quantum/tests/unit/recordings/*.yaml
+!azure-quantum/tests/unit/aio/recordings/*.yaml
 qdk/dist
 qdk/build
 *.txt
 [.][v]env/
 version.py
-!recordings/*.yaml

--- a/azure-quantum/azure/quantum/aio/job/base_job.py
+++ b/azure-quantum/azure/quantum/aio/job/base_job.py
@@ -5,13 +5,13 @@
 import logging
 
 from urllib.parse import urlparse
-from typing import Any, Dict, TYPE_CHECKING
+from typing import Any, Dict, Optional, TYPE_CHECKING
 from urllib.parse import urlparse
 from azure.storage.blob import BlobClient
 
 from azure.quantum.aio.storage import upload_blob, download_blob, ContainerClient
 from azure.quantum._client.models import JobDetails
-from azure.quantum.job.job import BaseJob as SyncBaseJob
+from azure.quantum.job.job import BaseJob as SyncBaseJob, ContentType
 
 
 if TYPE_CHECKING:
@@ -199,7 +199,7 @@ class BaseJob(SyncBaseJob):
     async def upload_input_data(
         container_uri: str,
         input_data: bytes,
-        content_type: str,
+        content_type: Optional[ContentType] = ContentType.json,
         blob_name: str = "inputData",
         encoding: str = "",
         return_sas_token: bool = False
@@ -288,9 +288,9 @@ class BaseJob(SyncBaseJob):
         if container_uri is None:
             container_uri = await self.workspace.get_container_uri(job_id=self.id)
 
-        uploaded_blob_uri = await cls.upload_input_data(
+        uploaded_blob_uri = await self.upload_input_data(
             container_uri = container_uri,
-            blob_name = name,
+            blob_name = blob_name,
             input_data = data,
             **kwargs
         )

--- a/azure-quantum/azure/quantum/aio/optimization/online_problem.py
+++ b/azure-quantum/azure/quantum/aio/optimization/online_problem.py
@@ -13,5 +13,5 @@ if TYPE_CHECKING:
 
 class OnlineProblem(SyncOnlineProblem):
     async def download(self, workspace: "Workspace") -> Problem:
-        logger.warning("The problem will be downloaded to the client")
+        logger.info("The problem will be downloaded to the client")
         return await Problem.download(self, workspace)

--- a/azure-quantum/azure/quantum/aio/storage.py
+++ b/azure-quantum/azure/quantum/aio/storage.py
@@ -115,6 +115,7 @@ async def upload_blob(
         uri = remove_sas_token(blob.url)
 
     logger.debug(f"  - blob access url: '{uri}'.")
+    await blob.close()
 
     return uri
 
@@ -163,6 +164,7 @@ async def append_blob(
         uri = remove_sas_token(blob.url)
 
     logger.debug(f"  - blob access url: '{uri}'.")
+    await blob.close()
 
     return uri
 
@@ -370,6 +372,8 @@ class StreamedBlob:
             metadata=metadata,
         )
         self.state = StreamedBlobState.committed
+        await self.container.close()
+        await self.blob.close()
         logger.debug(f"Committed {self.blob_name}")
 
     def getUri(self, with_sas_token: bool = False):

--- a/azure-quantum/azure/quantum/aio/target/solvers.py
+++ b/azure-quantum/azure/quantum/aio/target/solvers.py
@@ -40,19 +40,12 @@ class Solver(Target, SyncSolver):
         from azure.quantum.aio.optimization.problem import Problem
         if isinstance(problem, Problem):
             # Create job from input data
-            name = problem.name
-            blob = problem.to_blob()
-            job = await Job.from_input_data(
-                workspace=self.workspace,
-                name=name,
-                target=self.name,
-                input_data=blob,
-                blob_name="inputData",
-                content_type="application/json",
-                provider_id=self.provider_id,
-                input_data_format=self.input_data_format,
-                output_data_format=self.output_data_format,
+            return await super().submit(
+                input_data=problem,
+                name=problem.name,
                 input_params=self.params,
+                blob_name="inputData",
+                content_type = problem.content_type
             )
         
         else:

--- a/azure-quantum/azure/quantum/aio/target/target.py
+++ b/azure-quantum/azure/quantum/aio/target/target.py
@@ -34,6 +34,10 @@ class Target(SyncTarget, abc.ABC):
         :rtype: Job
         """
         input_params = input_params or {}
+        input_data_format = kwargs.pop("input_data_format", self.input_data_format)
+        output_data_format = kwargs.pop("output_data_format", self.output_data_format)
+        content_type = kwargs.pop("content_type", self.content_type)
+        encoding = kwargs.pop("encoding", self.encoding)
         blob = self._encode_input_data(data=input_data)
 
         return await Job.from_input_data(
@@ -41,11 +45,11 @@ class Target(SyncTarget, abc.ABC):
             name=name,
             target=self.name,
             input_data=blob,
-            content_type=self.content_type,
-            encoding=self.encoding,
+            content_type=content_type,
+            encoding=encoding,
             provider_id=self.provider_id,
-            input_data_format=self.input_data_format,
-            output_data_format=self.output_data_format,
+            input_data_format=input_data_format,
+            output_data_format=output_data_format,
             input_params=input_params,
             **kwargs
         )

--- a/azure-quantum/azure/quantum/job/job.py
+++ b/azure-quantum/azure/quantum/job/job.py
@@ -9,7 +9,7 @@ import json
 from typing import TYPE_CHECKING
 
 from azure.quantum._client.models import JobDetails
-from azure.quantum.job.base_job import BaseJob, DEFAULT_TIMEOUT
+from azure.quantum.job.base_job import BaseJob, ContentType, DEFAULT_TIMEOUT
 from azure.quantum.job.filtered_job import FilteredJob
 
 __all__ = ["Job"]

--- a/azure-quantum/tests/unit/aio/recordings/test_job_attachments.yaml
+++ b/azure-quantum/tests/unit/aio/recordings/test_job_attachments.yaml
@@ -1,0 +1,752 @@
+interactions:
+- request:
+    body: '{''client_id'': ''00000000-0000-0000-0000-000000000000'', ''client_secret'':
+      ''PLACEHOLDER'', ''grant_type'': ''client_credentials'', ''scope'': ''https://quantum.microsoft.com/.default''}'
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - azsdk-python-identity/1.10.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
+    method: POST
+    uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 86399, "ext_expires_in": 86399,
+        "access_token": "fake_token"}'
+    headers:
+      content-length:
+      - '1722'
+      content-type:
+      - application/json; charset=utf-8
+    status:
+      code: 200
+      message: OK
+    url: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
+- request:
+    body: 'b''{"containerName": "job-00000000-0000-0000-0000-000000000000"}'''
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '61'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
+    method: POST
+    uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
+  response:
+    body:
+      string: '{"sasUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "access_token": "fake_token"}'
+    headers:
+      content-length:
+      - '209'
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+    url: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
+      x-ms-date:
+      - Wed, 11 May 2022 06:12:11 GMT
+      x-ms-version:
+      - '2021-04-10'
+    method: GET
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
+        specified container does not exist.\nRequestId:b151eb3d-401e-0053-2afe-64bcd9000000\nTime:2022-05-11T06:12:12.0293657Z</Message></Error>"
+    headers:
+      content-length:
+      - '225'
+      content-type:
+      - application/xml
+      x-ms-version:
+      - '2021-04-10'
+    status:
+      code: 404
+      message: The specified container does not exist.
+    url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
+      x-ms-date:
+      - Wed, 11 May 2022 06:12:12 GMT
+      x-ms-version:
+      - '2021-04-10'
+    method: PUT
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      x-ms-version:
+      - '2021-04-10'
+    status:
+      code: 201
+      message: Created
+    url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
+      x-ms-date:
+      - Wed, 11 May 2022 06:12:12 GMT
+      x-ms-version:
+      - '2021-04-10'
+    method: GET
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-version:
+      - '2021-04-10'
+    status:
+      code: 200
+      message: OK
+    url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+- request:
+    body: b'\x1f\x8b\x08\x00\xbbS{b\x02\xffU\xcc\xc1\n\xc3 \x0c\x06\xe0W\x91\x9c\xdbQ\xedv\xd8^e\x94bm\xc6:PKM\x0bC|\xf7\x05{p\x9e\x8c\xff\x97?\x11,\x92\x9e5ix\x88\x08N[\xe4\x01\x08\x03\x8d\x1f?\x8d\x9aH\x9b\xb7EG\x01R#\xc0x\x86\xd7\xee\x0c-\xde\xe5\xca\x81[8g\x90\x97\x0ex\x87\xbek>\xb2\xee\x93\xcf\x7f\xdcl\xe0\xe0\x19\xc1\xf0\xd3\xf6\x9c-sNd#\xba\x81\xef\x9er+\xa0*\xb8W
+      \x0b\xa8\x02}\xd5h\xaf\x95\xfcUjPC\x1aR\xfa\x01\xcc\xacx\xfb\x06\x01\x00\x00'
+    headers:
+      Accept:
+      - application/xml
+      Content-Length:
+      - '155'
+      Content-Type:
+      - application/octet-stream
+      User-Agent:
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Wed, 11 May 2022 06:12:12 GMT
+      x-ms-version:
+      - '2021-04-10'
+    method: PUT
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      x-ms-version:
+      - '2021-04-10'
+    status:
+      code: 201
+      message: Created
+    url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+- request:
+    body: 'b''{"id": "00000000-0000-0000-0000-000000000000", "name": "test_job_attachments",
+      "containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+      "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData",
+      "inputDataFormat": "microsoft.qio.v2", "inputParams": {"params": {}}, "providerId":
+      "Microsoft", "target": "microsoft.simulatedannealing-parameterfree.cpu", "outputDataFormat":
+      "microsoft.qio-results.v2"}'''
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '608'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
+    method: PUT
+    uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
+  response:
+    body:
+      string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=rcw",
+        "inputDataFormat": "microsoft.qio.v2", "inputParams": {"params": {}}, "providerId":
+        "microsoft", "target": "microsoft.simulatedannealing-parameterfree.cpu", "metadata":
+        null, "name": "test_job_attachments", "id": "00000000-0000-0000-0000-000000000000",
+        "status": "Waiting", "outputDataFormat": "microsoft.qio-results.v2", "outputDataUri":
+        "https://e2etests.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "creationTime": "2022-05-11T06:12:12.3805193+00:00", "beginExecutionTime":
+        null, "endExecutionTime": null, "cancellationTime": null, "costEstimate":
+        null, "errorData": null, "isCancelling": false, "tags": [], "access_token":
+        "fake_token"}'
+    headers:
+      content-length:
+      - '1161'
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+    url: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
+- request:
+    body: 'b''{"containerName": "job-00000000-0000-0000-0000-000000000000"}'''
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '61'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
+    method: POST
+    uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
+  response:
+    body:
+      string: '{"sasUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "access_token": "fake_token"}'
+    headers:
+      content-length:
+      - '205'
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+    url: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
+      x-ms-date:
+      - Wed, 11 May 2022 06:12:12 GMT
+      x-ms-version:
+      - '2021-04-10'
+    method: GET
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-version:
+      - '2021-04-10'
+    status:
+      code: 200
+      message: OK
+    url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
+      x-ms-date:
+      - Wed, 11 May 2022 06:12:12 GMT
+      x-ms-version:
+      - '2021-04-10'
+    method: GET
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-version:
+      - '2021-04-10'
+    status:
+      code: 200
+      message: OK
+    url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+- request:
+    body: b'Some data 1'
+    headers:
+      Accept:
+      - application/xml
+      Content-Length:
+      - '11'
+      Content-Type:
+      - application/octet-stream
+      User-Agent:
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Wed, 11 May 2022 06:12:12 GMT
+      x-ms-version:
+      - '2021-04-10'
+    method: PUT
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/test-1?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      x-ms-version:
+      - '2021-04-10'
+    status:
+      code: 201
+      message: Created
+    url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/test-1?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+- request:
+    body: 'b''{"containerName": "job-00000000-0000-0000-0000-000000000000"}'''
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '61'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
+    method: POST
+    uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
+  response:
+    body:
+      string: '{"sasUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "access_token": "fake_token"}'
+    headers:
+      content-length:
+      - '205'
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+    url: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
+      x-ms-date:
+      - Wed, 11 May 2022 06:12:13 GMT
+      x-ms-version:
+      - '2021-04-10'
+    method: GET
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-version:
+      - '2021-04-10'
+    status:
+      code: 200
+      message: OK
+    url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
+      x-ms-date:
+      - Wed, 11 May 2022 06:12:13 GMT
+      x-ms-version:
+      - '2021-04-10'
+    method: GET
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-version:
+      - '2021-04-10'
+    status:
+      code: 200
+      message: OK
+    url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+- request:
+    body: b'Some other random data 2'
+    headers:
+      Accept:
+      - application/xml
+      Content-Length:
+      - '24'
+      Content-Type:
+      - application/octet-stream
+      User-Agent:
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Wed, 11 May 2022 06:12:13 GMT
+      x-ms-version:
+      - '2021-04-10'
+    method: PUT
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/test-2?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      x-ms-version:
+      - '2021-04-10'
+    status:
+      code: 201
+      message: Created
+    url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/test-2?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+- request:
+    body: 'b''{"containerName": "job-00000000-0000-0000-0000-000000000000"}'''
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '61'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
+    method: POST
+    uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
+  response:
+    body:
+      string: '{"sasUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "access_token": "fake_token"}'
+    headers:
+      content-length:
+      - '205'
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+    url: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
+      x-ms-date:
+      - Wed, 11 May 2022 06:12:13 GMT
+      x-ms-version:
+      - '2021-04-10'
+    method: GET
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-version:
+      - '2021-04-10'
+    status:
+      code: 200
+      message: OK
+    url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
+      x-ms-date:
+      - Wed, 11 May 2022 06:12:13 GMT
+      x-ms-range:
+      - bytes=0-33554431
+      x-ms-version:
+      - '2021-04-10'
+    method: GET
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/test-1?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+  response:
+    body:
+      string: Some data 1
+    headers:
+      accept-ranges:
+      - bytes
+      content-length:
+      - '11'
+      content-range:
+      - bytes 0-10/11
+      content-type:
+      - application/json
+      x-ms-blob-content-md5:
+      - QnAClf+ua713+IKfs7VTRw==
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-creation-time:
+      - Wed, 11 May 2022 06:12:12 GMT
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2021-04-10'
+    status:
+      code: 206
+      message: Partial Content
+    url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/test-1?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+- request:
+    body: 'b''{"containerName": "job-00000000-0000-0000-0000-000000000000"}'''
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '61'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
+    method: POST
+    uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
+  response:
+    body:
+      string: '{"sasUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "access_token": "fake_token"}'
+    headers:
+      content-length:
+      - '205'
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+    url: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
+      x-ms-date:
+      - Wed, 11 May 2022 06:12:13 GMT
+      x-ms-version:
+      - '2021-04-10'
+    method: GET
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-version:
+      - '2021-04-10'
+    status:
+      code: 200
+      message: OK
+    url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
+      x-ms-date:
+      - Wed, 11 May 2022 06:12:13 GMT
+      x-ms-range:
+      - bytes=0-33554431
+      x-ms-version:
+      - '2021-04-10'
+    method: GET
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/test-2?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+  response:
+    body:
+      string: Some other random data 2
+    headers:
+      accept-ranges:
+      - bytes
+      content-length:
+      - '24'
+      content-range:
+      - bytes 0-23/24
+      content-type:
+      - application/json
+      x-ms-blob-content-md5:
+      - SEhuUjLQu3v65oxzR1n73Q==
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-creation-time:
+      - Wed, 11 May 2022 06:12:13 GMT
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2021-04-10'
+    status:
+      code: 206
+      message: Partial Content
+    url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/test-2?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+- request:
+    body: 'b''{"containerName": "job-00000000-0000-0000-0000-000000000000"}'''
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '61'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
+    method: POST
+    uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
+  response:
+    body:
+      string: '{"sasUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "access_token": "fake_token"}'
+    headers:
+      content-length:
+      - '205'
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+    url: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
+      x-ms-date:
+      - Wed, 11 May 2022 06:12:14 GMT
+      x-ms-version:
+      - '2021-04-10'
+    method: GET
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-version:
+      - '2021-04-10'
+    status:
+      code: 200
+      message: OK
+    url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
+      x-ms-date:
+      - Wed, 11 May 2022 06:12:14 GMT
+      x-ms-range:
+      - bytes=0-33554431
+      x-ms-version:
+      - '2021-04-10'
+    method: GET
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+  response:
+    body:
+      string: '{"metadata": {"name": "test_job_attachments"}, "cost_function": {"version":
+        "1.0", "type": "pubo", "terms": [{"c": -3, "ids": [1, 0]}, {"c": 5, "ids":
+        [2, 0]}, {"c": 9, "ids": [2, 1]}, {"c": 2, "ids": [3, 0]}, {"c": -4, "ids":
+        [3, 1]}, {"c": 4, "ids": [3, 2]}]}, "access_token": "fake_token"}'
+    headers:
+      accept-ranges:
+      - bytes
+      content-length:
+      - '262'
+      content-range:
+      - bytes 0-154/155
+      content-type:
+      - application/json
+      x-ms-blob-content-md5:
+      - tGhVF43/6slEeJyARBQ1lQ==
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-creation-time:
+      - Wed, 11 May 2022 06:12:12 GMT
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2021-04-10'
+    status:
+      code: 206
+      message: Partial Content
+    url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+version: 1

--- a/azure-quantum/tests/unit/aio/recordings/test_job_submit_honeywell.yaml
+++ b/azure-quantum/tests/unit/aio/recordings/test_job_submit_honeywell.yaml
@@ -6,7 +6,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - azsdk-python-identity/1.7.1 Python/3.7.10 (Darwin-21.3.0-x86_64-i386-64bit)
+      - azsdk-python-identity/1.10.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
   response:
@@ -32,7 +32,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.10 (Darwin-21.3.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
   response:
@@ -41,7 +41,7 @@ interactions:
         "access_token": "fake_token"}'
     headers:
       content-length:
-      - '221'
+      - '209'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -56,24 +56,24 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.10 (Darwin-21.3.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Sat, 19 Feb 2022 01:11:49 GMT
+      - Wed, 11 May 2022 01:13:46 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
-        specified container does not exist.\nRequestId:82f597c2-301e-0005-4a2d-25f772000000\nTime:2022-02-19T01:11:49.8588787Z</Message></Error>"
+        specified container does not exist.\nRequestId:95c4e18f-d01e-009a-14d4-640134000000\nTime:2022-05-11T01:13:46.9220214Z</Message></Error>"
     headers:
       content-length:
       - '225'
       content-type:
       - application/xml
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 404
       message: The specified container does not exist.
@@ -84,11 +84,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.10 (Darwin-21.3.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Sat, 19 Feb 2022 01:11:49 GMT
+      - Wed, 11 May 2022 01:13:46 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -98,7 +98,7 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -109,11 +109,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.10 (Darwin-21.3.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Sat, 19 Feb 2022 01:11:49 GMT
+      - Wed, 11 May 2022 01:13:47 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -127,7 +127,7 @@ interactions:
       x-ms-lease-status:
       - unlocked
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 200
       message: OK
@@ -147,13 +147,13 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.10 (Darwin-21.3.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Sat, 19 Feb 2022 01:11:50 GMT
+      - Wed, 11 May 2022 01:13:47 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -163,7 +163,7 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -178,11 +178,11 @@ interactions:
       Accept:
       - application/json
       Content-Length:
-      - '608'
+      - '580'
       Content-Type:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.10 (Darwin-21.3.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: PUT
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
@@ -192,14 +192,14 @@ interactions:
         "inputDataFormat": "honeywell.openqasm.v1", "inputParams": {}, "providerId":
         "quantinuum", "target": "quantinuum.hqs-lt-s1-apival", "metadata": null, "name":
         "honeywell-job", "id": "00000000-0000-0000-0000-000000000000", "status": "Waiting",
-        "outputDataFormat": "honeywell.quantum-results.v1", "outputDataUri": "https://st8bd7d3874f6b42beb1d90a.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "creationTime": "2022-02-19T01:11:50.9678995+00:00", "beginExecutionTime":
+        "outputDataFormat": "honeywell.quantum-results.v1", "outputDataUri": "https://e2etests.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "creationTime": "2022-05-11T01:13:47.6539352+00:00", "beginExecutionTime":
         null, "endExecutionTime": null, "cancellationTime": null, "costEstimate":
         null, "errorData": null, "isCancelling": false, "tags": [], "access_token":
         "fake_token"}'
     headers:
       content-length:
-      - '1061'
+      - '1021'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -214,7 +214,7 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.10 (Darwin-21.3.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
@@ -225,13 +225,13 @@ interactions:
         "quantinuum", "target": "quantinuum.hqs-lt-s1-apival", "metadata": null, "name":
         "honeywell-job", "id": "00000000-0000-0000-0000-000000000000", "status": "Succeeded",
         "outputDataFormat": "honeywell.quantum-results.v1", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dhoneywell-job-00000000-0000-0000-0000-000000000000.output.json",
-        "creationTime": "2022-02-19T01:11:50.9678995+00:00", "beginExecutionTime":
-        "2022-02-19T01:11:53.984251+00:00", "endExecutionTime": "2022-02-19T01:11:53.984862+00:00",
+        "creationTime": "2022-05-11T01:13:47.6539352+00:00", "beginExecutionTime":
+        "2022-05-11T01:13:48.620774+00:00", "endExecutionTime": "2022-05-11T01:13:48.62107+00:00",
         "cancellationTime": null, "costEstimate": null, "errorData": null, "isCancelling":
         false, "tags": [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1412'
+      - '1365'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -246,13 +246,13 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.10 (Darwin-21.3.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Sat, 19 Feb 2022 01:12:00 GMT
+      - Wed, 11 May 2022 01:13:59 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dhoneywell-job-00000000-0000-0000-0000-000000000000.output.json
   response:
@@ -272,7 +272,7 @@ interactions:
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Sat, 19 Feb 2022 01:11:52 GMT
+      - Wed, 11 May 2022 01:13:47 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -280,7 +280,7 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 206
       message: Partial Content

--- a/azure-quantum/tests/unit/aio/recordings/test_job_submit_ionq.yaml
+++ b/azure-quantum/tests/unit/aio/recordings/test_job_submit_ionq.yaml
@@ -6,7 +6,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - azsdk-python-identity/1.7.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-identity/1.10.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
   response:
@@ -32,7 +32,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
   response:
@@ -41,7 +41,7 @@ interactions:
         "access_token": "fake_token"}'
     headers:
       content-length:
-      - '220'
+      - '207'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -56,24 +56,24 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:31:17 GMT
+      - Wed, 11 May 2022 01:13:21 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
-        specified container does not exist.\nRequestId:add13cae-301e-005b-5584-0d8b4c000000\nTime:2022-01-19T22:31:17.5888102Z</Message></Error>"
+        specified container does not exist.\nRequestId:042e1045-b01e-009c-7ed4-64328b000000\nTime:2022-05-11T01:13:22.1150560Z</Message></Error>"
     headers:
       content-length:
       - '225'
       content-type:
       - application/xml
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 404
       message: The specified container does not exist.
@@ -84,11 +84,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:31:17 GMT
+      - Wed, 11 May 2022 01:13:22 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -98,7 +98,7 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -109,11 +109,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:31:17 GMT
+      - Wed, 11 May 2022 01:13:22 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -127,7 +127,7 @@ interactions:
       x-ms-lease-status:
       - unlocked
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 200
       message: OK
@@ -143,13 +143,13 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 19 Jan 2022 22:31:18 GMT
+      - Wed, 11 May 2022 01:13:22 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -159,7 +159,7 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -174,11 +174,11 @@ interactions:
       Accept:
       - application/json
       Content-Length:
-      - '568'
+      - '548'
       Content-Type:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: PUT
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
@@ -188,14 +188,14 @@ interactions:
         "inputDataFormat": "ionq.circuit.v1", "inputParams": {}, "providerId": "ionq",
         "target": "ionq.simulator", "metadata": null, "name": "ionq-3ghz-job", "id":
         "00000000-0000-0000-0000-000000000000", "status": "Waiting", "outputDataFormat":
-        "ionq.quantum-results.v1", "outputDataUri": "https://azuresdkteststo.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "creationTime": "2022-01-19T22:31:18.6547271+00:00", "beginExecutionTime":
+        "ionq.quantum-results.v1", "outputDataUri": "https://e2etests.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "creationTime": "2022-05-11T01:13:23.079179+00:00", "beginExecutionTime":
         null, "endExecutionTime": null, "cancellationTime": null, "costEstimate":
         null, "errorData": null, "isCancelling": false, "tags": [], "access_token":
         "fake_token"}'
     headers:
       content-length:
-      - '1127'
+      - '1093'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -210,7 +210,7 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
@@ -221,8 +221,8 @@ interactions:
         "target": "ionq.simulator", "metadata": null, "name": "ionq-3ghz-job", "id":
         "00000000-0000-0000-0000-000000000000", "status": "Succeeded", "outputDataFormat":
         "ionq.quantum-results.v1", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dionq-3ghz-job-00000000-0000-0000-0000-000000000000.output.json",
-        "creationTime": "2022-01-19T22:31:18.6547271+00:00", "beginExecutionTime":
-        "2022-01-19T22:31:54.352Z", "endExecutionTime": "2022-01-19T22:31:54.377Z",
+        "creationTime": "2022-05-11T01:13:23.079179+00:00", "beginExecutionTime":
+        "2022-05-11T01:13:28.504Z", "endExecutionTime": "2022-05-11T01:13:28.52Z",
         "cancellationTime": null, "costEstimate": {"currencyCode": "USD", "events":
         [{"dimensionId": "gs1q", "dimensionName": "1Q Gate Shot", "measureUnit": "1q
         gate shot", "amountBilled": 0.0, "amountConsumed": 0.0, "unitPrice": 0.0},
@@ -232,7 +232,7 @@ interactions:
         [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1673'
+      - '1638'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -247,34 +247,33 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:32:12 GMT
+      - Wed, 11 May 2022 01:13:31 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dionq-3ghz-job-00000000-0000-0000-0000-000000000000.output.json
   response:
     body:
-      string: '{"duration": 25014144, "histogram": {"0": 0.5, "7": 0.5}, "access_token":
-        "fake_token"}'
+      string: '{"histogram": {"0": 0.5, "7": 0.5}, "access_token": "fake_token"}'
     headers:
       accept-ranges:
       - bytes
       content-length:
-      - '51'
+      - '31'
       content-range:
-      - bytes 0-50/51
+      - bytes 0-30/31
       content-type:
       - application/json
       x-ms-blob-content-md5:
-      - eaYhwBypk2ichRZPKk27oA==
+      - cGqXSmqmC2yPLYb+M2KHRg==
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 19 Jan 2022 22:31:49 GMT
+      - Wed, 11 May 2022 01:13:25 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -282,7 +281,7 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 206
       message: Partial Content

--- a/azure-quantum/tests/unit/aio/recordings/test_job_submit_ionq_100_shots.yaml
+++ b/azure-quantum/tests/unit/aio/recordings/test_job_submit_ionq_100_shots.yaml
@@ -6,7 +6,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - azsdk-python-identity/1.7.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-identity/1.10.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
   response:
@@ -32,7 +32,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
   response:
@@ -41,7 +41,7 @@ interactions:
         "access_token": "fake_token"}'
     headers:
       content-length:
-      - '212'
+      - '211'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -56,24 +56,24 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:32:14 GMT
+      - Wed, 11 May 2022 01:13:32 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
-        specified container does not exist.\nRequestId:72d1a5b0-101e-005c-4984-0de72f000000\nTime:2022-01-19T22:32:15.3810713Z</Message></Error>"
+        specified container does not exist.\nRequestId:7759e5a7-f01e-0024-2dd4-64694d000000\nTime:2022-05-11T01:13:32.8093405Z</Message></Error>"
     headers:
       content-length:
       - '225'
       content-type:
       - application/xml
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 404
       message: The specified container does not exist.
@@ -84,11 +84,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:32:15 GMT
+      - Wed, 11 May 2022 01:13:32 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -98,7 +98,7 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -109,11 +109,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:32:15 GMT
+      - Wed, 11 May 2022 01:13:32 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -127,7 +127,7 @@ interactions:
       x-ms-lease-status:
       - unlocked
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 200
       message: OK
@@ -143,13 +143,13 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 19 Jan 2022 22:32:15 GMT
+      - Wed, 11 May 2022 01:13:33 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -159,7 +159,7 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -174,11 +174,11 @@ interactions:
       Accept:
       - application/json
       Content-Length:
-      - '572'
+      - '564'
       Content-Type:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: PUT
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
@@ -188,14 +188,14 @@ interactions:
         "inputDataFormat": "ionq.circuit.v1", "inputParams": {"shots": 100}, "providerId":
         "ionq", "target": "ionq.simulator", "metadata": null, "name": "ionq-3ghz-job",
         "id": "00000000-0000-0000-0000-000000000000", "status": "Waiting", "outputDataFormat":
-        "ionq.quantum-results.v1", "outputDataUri": "https://azuresdkteststo.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "creationTime": "2022-01-19T22:32:16.3670058+00:00", "beginExecutionTime":
+        "ionq.quantum-results.v1", "outputDataUri": "https://e2etests.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "creationTime": "2022-05-11T01:13:33.3166407+00:00", "beginExecutionTime":
         null, "endExecutionTime": null, "cancellationTime": null, "costEstimate":
         null, "errorData": null, "isCancelling": false, "tags": [], "access_token":
         "fake_token"}'
     headers:
       content-length:
-      - '1122'
+      - '1121'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -210,7 +210,7 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
@@ -221,8 +221,8 @@ interactions:
         "ionq", "target": "ionq.simulator", "metadata": null, "name": "ionq-3ghz-job",
         "id": "00000000-0000-0000-0000-000000000000", "status": "Succeeded", "outputDataFormat":
         "ionq.quantum-results.v1", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dionq-3ghz-job-00000000-0000-0000-0000-000000000000.output.json",
-        "creationTime": "2022-01-19T22:32:16.3670058+00:00", "beginExecutionTime":
-        "2022-01-19T22:32:53.6Z", "endExecutionTime": "2022-01-19T22:32:53.632Z",
+        "creationTime": "2022-05-11T01:13:33.3166407+00:00", "beginExecutionTime":
+        "2022-05-11T01:13:41.143Z", "endExecutionTime": "2022-05-11T01:13:41.168Z",
         "cancellationTime": null, "costEstimate": {"currencyCode": "USD", "events":
         [{"dimensionId": "gs1q", "dimensionName": "1Q Gate Shot", "measureUnit": "1q
         gate shot", "amountBilled": 0.0, "amountConsumed": 0.0, "unitPrice": 0.0},
@@ -232,7 +232,7 @@ interactions:
         [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1672'
+      - '1665'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -247,34 +247,33 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:33:10 GMT
+      - Wed, 11 May 2022 01:13:45 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dionq-3ghz-job-00000000-0000-0000-0000-000000000000.output.json
   response:
     body:
-      string: '{"duration": 32022000, "histogram": {"0": 0.5, "7": 0.5}, "access_token":
-        "fake_token"}'
+      string: '{"histogram": {"0": 0.5, "7": 0.5}, "access_token": "fake_token"}'
     headers:
       accept-ranges:
       - bytes
       content-length:
-      - '51'
+      - '31'
       content-range:
-      - bytes 0-50/51
+      - bytes 0-30/31
       content-type:
       - application/json
       x-ms-blob-content-md5:
-      - rzon64pul3lE42ExB+0x9w==
+      - cGqXSmqmC2yPLYb+M2KHRg==
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 19 Jan 2022 22:32:47 GMT
+      - Wed, 11 May 2022 01:13:33 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -282,7 +281,7 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 206
       message: Partial Content

--- a/azure-quantum/tests/unit/aio/recordings/test_job_submit_microsoft_parallel_tempering.yaml
+++ b/azure-quantum/tests/unit/aio/recordings/test_job_submit_microsoft_parallel_tempering.yaml
@@ -6,7 +6,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - azsdk-python-identity/1.7.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-identity/1.10.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
   response:
@@ -32,7 +32,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
   response:
@@ -41,7 +41,7 @@ interactions:
         "access_token": "fake_token"}'
     headers:
       content-length:
-      - '218'
+      - '207'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -56,24 +56,24 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:08 GMT
+      - Wed, 11 May 2022 01:12:31 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
-        specified container does not exist.\nRequestId:6eff08e4-301e-0029-7e84-0d8c03000000\nTime:2022-01-19T22:30:08.9818531Z</Message></Error>"
+        specified container does not exist.\nRequestId:c133ac74-e01e-0065-1ad4-6431a9000000\nTime:2022-05-11T01:12:31.2891451Z</Message></Error>"
     headers:
       content-length:
       - '225'
       content-type:
       - application/xml
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 404
       message: The specified container does not exist.
@@ -84,11 +84,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:09 GMT
+      - Wed, 11 May 2022 01:12:31 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -98,7 +98,7 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -109,11 +109,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:09 GMT
+      - Wed, 11 May 2022 01:12:31 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -127,14 +127,13 @@ interactions:
       x-ms-lease-status:
       - unlocked
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 200
       message: OK
     url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
 - request:
-    body: b'\x1f\x8b\x08\x00\xef\x90\xe8a\x02\xffU\xccM\n\xc3 \x10\x05\xe0\xab\x84Y\xc7\xa2&\xa5\xa4\xa7\xe8"\xbb&\x14\x9bL\x8b\xe0OPS(\xc1\xbbW\xcc"u\xe5\xf8\xbe\x99\xb7\x81\xc6
-      f\x11\x04\\\xab\r\x8c\xd0\x98\x06\xe8\xd1\x07r\x13N(\x85\xaaG\xbd\xa0\x93\xe6M\x06\xe0\x94s\xcaXGX\xdbPz\x19\x00b]\xc1d}x\xbcV3\x05iM.\xfa\xa0\xf3\xfb\x0c\xecD!\xed\x84\xef\x92\xab\x97\xf5i\xf3\x1f\x9d\xf6)\xb8o0\xa5\x874)\x93sNX]\xd11\xf5\xeer>\x80\x17\xd0\x15\xc0\x0e\xe0\x074\xc5\x05i\x0b\xf9;)\x81\x8fq\x8c\xf1\x07+\x0bH\xc0\x1c\x01\x00\x00'
+    body: b'\x1f\x8b\x08\x00~\r{b\x02\xffU\xccA\x0e\x83 \x10\x05\xd0\xab\x98YK\x03cM\xda\x9e\xa2\x0bwj\x1a\xaa\xd3\xc6D\xc0\x006i\x0cw/\xc1\x85e\xc5\xf0\xdf\xcc\xdf@\x91\x97\xa3\xf4\x12n\xc5\x06Z*\x8a\x034\xe4<\xbbK+\xe7\x99\xe6\x86\xd4Bv\xd2o\xd6\x01rD^\x0b\xce\xc4E`\xc5;\x80P\x160\x18\xe7\x1f\xafU\x0f~2:\x15}\xc8\xba}\x06q\xe2\x10w\xfcwI\xd5\xcb\xfa4\xe9OV\xb9\x18\xb4\x1b\x0c\xf1aU\xcc\xa61%\xa2,x\x1f{w\xa9\x0f\xc0\x0c\xae\x19\x88\x03\xf0\x80*\xbb`\xe7L\xfeNr\xc0>\xf4!\xfc\x00\x0f\xf7\x02\x7f\x1c\x01\x00\x00'
     headers:
       Accept:
       - application/xml
@@ -143,13 +142,13 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:09 GMT
+      - Wed, 11 May 2022 01:12:31 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -159,7 +158,7 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -175,11 +174,11 @@ interactions:
       Accept:
       - application/json
       Content-Length:
-      - '644'
+      - '626'
       Content-Type:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: PUT
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
@@ -190,14 +189,14 @@ interactions:
         100}}, "providerId": "microsoft", "target": "microsoft.paralleltempering.cpu",
         "metadata": null, "name": "Test-ParallelTempering-\"20210101-000000\"", "id":
         "00000000-0000-0000-0000-000000000000", "status": "Waiting", "outputDataFormat":
-        "microsoft.qio-results.v2", "outputDataUri": "https://azuresdkteststo.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "creationTime": "2022-01-19T22:30:09.9759353+00:00", "beginExecutionTime":
+        "microsoft.qio-results.v2", "outputDataUri": "https://e2etests.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "creationTime": "2022-05-11T01:12:31.7490383+00:00", "beginExecutionTime":
         null, "endExecutionTime": null, "cancellationTime": null, "costEstimate":
         null, "errorData": null, "isCancelling": false, "tags": [], "access_token":
         "fake_token"}'
     headers:
       content-length:
-      - '1199'
+      - '1168'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -212,27 +211,29 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-ParallelTempering-%252220210101-000000%2522-5b020a0a-7977-11ec-9c89-acde48001122.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-ParallelTempering-%252220210101-000000%2522-6df70377-d0c7-11ec-9ecc-2816a847b9a3.input.json",
         "inputDataFormat": "microsoft.qio.v2", "inputParams": {"params": {"sweeps":
         100}}, "providerId": "microsoft", "target": "microsoft.paralleltempering.cpu",
         "metadata": null, "name": "Test-ParallelTempering-\"20210101-000000\"", "id":
         "00000000-0000-0000-0000-000000000000", "status": "Succeeded", "outputDataFormat":
-        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-ParallelTempering-%252220210101-000000%2522-5b020a0a-7977-11ec-9c89-acde48001122.output.json",
-        "creationTime": "2022-01-19T22:30:09.9759353+00:00", "beginExecutionTime":
-        "2022-01-19T22:30:10.9171152Z", "endExecutionTime": "2022-01-19T22:30:10.970428Z",
+        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-ParallelTempering-%252220210101-000000%2522-6df70377-d0c7-11ec-9ecc-2816a847b9a3.output.json",
+        "creationTime": "2022-05-11T01:12:31.7490383+00:00", "beginExecutionTime":
+        "2022-05-11T01:12:11.0901203Z", "endExecutionTime": "2022-05-11T01:12:11.1437362Z",
         "cancellationTime": null, "costEstimate": null, "errorData": null, "isCancelling":
         false, "tags": [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1502'
+      - '1470'
       content-type:
       - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
     status:
       code: 200
       message: OK
@@ -243,15 +244,15 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:13 GMT
+      - Wed, 11 May 2022 01:12:35 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
-    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-ParallelTempering-%252220210101-000000%2522-5b020a0a-7977-11ec-9c89-acde48001122.output.json
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-ParallelTempering-%252220210101-000000%2522-6df70377-d0c7-11ec-9ecc-2816a847b9a3.output.json
   response:
     body:
       string: '{"version": "1.0", "configuration": {"1": 1, "0": 1, "2": 0, "3": 1},
@@ -271,7 +272,7 @@ interactions:
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 19 Jan 2022 22:30:10 GMT
+      - Wed, 11 May 2022 01:12:32 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -279,36 +280,36 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 206
       message: Partial Content
-    url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-ParallelTempering-%252220210101-000000%2522-5b020a0a-7977-11ec-9c89-acde48001122.output.json
+    url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-ParallelTempering-%252220210101-000000%2522-6df70377-d0c7-11ec-9ecc-2816a847b9a3.output.json
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-ParallelTempering-%252220210101-000000%2522-5b020a0a-7977-11ec-9c89-acde48001122.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-ParallelTempering-%252220210101-000000%2522-6df70377-d0c7-11ec-9ecc-2816a847b9a3.input.json",
         "inputDataFormat": "microsoft.qio.v2", "inputParams": {"params": {"sweeps":
         100}}, "providerId": "microsoft", "target": "microsoft.paralleltempering.cpu",
         "metadata": null, "name": "Test-ParallelTempering-\"20210101-000000\"", "id":
         "00000000-0000-0000-0000-000000000000", "status": "Succeeded", "outputDataFormat":
-        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-ParallelTempering-%252220210101-000000%2522-5b020a0a-7977-11ec-9c89-acde48001122.output.json",
-        "creationTime": "2022-01-19T22:30:09.9759353+00:00", "beginExecutionTime":
-        "2022-01-19T22:30:10.9171152Z", "endExecutionTime": "2022-01-19T22:30:10.970428Z",
+        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-ParallelTempering-%252220210101-000000%2522-6df70377-d0c7-11ec-9ecc-2816a847b9a3.output.json",
+        "creationTime": "2022-05-11T01:12:31.7490383+00:00", "beginExecutionTime":
+        "2022-05-11T01:12:11.0901203Z", "endExecutionTime": "2022-05-11T01:12:11.1437362Z",
         "cancellationTime": null, "costEstimate": null, "errorData": null, "isCancelling":
         false, "tags": [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1494'
+      - '1470'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:

--- a/azure-quantum/tests/unit/aio/recordings/test_job_submit_microsoft_population_annealing.yaml
+++ b/azure-quantum/tests/unit/aio/recordings/test_job_submit_microsoft_population_annealing.yaml
@@ -6,7 +6,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - azsdk-python-identity/1.7.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-identity/1.10.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
   response:
@@ -32,7 +32,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
   response:
@@ -41,7 +41,7 @@ interactions:
         "access_token": "fake_token"}'
     headers:
       content-length:
-      - '218'
+      - '209'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -56,24 +56,24 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:14 GMT
+      - Wed, 11 May 2022 01:12:36 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
-        specified container does not exist.\nRequestId:b6899771-a01e-003b-4f84-0df7d3000000\nTime:2022-01-19T22:30:15.3077366Z</Message></Error>"
+        specified container does not exist.\nRequestId:ed9fa6ab-401e-0088-10d4-647ae4000000\nTime:2022-05-11T01:12:36.9478866Z</Message></Error>"
     headers:
       content-length:
       - '225'
       content-type:
       - application/xml
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 404
       message: The specified container does not exist.
@@ -84,11 +84,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:15 GMT
+      - Wed, 11 May 2022 01:12:36 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -98,7 +98,7 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -109,11 +109,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:15 GMT
+      - Wed, 11 May 2022 01:12:37 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -127,14 +127,13 @@ interactions:
       x-ms-lease-status:
       - unlocked
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 200
       message: OK
     url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
 - request:
-    body: b"\x1f\x8b\x08\x00\xf5\x90\xe8a\x02\xffU\x8c\xc1\x0e\xc2 \x10D\x7f\xa5\xd9s1,\xd4C\xbd\xf9\x07\x1e\xbc\xd9\xc6
-      E\xd3\xa4\x05R\xa8\x89!\xfc\xbbH\x0f\x95\xd3\xce\xce\x9b\x99\x00\xb3\xf2b\x10^\xc0\xa9\n\xa0\xc5\xac\x92\x80\xabr\x9e\\\x8c]'\xe1G\xa3\xcfZ+1\x8d\xfaE:`\x941\x8a\xd8\x12l8E\xde\x01\xc4\xba\x02i\x9c\xbf?W-\x7f\xf1<\xf5V\x8b\xdb4\xe0\x81B\xca\xf8\x8f\xcd\xe3v}\x98\xfc\xabev\xc9\xb8\x05\x90\xe9\x10\x9e\xbcq\xc8\x0e\xd6\x15\xed\xd3\xeeF\x8e;`\x05h\x0b\x80;`;\xe0E\x834\x05\xf9\xab\x94\x80\xf5\xb1\x8f\xf1\x0b\x04\x02\x19\xd7\x1e\x01\x00\x00"
+    body: b'\x1f\x8b\x08\x00\x83\r{b\x02\xffU\x8c\xc1\x0e\xc2 \x10D\x7f\xa5\xd9s1\xb0H\xa2\xde\xfc\x03\x0f\xdelc\x90\xa2i\xd2BS\xc0\xc44\xfc\xbbH\x0f\x95\xd3\xce\xce\x9b\x99\x05F\xede\'\xbd\x84S\xb5\x80\x91\xa3N\x02\xae\xdayr\xb1S\x18\xa4\xef\xad9\x1b\xa3\xe5\xd0\x9b\x17i\x00)"\x15\x8c\x12v`\xc8E\x03\x10\xeb\n\x94u\xfe\xfe\x0cF\xfd\xe2y\xea\xadg\xb7j`;\n)\xe3?S\x1e\x9f\xc2\xc3\xe6_\xcf\xa3K\xc6m\x01\x95\x0e\xe1\xc9\xeb\xbb\xec\xb0\xba\xa2m\xda]\x89\xd8\x00\x16\xe0X\x00\xb6\x01\xdc\x00/\x1ad_\x90\xbfJ\t\xb0\x8dm\x8c_\xd0\xc5\x1e\xe5\x1e\x01\x00\x00'
     headers:
       Accept:
       - application/xml
@@ -143,13 +142,13 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:15 GMT
+      - Wed, 11 May 2022 01:12:37 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -159,7 +158,7 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -175,11 +174,11 @@ interactions:
       Accept:
       - application/json
       Content-Length:
-      - '648'
+      - '632'
       Content-Type:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: PUT
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
@@ -190,14 +189,14 @@ interactions:
         200}}, "providerId": "microsoft", "target": "microsoft.populationannealing.cpu",
         "metadata": null, "name": "Test-PopulationAnnealing-\"20210101-000000\"",
         "id": "00000000-0000-0000-0000-000000000000", "status": "Waiting", "outputDataFormat":
-        "microsoft.qio-results.v2", "outputDataUri": "https://azuresdkteststo.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "creationTime": "2022-01-19T22:30:16.1678985+00:00", "beginExecutionTime":
+        "microsoft.qio-results.v2", "outputDataUri": "https://e2etests.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "creationTime": "2022-05-11T01:12:37.6067116+00:00", "beginExecutionTime":
         null, "endExecutionTime": null, "cancellationTime": null, "costEstimate":
         null, "errorData": null, "isCancelling": false, "tags": [], "access_token":
         "fake_token"}'
     headers:
       content-length:
-      - '1205'
+      - '1176'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -212,25 +211,25 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-PopulationAnnealing-%252220210101-000000%2522-5ec5fdfe-7977-11ec-9c89-acde48001122.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-PopulationAnnealing-%252220210101-000000%2522-712bec7b-d0c7-11ec-9985-2816a847b9a3.input.json",
         "inputDataFormat": "microsoft.qio.v2", "inputParams": {"params": {"sweeps":
         200}}, "providerId": "microsoft", "target": "microsoft.populationannealing.cpu",
         "metadata": null, "name": "Test-PopulationAnnealing-\"20210101-000000\"",
         "id": "00000000-0000-0000-0000-000000000000", "status": "Succeeded", "outputDataFormat":
-        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-PopulationAnnealing-%252220210101-000000%2522-5ec5fdfe-7977-11ec-9c89-acde48001122.output.json",
-        "creationTime": "2022-01-19T22:30:16.1678985+00:00", "beginExecutionTime":
-        "2022-01-19T22:30:17.1818033Z", "endExecutionTime": "2022-01-19T22:30:17.3422759Z",
+        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-PopulationAnnealing-%252220210101-000000%2522-712bec7b-d0c7-11ec-9985-2816a847b9a3.output.json",
+        "creationTime": "2022-05-11T01:12:37.6067116+00:00", "beginExecutionTime":
+        "2022-05-11T01:12:34.6208383Z", "endExecutionTime": "2022-05-11T01:12:34.7814437Z",
         "cancellationTime": null, "costEstimate": null, "errorData": null, "isCancelling":
         false, "tags": [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1499'
+      - '1478'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -245,38 +244,38 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:19 GMT
+      - Wed, 11 May 2022 01:12:41 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
-    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-PopulationAnnealing-%252220210101-000000%2522-5ec5fdfe-7977-11ec-9c89-acde48001122.output.json
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-PopulationAnnealing-%252220210101-000000%2522-712bec7b-d0c7-11ec-9985-2816a847b9a3.output.json
   response:
     body:
       string: '{"version": "1.0", "configuration": {"0": 1, "1": 1, "2": 0, "3": 1},
         "cost": -5.0, "parameters": {"alpha": 2.0, "beta": {"final": 5.0, "initial":
         0.0, "type": "linear"}, "beta_start": 0.0, "beta_stop": 5.0, "constant_population":
-        false, "population": 72, "seed": 3994992209, "sweeps": 200, "sweeps_per_replica":
+        false, "population": 72, "seed": 585567228, "sweeps": 200, "sweeps_per_replica":
         1}, "solutions": [{"configuration": {"0": 1, "1": 1, "2": 0, "3": 1}, "cost":
         -5.0}], "access_token": "fake_token"}'
     headers:
       accept-ranges:
       - bytes
       content-length:
-      - '571'
+      - '570'
       content-range:
-      - bytes 0-570/571
+      - bytes 0-569/570
       content-type:
       - application/json
       x-ms-blob-content-md5:
-      - rxCfD9qnSnCp/Dtr9t0/Zw==
+      - 03qaT05fiw9roX6G9oK9ZA==
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 19 Jan 2022 22:30:17 GMT
+      - Wed, 11 May 2022 01:12:38 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -284,36 +283,36 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 206
       message: Partial Content
-    url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-PopulationAnnealing-%252220210101-000000%2522-5ec5fdfe-7977-11ec-9c89-acde48001122.output.json
+    url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-PopulationAnnealing-%252220210101-000000%2522-712bec7b-d0c7-11ec-9985-2816a847b9a3.output.json
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-PopulationAnnealing-%252220210101-000000%2522-5ec5fdfe-7977-11ec-9c89-acde48001122.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-PopulationAnnealing-%252220210101-000000%2522-712bec7b-d0c7-11ec-9985-2816a847b9a3.input.json",
         "inputDataFormat": "microsoft.qio.v2", "inputParams": {"params": {"sweeps":
         200}}, "providerId": "microsoft", "target": "microsoft.populationannealing.cpu",
         "metadata": null, "name": "Test-PopulationAnnealing-\"20210101-000000\"",
         "id": "00000000-0000-0000-0000-000000000000", "status": "Succeeded", "outputDataFormat":
-        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-PopulationAnnealing-%252220210101-000000%2522-5ec5fdfe-7977-11ec-9c89-acde48001122.output.json",
-        "creationTime": "2022-01-19T22:30:16.1678985+00:00", "beginExecutionTime":
-        "2022-01-19T22:30:17.1818033Z", "endExecutionTime": "2022-01-19T22:30:17.3422759Z",
+        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-PopulationAnnealing-%252220210101-000000%2522-712bec7b-d0c7-11ec-9985-2816a847b9a3.output.json",
+        "creationTime": "2022-05-11T01:12:37.6067116+00:00", "beginExecutionTime":
+        "2022-05-11T01:12:34.6208383Z", "endExecutionTime": "2022-05-11T01:12:34.7814437Z",
         "cancellationTime": null, "costEstimate": null, "errorData": null, "isCancelling":
         false, "tags": [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1513'
+      - '1480'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:

--- a/azure-quantum/tests/unit/aio/recordings/test_job_submit_microsoft_quantum_monte_carlo.yaml
+++ b/azure-quantum/tests/unit/aio/recordings/test_job_submit_microsoft_quantum_monte_carlo.yaml
@@ -6,7 +6,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - azsdk-python-identity/1.7.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-identity/1.10.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
   response:
@@ -32,7 +32,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
   response:
@@ -41,7 +41,7 @@ interactions:
         "access_token": "fake_token"}'
     headers:
       content-length:
-      - '214'
+      - '205'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -56,24 +56,24 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:21 GMT
+      - Wed, 11 May 2022 01:12:43 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
-        specified container does not exist.\nRequestId:fbbc9b9c-301e-0074-5a84-0d8687000000\nTime:2022-01-19T22:30:21.6888642Z</Message></Error>"
+        specified container does not exist.\nRequestId:caed2324-101e-003c-76d4-64b62a000000\nTime:2022-05-11T01:12:43.4620652Z</Message></Error>"
     headers:
       content-length:
       - '225'
       content-type:
       - application/xml
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 404
       message: The specified container does not exist.
@@ -84,11 +84,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:21 GMT
+      - Wed, 11 May 2022 01:12:43 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -98,7 +98,7 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -109,11 +109,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:21 GMT
+      - Wed, 11 May 2022 01:12:43 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -127,28 +127,29 @@ interactions:
       x-ms-lease-status:
       - unlocked
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 200
       message: OK
     url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
 - request:
-    body: b'\x1f\x8b\x08\x00\xfc\x90\xe8a\x02\xffU\xcc\xb1\x0e\xc2 \x10\x06\xe0Win.\x06\xaeu\xa8\xab\xb3\x83\x89\x9bm\x0c\xb6\x984\x11h\xe001\r\xef.\xa1Ce\xe2\xf8\xbf\xbb\x7f\x05\xadHN\x92$\x9c\xaa\x15\x8c\xd4*\rpS\x9e\xd85HCA_\xac!u\x96\xeemY\x0f\xc8\x11\xb9\x10\x1d\x13m\xc3\x91\xf7\x00\xb1\xae`\xb4\x9e\x1e\xaf`F\x9a\xad\xc9E\x1f\xe5\xfc6\x838pH;\xf4]r\xf5\x12\x9e6\xff\x95\xd3>\x05\xf7\x15\xc6\xf4\xb0&e\xf3\x94\x13QW|H\xbd\x9b\x1cw\xc0\x02\xba\x02\xc4\x0e\xb8CS\\\xb0\xb6\x90\xbf\x93\x12p\x88C\x8c?f\xc8\xf9\xd9\x1c\x01\x00\x00'
+    body: b'\x1f\x8b\x08\x00\x8a\r{b\x02\xffU\xcc\xb1\n\x830\x10\x06\xe0W\x91\x9bMIN\x85\xb6kg\x87B\xb7*%\xd5\x14\x84&\x11s)\x14\xc9\xbb7\xc4\xc1f\xca\xe5\xff\xee\xfe\x15\xb4"9J\x92p.V0R\xab8\xc0M9bW/\ry\xddZC\xea"\x97\xb7e\x1d
+      G\xe4\x8d\xe0L\x1c\x05\xd6\xd8\x01\x84\xb2\x80\xc1:z\xbc\xbc\x19h\xb2&\x15}\xd4\xe2\xb6\x19\xc4\x81C\xdc\xa1\xef\x9c\xaag\xff\xb4\xe9\xaf\x16\xedbp_a\x88\x0f\xabb6\x8d)\x11e\xc1\xfb\xd8\xbbI\xb3\x03fp\xca@\xec\x80;T\xd9\x05\xab3\xf9;\xc9\x01\xfb\xd0\x87\xf0\x03\xb1\xeaY\xb3\x1c\x01\x00\x00'
     headers:
       Accept:
       - application/xml
       Content-Length:
-      - '175'
+      - '176'
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:22 GMT
+      - Wed, 11 May 2022 01:12:43 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -158,7 +159,7 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -174,11 +175,11 @@ interactions:
       Accept:
       - application/json
       Content-Length:
-      - '632'
+      - '616'
       Content-Type:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: PUT
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
@@ -189,14 +190,14 @@ interactions:
         1}}, "providerId": "microsoft", "target": "microsoft.qmc.cpu", "metadata":
         null, "name": "Test-QuantumMonteCarlo-\"20210101-000000\"", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Waiting", "outputDataFormat": "microsoft.qio-results.v2", "outputDataUri":
-        "https://azuresdkteststo.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "creationTime": "2022-01-19T22:30:22.7373569+00:00", "beginExecutionTime":
+        "https://e2etests.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "creationTime": "2022-05-11T01:12:43.9296081+00:00", "beginExecutionTime":
         null, "endExecutionTime": null, "cancellationTime": null, "costEstimate":
         null, "errorData": null, "isCancelling": false, "tags": [], "access_token":
         "fake_token"}'
     headers:
       content-length:
-      - '1183'
+      - '1156'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -211,25 +212,25 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-QuantumMonteCarlo-%252220210101-000000%2522-626a2b6a-7977-11ec-9c89-acde48001122.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-QuantumMonteCarlo-%252220210101-000000%2522-75189690-d0c7-11ec-bc50-2816a847b9a3.input.json",
         "inputDataFormat": "microsoft.qio.v2", "inputParams": {"params": {"trotter_number":
         1}}, "providerId": "microsoft", "target": "microsoft.qmc.cpu", "metadata":
         null, "name": "Test-QuantumMonteCarlo-\"20210101-000000\"", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "microsoft.qio-results.v2", "outputDataUri":
-        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-QuantumMonteCarlo-%252220210101-000000%2522-626a2b6a-7977-11ec-9c89-acde48001122.output.json",
-        "creationTime": "2022-01-19T22:30:22.7373569+00:00", "beginExecutionTime":
-        "2022-01-19T22:30:24.0934985Z", "endExecutionTime": "2022-01-19T22:30:24.2008487Z",
+        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-QuantumMonteCarlo-%252220210101-000000%2522-75189690-d0c7-11ec-bc50-2816a847b9a3.output.json",
+        "creationTime": "2022-05-11T01:12:43.9296081+00:00", "beginExecutionTime":
+        "2022-05-11T01:12:23.172107Z", "endExecutionTime": "2022-05-11T01:12:23.3281905Z",
         "cancellationTime": null, "costEstimate": null, "errorData": null, "isCancelling":
         false, "tags": [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1485'
+      - '1457'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -244,15 +245,15 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:25 GMT
+      - Wed, 11 May 2022 01:12:47 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
-    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-QuantumMonteCarlo-%252220210101-000000%2522-626a2b6a-7977-11ec-9c89-acde48001122.output.json
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-QuantumMonteCarlo-%252220210101-000000%2522-75189690-d0c7-11ec-bc50-2816a847b9a3.output.json
   response:
     body:
       string: '{"version": "1.0", "configuration": {"1": 1, "0": 1, "2": 0, "3": 1},
@@ -272,7 +273,7 @@ interactions:
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 19 Jan 2022 22:30:23 GMT
+      - Wed, 11 May 2022 01:12:44 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -280,36 +281,36 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 206
       message: Partial Content
-    url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-QuantumMonteCarlo-%252220210101-000000%2522-626a2b6a-7977-11ec-9c89-acde48001122.output.json
+    url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-QuantumMonteCarlo-%252220210101-000000%2522-75189690-d0c7-11ec-bc50-2816a847b9a3.output.json
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-QuantumMonteCarlo-%252220210101-000000%2522-626a2b6a-7977-11ec-9c89-acde48001122.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-QuantumMonteCarlo-%252220210101-000000%2522-75189690-d0c7-11ec-bc50-2816a847b9a3.input.json",
         "inputDataFormat": "microsoft.qio.v2", "inputParams": {"params": {"trotter_number":
         1}}, "providerId": "microsoft", "target": "microsoft.qmc.cpu", "metadata":
         null, "name": "Test-QuantumMonteCarlo-\"20210101-000000\"", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "microsoft.qio-results.v2", "outputDataUri":
-        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-QuantumMonteCarlo-%252220210101-000000%2522-626a2b6a-7977-11ec-9c89-acde48001122.output.json",
-        "creationTime": "2022-01-19T22:30:22.7373569+00:00", "beginExecutionTime":
-        "2022-01-19T22:30:24.0934985Z", "endExecutionTime": "2022-01-19T22:30:24.2008487Z",
+        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-QuantumMonteCarlo-%252220210101-000000%2522-75189690-d0c7-11ec-bc50-2816a847b9a3.output.json",
+        "creationTime": "2022-05-11T01:12:43.9296081+00:00", "beginExecutionTime":
+        "2022-05-11T01:12:23.172107Z", "endExecutionTime": "2022-05-11T01:12:23.3281905Z",
         "cancellationTime": null, "costEstimate": null, "errorData": null, "isCancelling":
         false, "tags": [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1487'
+      - '1457'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:

--- a/azure-quantum/tests/unit/aio/recordings/test_job_submit_microsoft_simulated_annealing.yaml
+++ b/azure-quantum/tests/unit/aio/recordings/test_job_submit_microsoft_simulated_annealing.yaml
@@ -6,7 +6,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - azsdk-python-identity/1.7.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-identity/1.10.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
   response:
@@ -32,7 +32,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
   response:
@@ -41,7 +41,7 @@ interactions:
         "access_token": "fake_token"}'
     headers:
       content-length:
-      - '212'
+      - '211'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -56,24 +56,24 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:27 GMT
+      - Wed, 11 May 2022 01:12:48 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
-        specified container does not exist.\nRequestId:1cab83c5-101e-0063-4e84-0d2f8c000000\nTime:2022-01-19T22:30:27.9708387Z</Message></Error>"
+        specified container does not exist.\nRequestId:3209d5f6-301e-003b-25d4-64da49000000\nTime:2022-05-11T01:12:48.4859147Z</Message></Error>"
     headers:
       content-length:
       - '225'
       content-type:
       - application/xml
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 404
       message: The specified container does not exist.
@@ -84,11 +84,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:27 GMT
+      - Wed, 11 May 2022 01:12:48 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -98,7 +98,7 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -109,11 +109,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:28 GMT
+      - Wed, 11 May 2022 01:12:48 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -127,14 +127,15 @@ interactions:
       x-ms-lease-status:
       - unlocked
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 200
       message: OK
     url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
 - request:
-    body: b'\x1f\x8b\x08\x00\x02\x91\xe8a\x02\xffU\xccA\x0e\x83 \x10\x05\xd0\xab\x98YK\x03\xa3mbw=C\xbb\xab\xa6\xa1J\x1b\x12\x01#c\x93\xc6p\xf7\x12\\XV\x0c\xff\xcd\xfc\x15\x8c"9H\x92p.V\xb0\xd2\xa88\xc0MybWm\x96Q\x92\x1a.\xd6*9j\xfbf-
-      G\xe4B4L\xd4\x15\xc7S\x0b\x10\xca\x02z\xe7\xe9\xf1ZlO\xda\xd9\xd4\xf4Q\xb3\xdff\x10\x07\x0eq\x87\xbeS\xea\x9e\x96\xa7K\x7f5\x1b\x1f\x83\xfb\n}|X\x153=\xa4D\x94\x05\xefb\xef&\xc7\x1d0\x83&\x03\xb1\x03\xeePe\x17\xac\xce\xe4\xef$\x07\xecB\x17\xc2\x0f\x9e8\x14u\x1d\x01\x00\x00'
+    body: b'\x1f\x8b\x08\x00\x8f\r{b\x02\xffU\xccM\x0e\x83 \x10\x05\xe0\xab\x98YK\x03\xa3\xa6?;\xcf\xd0\xee\xaai\xa8N\x1b\x12A#\xd8\xa41\xdc\xbd\x04\x17\x96\x15\xc3\xfbf\xde\n\x9a\x9c\xec\xa5\x93p\xc9V0RS\x18\xe0F\xd6\xb1\xab\xd2\xcb
+      \x1d\xf5\xb51$\x07e\xde\xac\x01\xe4\x88\xbc\x12\x9c\x89\x93\xc0\xf2\xd8\x00\xf8<\x83n\xb4\xee\xf1ZL\xe7\xd4hb\xd3\x87f\xbb\xcd
+      \x0e\x1c\xc2\x8e\xfbN\xb1{Z\x9ec\xfc\xd3\xacm\x08\xee+t\xe1aE\xc8T\x1f\x13\x91g\xbc\r\xbd\x9bT;`\x02\xe7\x04\xc4\x0e\xb8C\x91\\\xb02\x91\xbf\x93\x14\xb0\xf5\xad\xf7?\xf5PK\x91\x1d\x01\x00\x00'
     headers:
       Accept:
       - application/xml
@@ -143,13 +144,13 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:28 GMT
+      - Wed, 11 May 2022 01:12:48 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -159,7 +160,7 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -175,11 +176,11 @@ interactions:
       Accept:
       - application/json
       Content-Length:
-      - '642'
+      - '634'
       Content-Type:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: PUT
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
@@ -190,14 +191,14 @@ interactions:
         0}}, "providerId": "microsoft", "target": "microsoft.simulatedannealing.cpu",
         "metadata": null, "name": "Test-SimulatedAnnealing-\"20210101-000000\"", "id":
         "00000000-0000-0000-0000-000000000000", "status": "Waiting", "outputDataFormat":
-        "microsoft.qio-results.v2", "outputDataUri": "https://azuresdkteststo.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "creationTime": "2022-01-19T22:30:28.7457739+00:00", "beginExecutionTime":
+        "microsoft.qio-results.v2", "outputDataUri": "https://e2etests.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "creationTime": "2022-05-11T01:12:49.0442689+00:00", "beginExecutionTime":
         null, "endExecutionTime": null, "cancellationTime": null, "costEstimate":
         null, "errorData": null, "isCancelling": false, "tags": [], "access_token":
         "fake_token"}'
     headers:
       content-length:
-      - '1189'
+      - '1184'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -212,56 +213,25 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-664303ce-7977-11ec-9c89-acde48001122.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-7857031f-d0c7-11ec-b00f-2816a847b9a3.input.json",
         "inputDataFormat": "microsoft.qio.v2", "inputParams": {"params": {"beta_start":
         0}}, "providerId": "microsoft", "target": "microsoft.simulatedannealing.cpu",
         "metadata": null, "name": "Test-SimulatedAnnealing-\"20210101-000000\"", "id":
         "00000000-0000-0000-0000-000000000000", "status": "Executing", "outputDataFormat":
-        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-664303ce-7977-11ec-9c89-acde48001122.output.json",
-        "creationTime": "2022-01-19T22:30:28.7457739+00:00", "beginExecutionTime":
-        "2022-01-19T22:30:29.3771426Z", "endExecutionTime": null, "cancellationTime":
+        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-7857031f-d0c7-11ec-b00f-2816a847b9a3.output.json",
+        "creationTime": "2022-05-11T01:12:49.0442689+00:00", "beginExecutionTime":
+        "2022-05-11T01:12:49.5353146Z", "endExecutionTime": null, "cancellationTime":
         null, "costEstimate": null, "errorData": null, "isCancelling": false, "tags":
         [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1464'
-      content-type:
-      - application/json; charset=utf-8
-    status:
-      code: 200
-      message: OK
-    url: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
-    method: GET
-    uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
-  response:
-    body:
-      string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-664303ce-7977-11ec-9c89-acde48001122.input.json",
-        "inputDataFormat": "microsoft.qio.v2", "inputParams": {"params": {"beta_start":
-        0}}, "providerId": "microsoft", "target": "microsoft.simulatedannealing.cpu",
-        "metadata": null, "name": "Test-SimulatedAnnealing-\"20210101-000000\"", "id":
-        "00000000-0000-0000-0000-000000000000", "status": "Executing", "outputDataFormat":
-        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-664303ce-7977-11ec-9c89-acde48001122.output.json",
-        "creationTime": "2022-01-19T22:30:28.7457739+00:00", "beginExecutionTime":
-        "2022-01-19T22:30:29.3771426Z", "endExecutionTime": null, "cancellationTime":
-        null, "costEstimate": null, "errorData": null, "isCancelling": false, "tags":
-        [], "access_token": "fake_token"}'
-    headers:
-      content-length:
-      - '1464'
+      - '1447'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -276,25 +246,25 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-664303ce-7977-11ec-9c89-acde48001122.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-7857031f-d0c7-11ec-b00f-2816a847b9a3.input.json",
         "inputDataFormat": "microsoft.qio.v2", "inputParams": {"params": {"beta_start":
         0}}, "providerId": "microsoft", "target": "microsoft.simulatedannealing.cpu",
         "metadata": null, "name": "Test-SimulatedAnnealing-\"20210101-000000\"", "id":
         "00000000-0000-0000-0000-000000000000", "status": "Executing", "outputDataFormat":
-        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-664303ce-7977-11ec-9c89-acde48001122.output.json",
-        "creationTime": "2022-01-19T22:30:28.7457739+00:00", "beginExecutionTime":
-        "2022-01-19T22:30:29.3771426Z", "endExecutionTime": null, "cancellationTime":
+        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-7857031f-d0c7-11ec-b00f-2816a847b9a3.output.json",
+        "creationTime": "2022-05-11T01:12:49.0442689+00:00", "beginExecutionTime":
+        "2022-05-11T01:12:49.5353146Z", "endExecutionTime": null, "cancellationTime":
         null, "costEstimate": null, "errorData": null, "isCancelling": false, "tags":
         [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1464'
+      - '1451'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -309,25 +279,25 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-664303ce-7977-11ec-9c89-acde48001122.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-7857031f-d0c7-11ec-b00f-2816a847b9a3.input.json",
         "inputDataFormat": "microsoft.qio.v2", "inputParams": {"params": {"beta_start":
         0}}, "providerId": "microsoft", "target": "microsoft.simulatedannealing.cpu",
         "metadata": null, "name": "Test-SimulatedAnnealing-\"20210101-000000\"", "id":
         "00000000-0000-0000-0000-000000000000", "status": "Executing", "outputDataFormat":
-        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-664303ce-7977-11ec-9c89-acde48001122.output.json",
-        "creationTime": "2022-01-19T22:30:28.7457739+00:00", "beginExecutionTime":
-        "2022-01-19T22:30:29.3771426Z", "endExecutionTime": null, "cancellationTime":
+        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-7857031f-d0c7-11ec-b00f-2816a847b9a3.output.json",
+        "creationTime": "2022-05-11T01:12:49.0442689+00:00", "beginExecutionTime":
+        "2022-05-11T01:12:49.5353146Z", "endExecutionTime": null, "cancellationTime":
         null, "costEstimate": null, "errorData": null, "isCancelling": false, "tags":
         [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1468'
+      - '1451'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -342,25 +312,25 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-664303ce-7977-11ec-9c89-acde48001122.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-7857031f-d0c7-11ec-b00f-2816a847b9a3.input.json",
         "inputDataFormat": "microsoft.qio.v2", "inputParams": {"params": {"beta_start":
         0}}, "providerId": "microsoft", "target": "microsoft.simulatedannealing.cpu",
         "metadata": null, "name": "Test-SimulatedAnnealing-\"20210101-000000\"", "id":
         "00000000-0000-0000-0000-000000000000", "status": "Executing", "outputDataFormat":
-        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-664303ce-7977-11ec-9c89-acde48001122.output.json",
-        "creationTime": "2022-01-19T22:30:28.7457739+00:00", "beginExecutionTime":
-        "2022-01-19T22:30:29.3771426Z", "endExecutionTime": null, "cancellationTime":
+        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-7857031f-d0c7-11ec-b00f-2816a847b9a3.output.json",
+        "creationTime": "2022-05-11T01:12:49.0442689+00:00", "beginExecutionTime":
+        "2022-05-11T01:12:49.5353146Z", "endExecutionTime": null, "cancellationTime":
         null, "costEstimate": null, "errorData": null, "isCancelling": false, "tags":
         [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1468'
+      - '1451'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -375,25 +345,25 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-664303ce-7977-11ec-9c89-acde48001122.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-7857031f-d0c7-11ec-b00f-2816a847b9a3.input.json",
         "inputDataFormat": "microsoft.qio.v2", "inputParams": {"params": {"beta_start":
         0}}, "providerId": "microsoft", "target": "microsoft.simulatedannealing.cpu",
         "metadata": null, "name": "Test-SimulatedAnnealing-\"20210101-000000\"", "id":
         "00000000-0000-0000-0000-000000000000", "status": "Executing", "outputDataFormat":
-        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-664303ce-7977-11ec-9c89-acde48001122.output.json",
-        "creationTime": "2022-01-19T22:30:28.7457739+00:00", "beginExecutionTime":
-        "2022-01-19T22:30:29.3771426Z", "endExecutionTime": null, "cancellationTime":
+        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-7857031f-d0c7-11ec-b00f-2816a847b9a3.output.json",
+        "creationTime": "2022-05-11T01:12:49.0442689+00:00", "beginExecutionTime":
+        "2022-05-11T01:12:49.5353146Z", "endExecutionTime": null, "cancellationTime":
         null, "costEstimate": null, "errorData": null, "isCancelling": false, "tags":
         [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1470'
+      - '1451'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -408,25 +378,25 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-664303ce-7977-11ec-9c89-acde48001122.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-7857031f-d0c7-11ec-b00f-2816a847b9a3.input.json",
         "inputDataFormat": "microsoft.qio.v2", "inputParams": {"params": {"beta_start":
         0}}, "providerId": "microsoft", "target": "microsoft.simulatedannealing.cpu",
         "metadata": null, "name": "Test-SimulatedAnnealing-\"20210101-000000\"", "id":
         "00000000-0000-0000-0000-000000000000", "status": "Executing", "outputDataFormat":
-        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-664303ce-7977-11ec-9c89-acde48001122.output.json",
-        "creationTime": "2022-01-19T22:30:28.7457739+00:00", "beginExecutionTime":
-        "2022-01-19T22:30:29.3771426Z", "endExecutionTime": null, "cancellationTime":
+        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-7857031f-d0c7-11ec-b00f-2816a847b9a3.output.json",
+        "creationTime": "2022-05-11T01:12:49.0442689+00:00", "beginExecutionTime":
+        "2022-05-11T01:12:49.5353146Z", "endExecutionTime": null, "cancellationTime":
         null, "costEstimate": null, "errorData": null, "isCancelling": false, "tags":
         [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1464'
+      - '1451'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -441,25 +411,25 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-664303ce-7977-11ec-9c89-acde48001122.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-7857031f-d0c7-11ec-b00f-2816a847b9a3.input.json",
         "inputDataFormat": "microsoft.qio.v2", "inputParams": {"params": {"beta_start":
         0}}, "providerId": "microsoft", "target": "microsoft.simulatedannealing.cpu",
         "metadata": null, "name": "Test-SimulatedAnnealing-\"20210101-000000\"", "id":
         "00000000-0000-0000-0000-000000000000", "status": "Succeeded", "outputDataFormat":
-        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-664303ce-7977-11ec-9c89-acde48001122.output.json",
-        "creationTime": "2022-01-19T22:30:28.7457739+00:00", "beginExecutionTime":
-        "2022-01-19T22:30:29.4744278Z", "endExecutionTime": "2022-01-19T22:30:34.6217389Z",
+        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-7857031f-d0c7-11ec-b00f-2816a847b9a3.output.json",
+        "creationTime": "2022-05-11T01:12:49.0442689+00:00", "beginExecutionTime":
+        "2022-05-11T01:12:16.0359615Z", "endExecutionTime": "2022-05-11T01:12:21.1330468Z",
         "cancellationTime": null, "costEstimate": null, "errorData": null, "isCancelling":
         false, "tags": [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1493'
+      - '1484'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -474,15 +444,15 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:37 GMT
+      - Wed, 11 May 2022 01:12:57 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
-    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-664303ce-7977-11ec-9c89-acde48001122.output.json
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-7857031f-d0c7-11ec-b00f-2816a847b9a3.output.json
   response:
     body:
       string: '{"version": "1.0", "configuration": {"1": 1, "0": 1, "2": 0, "3": 1},
@@ -502,7 +472,7 @@ interactions:
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 19 Jan 2022 22:30:29 GMT
+      - Wed, 11 May 2022 01:12:49 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -510,36 +480,36 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 206
       message: Partial Content
-    url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-664303ce-7977-11ec-9c89-acde48001122.output.json
+    url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-7857031f-d0c7-11ec-b00f-2816a847b9a3.output.json
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-664303ce-7977-11ec-9c89-acde48001122.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-7857031f-d0c7-11ec-b00f-2816a847b9a3.input.json",
         "inputDataFormat": "microsoft.qio.v2", "inputParams": {"params": {"beta_start":
         0}}, "providerId": "microsoft", "target": "microsoft.simulatedannealing.cpu",
         "metadata": null, "name": "Test-SimulatedAnnealing-\"20210101-000000\"", "id":
         "00000000-0000-0000-0000-000000000000", "status": "Succeeded", "outputDataFormat":
-        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-664303ce-7977-11ec-9c89-acde48001122.output.json",
-        "creationTime": "2022-01-19T22:30:28.7457739+00:00", "beginExecutionTime":
-        "2022-01-19T22:30:29.4744278Z", "endExecutionTime": "2022-01-19T22:30:34.6217389Z",
+        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SimulatedAnnealing-%252220210101-000000%2522-7857031f-d0c7-11ec-b00f-2816a847b9a3.output.json",
+        "creationTime": "2022-05-11T01:12:49.0442689+00:00", "beginExecutionTime":
+        "2022-05-11T01:12:16.0359615Z", "endExecutionTime": "2022-05-11T01:12:21.1330468Z",
         "cancellationTime": null, "costEstimate": null, "errorData": null, "isCancelling":
         false, "tags": [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1493'
+      - '1484'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -555,7 +525,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - azsdk-python-identity/1.7.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-identity/1.10.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
   response:
@@ -581,7 +551,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
   response:
@@ -590,9 +560,11 @@ interactions:
         "access_token": "fake_token"}'
     headers:
       content-length:
-      - '216'
+      - '209'
       content-type:
       - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
     status:
       code: 200
       message: OK
@@ -603,24 +575,24 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:39 GMT
+      - Wed, 11 May 2022 01:13:01 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
-        specified container does not exist.\nRequestId:41fd19c1-501e-0010-7284-0d771f000000\nTime:2022-01-19T22:30:39.6134016Z</Message></Error>"
+        specified container does not exist.\nRequestId:7fdc9407-301e-0014-71d4-64d782000000\nTime:2022-05-11T01:13:01.3557145Z</Message></Error>"
     headers:
       content-length:
       - '225'
       content-type:
       - application/xml
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 404
       message: The specified container does not exist.
@@ -631,11 +603,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:39 GMT
+      - Wed, 11 May 2022 01:13:01 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -645,7 +617,7 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -656,11 +628,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:39 GMT
+      - Wed, 11 May 2022 01:13:01 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -674,13 +646,13 @@ interactions:
       x-ms-lease-status:
       - unlocked
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 200
       message: OK
     url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
 - request:
-    body: b'\x1f\x8b\x08\x00\r\x91\xe8a\x02\xffU\xcc\xb1\x0e\xc2 \x10\x06\xe0W!7\x17\xd3R\x1d\xf4\x01\x1c\x9c\xbb\x19b(EC"\xd0\xc0\xd5\xc4\x10\xde]B\x07d\xe2\xf8\xbf\xfb/\x82Q(\x16\x81\x02.$\x82\x15F\xe5\x01&\x15\x90\xde\xdcL\xaf\xfa\x8d\xcak\xfb\x82\xd4\x11\x90.\xe0\xe3\xb9Y\x89\xda\xd9R\xf8(\x1f\xf6\x19\x86C\x0fy\x07\xbfk9\xb1n\xb3+\x7f\xe5M\xc8\xc1=\x82\xcc\x0f\x1ds\xa6\x97\x92\x0c\x1d\xe9y\xbe\xbb\xcb\xa9\x02k\xe0\xdc\xc0P\x81U\x18\x9b\x06=6\xf2Wi\x81\xf1\xc4S\xfa\x01\xae\xc4lL\x04\x01\x00\x00'
+    body: b'\x1f\x8b\x08\x00\x9b\r{b\x02\xffU\xcc\xb1\x0e\xc2 \x10\x06\xe0W!7\x17\xd3R\x1d\xf4\x01\x1c\x9c\xbb\x19b(EC"\xd0\xc0\xd5\xc4\x10\xde]B\x07d\xe2\xf8\xbf\xfb/\x82Q(\x16\x81\x02.$\x82\x15F\xe5\x01&\x15\x90\xde\xdcL\xaf\xfa\x8d\xcak\xfb\x82\xd4\x11\x90.\xe0\xe3\xb9Y\x89\xda\xd9R\xf8(\x1f\xf6\x19\x86C\x0fy\x07\xbfk9\xb1n\xb3+\x7f\xe5M\xc8\xc1=\x82\xcc\x0f\x1ds\xa6\x97\x92\x0c\x1d\xe9y\xbe\xbb\xcb\xa9\x02k\xe0\xdc\xc0P\x81U\x18\x9b\x06=6\xf2Wi\x81\xf1\xc4S\xfa\x01\xae\xc4lL\x04\x01\x00\x00'
     headers:
       Accept:
       - application/xml
@@ -689,13 +661,13 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:40 GMT
+      - Wed, 11 May 2022 01:13:01 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -705,7 +677,7 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -721,11 +693,11 @@ interactions:
       Accept:
       - application/json
       Content-Length:
-      - '621'
+      - '607'
       Content-Type:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: PUT
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
@@ -736,14 +708,14 @@ interactions:
         0}}, "providerId": "microsoft", "target": "microsoft.simulatedannealing.cpu",
         "metadata": null, "name": "Test-Job-Filtering", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Waiting", "outputDataFormat": "microsoft.qio-results.v2", "outputDataUri":
-        "https://azuresdkteststo.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "creationTime": "2022-01-19T22:30:40.5102565+00:00", "beginExecutionTime":
+        "https://e2etests.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "creationTime": "2022-05-11T01:13:02.8572888+00:00", "beginExecutionTime":
         null, "endExecutionTime": null, "cancellationTime": null, "costEstimate":
         null, "errorData": null, "isCancelling": false, "tags": [], "access_token":
         "fake_token"}'
     headers:
       content-length:
-      - '1172'
+      - '1153'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:

--- a/azure-quantum/tests/unit/aio/recordings/test_job_submit_microsoft_substochastic_monte_carlo.yaml
+++ b/azure-quantum/tests/unit/aio/recordings/test_job_submit_microsoft_substochastic_monte_carlo.yaml
@@ -6,7 +6,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - azsdk-python-identity/1.7.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-identity/1.10.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
   response:
@@ -32,7 +32,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
   response:
@@ -41,7 +41,7 @@ interactions:
         "access_token": "fake_token"}'
     headers:
       content-length:
-      - '216'
+      - '209'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -56,24 +56,24 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:41 GMT
+      - Wed, 11 May 2022 01:13:03 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
-        specified container does not exist.\nRequestId:f1cf4536-d01e-006c-7f84-0d59e0000000\nTime:2022-01-19T22:30:42.1098224Z</Message></Error>"
+        specified container does not exist.\nRequestId:623bc709-501e-003d-55d4-64e9f6000000\nTime:2022-05-11T01:13:03.9595676Z</Message></Error>"
     headers:
       content-length:
       - '225'
       content-type:
       - application/xml
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 404
       message: The specified container does not exist.
@@ -84,11 +84,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:42 GMT
+      - Wed, 11 May 2022 01:13:03 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -98,7 +98,7 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -109,11 +109,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:42 GMT
+      - Wed, 11 May 2022 01:13:04 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -127,13 +127,15 @@ interactions:
       x-ms-lease-status:
       - unlocked
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 200
       message: OK
     url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
 - request:
-    body: b'\x1f\x8b\x08\x00\x10\x91\xe8a\x02\xffU\x8d1\x0f\xc2 \x10\x85\xffJss1@q\xa8\xab\xb3\x93n\xb61\x94blb\xa1\x81\xab\x89!\xfcw\t\x1d*\xd3\xbd{\xdf\xbdw\x01f\x8dr\x94(\xe1T\x050r\xd6I\xc0M{$\xd7u\xf0h\xd5Kz\x9c\xd4\xc5\x1a\xd4g\xe9\xde\x96t\xc0)\xe7\x94\xb1\x960\xd1PA;\x80XW\xa0\xac\xc7\xc7s5\n\'kr\xddG;\xbfi`\x07\n\xe9\x06\xbfK~\xb0\xac\x83\xcd\xbbv\xb3O\xc6=\x80J\x834\xc9\x9b\xc6\xec\xb0\xba\xa2}\xea\xdd\xc8q\x07\xbc\x00m\x01\xd8\x0e\xf8\x0e\x9a"ADA\xfe"%\xe0}\xecc\xfc\x01+\xe2\\\xa5"\x01\x00\x00'
+    body: 'b''\x1f\x8b\x08\x00\x9f\r{b\x02\xffU\x8d\xcd\n\xc20\x10\x84_\xa5\xec\xb9\x91\xfcXP\xaf\x9e=\xe9\xcd\x16I\xd3\x88\x05\x93\x94d+H\xc9\xbb\x1b\xd2C\xcdig\xe7\xdb\x99]\xc0h\x94\x83D\t\xa7j\x01+\x8dN\x02n:
+      \xb9\xce}@\xa7^2\xe0\xa8.\xce\xa2>K\xffv\xa4\x05N9\xa7\r\xa3\x84\x1d\x98\xa0\xa2\x05\x88u\x05\xca\x05|<g\xabpt6\xd7}\xb4\x0f\xab\x06\xb6\xa3\x90n\xf0;\xe5\x07\xd3\xdc\xbb\xbckoB2\xee\x0b\xa84\x88H\xde8d\x87\xd5\x15\xedR\xefJ\x9a\r\xf0\x02\x1c\x0b\xc06\xc07
+      \x8a\x04\xd9\x17\xe4/R\x02\xde\xc5.\xc6\x1f\xa2F\xc0\xca"\x01\x00\x00'''
     headers:
       Accept:
       - application/xml
@@ -142,13 +144,13 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:42 GMT
+      - Wed, 11 May 2022 01:13:04 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -158,7 +160,7 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -174,11 +176,11 @@ interactions:
       Accept:
       - application/json
       Content-Length:
-      - '658'
+      - '644'
       Content-Type:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: PUT
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
@@ -189,14 +191,14 @@ interactions:
         280}}, "providerId": "microsoft", "target": "microsoft.substochasticmontecarlo.cpu",
         "metadata": null, "name": "Test-SubstochasticMonteCarlo-\"20210101-000000\"",
         "id": "00000000-0000-0000-0000-000000000000", "status": "Waiting", "outputDataFormat":
-        "microsoft.qio-results.v2", "outputDataUri": "https://azuresdkteststo.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "creationTime": "2022-01-19T22:30:43.0454009+00:00", "beginExecutionTime":
+        "microsoft.qio-results.v2", "outputDataUri": "https://e2etests.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "creationTime": "2022-05-11T01:13:04.4301724+00:00", "beginExecutionTime":
         null, "endExecutionTime": null, "cancellationTime": null, "costEstimate":
         null, "errorData": null, "isCancelling": false, "tags": [], "access_token":
         "fake_token"}'
     headers:
       content-length:
-      - '1211'
+      - '1190'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -211,25 +213,25 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SubstochasticMonteCarlo-%252220210101-000000%2522-6eaae7d4-7977-11ec-9c89-acde48001122.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SubstochasticMonteCarlo-%252220210101-000000%2522-816ec5c0-d0c7-11ec-b383-2816a847b9a3.input.json",
         "inputDataFormat": "microsoft.qio.v2", "inputParams": {"params": {"step_limit":
         280}}, "providerId": "microsoft", "target": "microsoft.substochasticmontecarlo.cpu",
         "metadata": null, "name": "Test-SubstochasticMonteCarlo-\"20210101-000000\"",
         "id": "00000000-0000-0000-0000-000000000000", "status": "Waiting", "outputDataFormat":
-        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SubstochasticMonteCarlo-%252220210101-000000%2522-6eaae7d4-7977-11ec-9c89-acde48001122.output.json",
-        "creationTime": "2022-01-19T22:30:43.0454009+00:00", "beginExecutionTime":
+        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SubstochasticMonteCarlo-%252220210101-000000%2522-816ec5c0-d0c7-11ec-b383-2816a847b9a3.output.json",
+        "creationTime": "2022-05-11T01:13:04.4301724+00:00", "beginExecutionTime":
         null, "endExecutionTime": null, "cancellationTime": null, "costEstimate":
         null, "errorData": null, "isCancelling": false, "tags": [], "access_token":
         "fake_token"}'
     headers:
       content-length:
-      - '1462'
+      - '1445'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -244,25 +246,25 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SubstochasticMonteCarlo-%252220210101-000000%2522-6eaae7d4-7977-11ec-9c89-acde48001122.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SubstochasticMonteCarlo-%252220210101-000000%2522-816ec5c0-d0c7-11ec-b383-2816a847b9a3.input.json",
         "inputDataFormat": "microsoft.qio.v2", "inputParams": {"params": {"step_limit":
         280}}, "providerId": "microsoft", "target": "microsoft.substochasticmontecarlo.cpu",
         "metadata": null, "name": "Test-SubstochasticMonteCarlo-\"20210101-000000\"",
         "id": "00000000-0000-0000-0000-000000000000", "status": "Waiting", "outputDataFormat":
-        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SubstochasticMonteCarlo-%252220210101-000000%2522-6eaae7d4-7977-11ec-9c89-acde48001122.output.json",
-        "creationTime": "2022-01-19T22:30:43.0454009+00:00", "beginExecutionTime":
+        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SubstochasticMonteCarlo-%252220210101-000000%2522-816ec5c0-d0c7-11ec-b383-2816a847b9a3.output.json",
+        "creationTime": "2022-05-11T01:13:04.4301724+00:00", "beginExecutionTime":
         null, "endExecutionTime": null, "cancellationTime": null, "costEstimate":
         null, "errorData": null, "isCancelling": false, "tags": [], "access_token":
         "fake_token"}'
     headers:
       content-length:
-      - '1462'
+      - '1445'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -277,91 +279,58 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SubstochasticMonteCarlo-%252220210101-000000%2522-6eaae7d4-7977-11ec-9c89-acde48001122.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SubstochasticMonteCarlo-%252220210101-000000%2522-816ec5c0-d0c7-11ec-b383-2816a847b9a3.input.json",
         "inputDataFormat": "microsoft.qio.v2", "inputParams": {"params": {"step_limit":
         280}}, "providerId": "microsoft", "target": "microsoft.substochasticmontecarlo.cpu",
         "metadata": null, "name": "Test-SubstochasticMonteCarlo-\"20210101-000000\"",
-        "id": "00000000-0000-0000-0000-000000000000", "status": "Waiting", "outputDataFormat":
-        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SubstochasticMonteCarlo-%252220210101-000000%2522-6eaae7d4-7977-11ec-9c89-acde48001122.output.json",
-        "creationTime": "2022-01-19T22:30:43.0454009+00:00", "beginExecutionTime":
-        null, "endExecutionTime": null, "cancellationTime": null, "costEstimate":
-        null, "errorData": null, "isCancelling": false, "tags": [], "access_token":
-        "fake_token"}'
-    headers:
-      content-length:
-      - '1462'
-      content-type:
-      - application/json; charset=utf-8
-      transfer-encoding:
-      - chunked
-    status:
-      code: 200
-      message: OK
-    url: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
-    method: GET
-    uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
-  response:
-    body:
-      string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SubstochasticMonteCarlo-%252220210101-000000%2522-6eaae7d4-7977-11ec-9c89-acde48001122.input.json",
-        "inputDataFormat": "microsoft.qio.v2", "inputParams": {"params": {"step_limit":
-        280}}, "providerId": "microsoft", "target": "microsoft.substochasticmontecarlo.cpu",
-        "metadata": null, "name": "Test-SubstochasticMonteCarlo-\"20210101-000000\"",
-        "id": "00000000-0000-0000-0000-000000000000", "status": "Waiting", "outputDataFormat":
-        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SubstochasticMonteCarlo-%252220210101-000000%2522-6eaae7d4-7977-11ec-9c89-acde48001122.output.json",
-        "creationTime": "2022-01-19T22:30:43.0454009+00:00", "beginExecutionTime":
-        null, "endExecutionTime": null, "cancellationTime": null, "costEstimate":
-        null, "errorData": null, "isCancelling": false, "tags": [], "access_token":
-        "fake_token"}'
-    headers:
-      content-length:
-      - '1468'
-      content-type:
-      - application/json; charset=utf-8
-      transfer-encoding:
-      - chunked
-    status:
-      code: 200
-      message: OK
-    url: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
-    method: GET
-    uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
-  response:
-    body:
-      string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SubstochasticMonteCarlo-%252220210101-000000%2522-6eaae7d4-7977-11ec-9c89-acde48001122.input.json",
-        "inputDataFormat": "microsoft.qio.v2", "inputParams": {"params": {"step_limit":
-        280}}, "providerId": "microsoft", "target": "microsoft.substochasticmontecarlo.cpu",
-        "metadata": null, "name": "Test-SubstochasticMonteCarlo-\"20210101-000000\"",
-        "id": "00000000-0000-0000-0000-000000000000", "status": "Succeeded", "outputDataFormat":
-        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SubstochasticMonteCarlo-%252220210101-000000%2522-6eaae7d4-7977-11ec-9c89-acde48001122.output.json",
-        "creationTime": "2022-01-19T22:30:43.0454009+00:00", "beginExecutionTime":
-        "2022-01-19T22:30:44.0513605Z", "endExecutionTime": "2022-01-19T22:30:44.1570995Z",
+        "id": "00000000-0000-0000-0000-000000000000", "status": "Executing", "outputDataFormat":
+        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SubstochasticMonteCarlo-%252220210101-000000%2522-816ec5c0-d0c7-11ec-b383-2816a847b9a3.output.json",
+        "creationTime": "2022-05-11T01:13:04.4301724+00:00", "beginExecutionTime":
+        "2022-05-11T01:13:07.2545261Z", "endExecutionTime": "2022-05-11T01:13:07.3587791Z",
         "cancellationTime": null, "costEstimate": null, "errorData": null, "isCancelling":
         false, "tags": [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1517'
+      - '1499'
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+    url: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
+    method: GET
+    uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
+  response:
+    body:
+      string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SubstochasticMonteCarlo-%252220210101-000000%2522-816ec5c0-d0c7-11ec-b383-2816a847b9a3.input.json",
+        "inputDataFormat": "microsoft.qio.v2", "inputParams": {"params": {"step_limit":
+        280}}, "providerId": "microsoft", "target": "microsoft.substochasticmontecarlo.cpu",
+        "metadata": null, "name": "Test-SubstochasticMonteCarlo-\"20210101-000000\"",
+        "id": "00000000-0000-0000-0000-000000000000", "status": "Succeeded", "outputDataFormat":
+        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SubstochasticMonteCarlo-%252220210101-000000%2522-816ec5c0-d0c7-11ec-b383-2816a847b9a3.output.json",
+        "creationTime": "2022-05-11T01:13:04.4301724+00:00", "beginExecutionTime":
+        "2022-05-11T01:13:07.2545261Z", "endExecutionTime": "2022-05-11T01:13:07.3587791Z",
+        "cancellationTime": null, "costEstimate": null, "errorData": null, "isCancelling":
+        false, "tags": [], "access_token": "fake_token"}'
+    headers:
+      content-length:
+      - '1498'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -376,38 +345,38 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:48 GMT
+      - Wed, 11 May 2022 01:13:08 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
-    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SubstochasticMonteCarlo-%252220210101-000000%2522-6eaae7d4-7977-11ec-9c89-acde48001122.output.json
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SubstochasticMonteCarlo-%252220210101-000000%2522-816ec5c0-d0c7-11ec-b383-2816a847b9a3.output.json
   response:
     body:
       string: '{"version": "1.0", "configuration": {"0": 1, "1": 1, "2": 0, "3": 1},
         "cost": -5.0, "parameters": {"alpha": {"final": 0.0, "initial": 1.0, "type":
         "linear"}, "beta": {"final": 5.0, "initial": 0.0, "type": "linear"}, "seed":
-        4021867658, "step_limit": 280, "steps_per_walker": 1, "target_population":
+        618180177, "step_limit": 280, "steps_per_walker": 1, "target_population":
         72}, "solutions": [{"configuration": {"0": 1, "1": 1, "2": 0, "3": 1}, "cost":
         -5.0}], "access_token": "fake_token"}'
     headers:
       accept-ranges:
       - bytes
       content-length:
-      - '541'
+      - '540'
       content-range:
-      - bytes 0-540/541
+      - bytes 0-539/540
       content-type:
       - application/json
       x-ms-blob-content-md5:
-      - 7cRHsN5G8v9p5jM9Yh5mug==
+      - 97+/tCpWy+7XkuYRzBz1pg==
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 19 Jan 2022 22:30:43 GMT
+      - Wed, 11 May 2022 01:13:04 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -415,36 +384,36 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 206
       message: Partial Content
-    url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SubstochasticMonteCarlo-%252220210101-000000%2522-6eaae7d4-7977-11ec-9c89-acde48001122.output.json
+    url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SubstochasticMonteCarlo-%252220210101-000000%2522-816ec5c0-d0c7-11ec-b383-2816a847b9a3.output.json
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SubstochasticMonteCarlo-%252220210101-000000%2522-6eaae7d4-7977-11ec-9c89-acde48001122.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SubstochasticMonteCarlo-%252220210101-000000%2522-816ec5c0-d0c7-11ec-b383-2816a847b9a3.input.json",
         "inputDataFormat": "microsoft.qio.v2", "inputParams": {"params": {"step_limit":
         280}}, "providerId": "microsoft", "target": "microsoft.substochasticmontecarlo.cpu",
         "metadata": null, "name": "Test-SubstochasticMonteCarlo-\"20210101-000000\"",
         "id": "00000000-0000-0000-0000-000000000000", "status": "Succeeded", "outputDataFormat":
-        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SubstochasticMonteCarlo-%252220210101-000000%2522-6eaae7d4-7977-11ec-9c89-acde48001122.output.json",
-        "creationTime": "2022-01-19T22:30:43.0454009+00:00", "beginExecutionTime":
-        "2022-01-19T22:30:44.0513605Z", "endExecutionTime": "2022-01-19T22:30:44.1570995Z",
+        "microsoft.qio-results.v2", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-SubstochasticMonteCarlo-%252220210101-000000%2522-816ec5c0-d0c7-11ec-b383-2816a847b9a3.output.json",
+        "creationTime": "2022-05-11T01:13:04.4301724+00:00", "beginExecutionTime":
+        "2022-05-11T01:13:07.2545261Z", "endExecutionTime": "2022-05-11T01:13:07.3587791Z",
         "cancellationTime": null, "costEstimate": null, "errorData": null, "isCancelling":
         false, "tags": [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1517'
+      - '1498'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:

--- a/azure-quantum/tests/unit/aio/recordings/test_job_submit_microsoft_tabu.yaml
+++ b/azure-quantum/tests/unit/aio/recordings/test_job_submit_microsoft_tabu.yaml
@@ -6,7 +6,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - azsdk-python-identity/1.7.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-identity/1.10.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
   response:
@@ -32,7 +32,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
   response:
@@ -41,7 +41,7 @@ interactions:
         "access_token": "fake_token"}'
     headers:
       content-length:
-      - '212'
+      - '209'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -56,24 +56,24 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:49 GMT
+      - Wed, 11 May 2022 01:13:09 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
-        specified container does not exist.\nRequestId:b5fec18e-701e-0028-1484-0dd3df000000\nTime:2022-01-19T22:30:50.0190319Z</Message></Error>"
+        specified container does not exist.\nRequestId:bc0f1a14-101e-0013-66d4-64bbe1000000\nTime:2022-05-11T01:13:09.6675477Z</Message></Error>"
     headers:
       content-length:
       - '225'
       content-type:
       - application/xml
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 404
       message: The specified container does not exist.
@@ -84,11 +84,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:50 GMT
+      - Wed, 11 May 2022 01:13:09 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -98,7 +98,7 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -109,11 +109,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:50 GMT
+      - Wed, 11 May 2022 01:13:09 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -127,13 +127,14 @@ interactions:
       x-ms-lease-status:
       - unlocked
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 200
       message: OK
     url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
 - request:
-    body: b'\x1f\x8b\x08\x00\x18\x91\xe8a\x02\xffU\xccM\n\xc3 \x10\x05\xe0\xab\xc8\xacc\xf1\xaf\xd0\xf4\x1c\xd9%R\x8c\xb1\x90\x85I\x88Z(\xe2\xdd+fa]9\xbeo\xdeD\xb0\xc6\xabEy\x05O\x14aS\xd6\xe4\x01\x06\xe3<\x1e\xd4\x1c\xf0\x04\x8c0F(\xed1\x15\x9c\x88\xc7\x04\x90:\x04zw\xfe\xf5\x0e\x9b\xf6\xeb\xbe\x95\xee\xc7\x9c\xee\x9a\x81\xde\x08\xe4\x1d\xff=\xca\xb5#\xcc{\xf9\x9b\xd3\xba\x1c\x8c\x11t~0\xcf\xd9\xba\x94\x84v\x88\xc8|\xf7\x92{\x05\xd6@\xdf\x00\xad\xc0*\xf0\xa6\x81E#\x7f\x95\x16\x98L2\xa5\x1fWR\x07\x15\x0f\x01\x00\x00'
+    body: b'\x1f\x8b\x08\x00\xa4\r{b\x02\xffU\xccM\n\xc3 \x10\x05\xe0\xab\xc8\xacc\xf1\xa7\x81\xb4\xe7\xc8.\x91b\x8c\x85,4!j\xa1\x88w\xaf\x98\x85u\xe5\xf8\xbey\x13\xc1h/W\xe9%<Q\x04+\x8d\xce\x03\x8c\xday<\xca%\xe0\x19\x18a\x8c\xf4\x94`:PN\x86\x19
+      u\x08\xd4\xee\xfc\xeb\x1d\xac\xf2\xdbnK\xf7\xa3Ow\xcd@o\x04\xf2\x8e\xff\x1e\xe5\xda\x11\x96\xbd\xfc\xf5i\\\x0e\xa6\x08*?\x98\xe7l[KB;DD\xbe{I_\x815\xf0h\x80V`\x15x\xd3\xc0\xf7F\xfe*-0\x91DJ?b\xbcd\xf4\x0f\x01\x00\x00'
     headers:
       Accept:
       - application/xml
@@ -142,13 +143,13 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:50 GMT
+      - Wed, 11 May 2022 01:13:09 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -158,7 +159,7 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -174,29 +175,29 @@ interactions:
       Accept:
       - application/json
       Content-Length:
-      - '612'
+      - '602'
       Content-Type:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: PUT
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=rcw",
         "inputDataFormat": "microsoft.qio.v2", "inputParams": {"params": {"sweeps":
         100}}, "providerId": "microsoft", "target": "microsoft.tabu.cpu", "metadata":
         null, "name": "Test-Tabu-\"20210101-000000\"", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Waiting", "outputDataFormat": "microsoft.qio-results.v2", "outputDataUri":
-        "https://azuresdkteststo.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "creationTime": "2022-01-19T22:30:51.0310014+00:00", "beginExecutionTime":
+        "https://e2etests.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "creationTime": "2022-05-11T01:13:10.0901831+00:00", "beginExecutionTime":
         null, "endExecutionTime": null, "cancellationTime": null, "costEstimate":
         null, "errorData": null, "isCancelling": false, "tags": [], "access_token":
         "fake_token"}'
     headers:
       content-length:
-      - '1054'
+      - '1148'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -211,25 +212,25 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-Tabu-%252220210101-000000%2522-7370605a-7977-11ec-9c89-acde48001122.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-Tabu-%252220210101-000000%2522-84f2c2b9-d0c7-11ec-acec-2816a847b9a3.input.json",
         "inputDataFormat": "microsoft.qio.v2", "inputParams": {"params": {"sweeps":
         100}}, "providerId": "microsoft", "target": "microsoft.tabu.cpu", "metadata":
         null, "name": "Test-Tabu-\"20210101-000000\"", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "microsoft.qio-results.v2", "outputDataUri":
-        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-Tabu-%252220210101-000000%2522-7370605a-7977-11ec-9c89-acde48001122.output.json",
-        "creationTime": "2022-01-19T22:30:51.0310014+00:00", "beginExecutionTime":
-        "2022-01-19T22:30:51.7077377Z", "endExecutionTime": "2022-01-19T22:30:51.7621109Z",
+        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-Tabu-%252220210101-000000%2522-84f2c2b9-d0c7-11ec-acec-2816a847b9a3.output.json",
+        "creationTime": "2022-05-11T01:13:10.0901831+00:00", "beginExecutionTime":
+        "2022-05-11T01:13:10.2060047Z", "endExecutionTime": "2022-05-11T01:13:10.2593259Z",
         "cancellationTime": null, "costEstimate": null, "errorData": null, "isCancelling":
         false, "tags": [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1439'
+      - '1418'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -244,15 +245,15 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:54 GMT
+      - Wed, 11 May 2022 01:13:13 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
-    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-Tabu-%252220210101-000000%2522-7370605a-7977-11ec-9c89-acde48001122.output.json
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-Tabu-%252220210101-000000%2522-84f2c2b9-d0c7-11ec-acec-2816a847b9a3.output.json
   response:
     body:
       string: '{"version": "1.0", "configuration": {"1": 1, "0": 1, "2": 0, "3": 1},
@@ -272,7 +273,7 @@ interactions:
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 19 Jan 2022 22:30:51 GMT
+      - Wed, 11 May 2022 01:13:10 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -280,36 +281,36 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 206
       message: Partial Content
-    url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-Tabu-%252220210101-000000%2522-7370605a-7977-11ec-9c89-acde48001122.output.json
+    url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-Tabu-%252220210101-000000%2522-84f2c2b9-d0c7-11ec-acec-2816a847b9a3.output.json
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-Tabu-%252220210101-000000%2522-7370605a-7977-11ec-9c89-acde48001122.input.json",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-Tabu-%252220210101-000000%2522-84f2c2b9-d0c7-11ec-acec-2816a847b9a3.input.json",
         "inputDataFormat": "microsoft.qio.v2", "inputParams": {"params": {"sweeps":
         100}}, "providerId": "microsoft", "target": "microsoft.tabu.cpu", "metadata":
         null, "name": "Test-Tabu-\"20210101-000000\"", "id": "00000000-0000-0000-0000-000000000000",
         "status": "Succeeded", "outputDataFormat": "microsoft.qio-results.v2", "outputDataUri":
-        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-Tabu-%252220210101-000000%2522-7370605a-7977-11ec-9c89-acde48001122.output.json",
-        "creationTime": "2022-01-19T22:30:51.0310014+00:00", "beginExecutionTime":
-        "2022-01-19T22:30:51.7077377Z", "endExecutionTime": "2022-01-19T22:30:51.7621109Z",
+        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3DTest-Tabu-%252220210101-000000%2522-84f2c2b9-d0c7-11ec-acec-2816a847b9a3.output.json",
+        "creationTime": "2022-05-11T01:13:10.0901831+00:00", "beginExecutionTime":
+        "2022-05-11T01:13:10.2060047Z", "endExecutionTime": "2022-05-11T01:13:10.2593259Z",
         "cancellationTime": null, "costEstimate": null, "errorData": null, "isCancelling":
         false, "tags": [], "access_token": "fake_token"}'
     headers:
       content-length:
-      - '1439'
+      - '1418'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:

--- a/azure-quantum/tests/unit/aio/recordings/test_job_submit_quantinuum.yaml
+++ b/azure-quantum/tests/unit/aio/recordings/test_job_submit_quantinuum.yaml
@@ -6,7 +6,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - azsdk-python-identity/1.7.1 Python/3.9.10 (Linux-5.10.60.1-microsoft-standard-WSL2-x86_64-with-glibc2.31)
+      - azsdk-python-identity/1.10.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
   response:
@@ -32,7 +32,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.10 (Linux-5.10.60.1-microsoft-standard-WSL2-x86_64-with-glibc2.31)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
   response:
@@ -56,24 +56,24 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.10 (Linux-5.10.60.1-microsoft-standard-WSL2-x86_64-with-glibc2.31)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Sat, 19 Feb 2022 05:17:22 GMT
+      - Wed, 11 May 2022 01:14:01 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
-        specified container does not exist.\nRequestId:6bda66e3-b01e-009c-1e4f-25328b000000\nTime:2022-02-19T05:17:21.6920171Z</Message></Error>"
+        specified container does not exist.\nRequestId:d65fe287-901e-009b-44d4-645ee8000000\nTime:2022-05-11T01:14:01.9999767Z</Message></Error>"
     headers:
       content-length:
       - '225'
       content-type:
       - application/xml
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 404
       message: The specified container does not exist.
@@ -84,11 +84,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.10 (Linux-5.10.60.1-microsoft-standard-WSL2-x86_64-with-glibc2.31)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Sat, 19 Feb 2022 05:17:22 GMT
+      - Wed, 11 May 2022 01:14:02 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -98,7 +98,7 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -109,11 +109,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.10 (Linux-5.10.60.1-microsoft-standard-WSL2-x86_64-with-glibc2.31)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Sat, 19 Feb 2022 05:17:22 GMT
+      - Wed, 11 May 2022 01:14:02 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -127,7 +127,7 @@ interactions:
       x-ms-lease-status:
       - unlocked
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 200
       message: OK
@@ -147,13 +147,13 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.9.10 (Linux-5.10.60.1-microsoft-standard-WSL2-x86_64-with-glibc2.31)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Sat, 19 Feb 2022 05:17:22 GMT
+      - Wed, 11 May 2022 01:14:02 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
     uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
@@ -163,7 +163,7 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
@@ -182,21 +182,109 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.10 (Linux-5.10.60.1-microsoft-standard-WSL2-x86_64-with-glibc2.31)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: PUT
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
-      string: '{"error": {"code": "InvalidJobDefinition", "message": "The provider
-        specified does not exist or is not enabled for the workspace."}, "access_token":
+      string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=rcw",
+        "inputDataFormat": "honeywell.openqasm.v1", "inputParams": {}, "providerId":
+        "quantinuum", "target": "quantinuum.hqs-lt-s1-apival", "metadata": null, "name":
+        "quantinuum-job", "id": "00000000-0000-0000-0000-000000000000", "status":
+        "Waiting", "outputDataFormat": "honeywell.quantum-results.v1", "outputDataUri":
+        "https://e2etests.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "creationTime": "2022-05-11T01:14:02.3870372+00:00", "beginExecutionTime":
+        null, "endExecutionTime": null, "cancellationTime": null, "costEstimate":
+        null, "errorData": null, "isCancelling": false, "tags": [], "access_token":
         "fake_token"}'
     headers:
       content-length:
-      - '128'
+      - '1121'
       content-type:
       - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
     status:
-      code: 403
-      message: Forbidden
+      code: 200
+      message: OK
     url: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
+    method: GET
+    uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
+  response:
+    body:
+      string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dquantinuum-job-00000000-0000-0000-0000-000000000000.input.json",
+        "inputDataFormat": "honeywell.openqasm.v1", "inputParams": {}, "providerId":
+        "quantinuum", "target": "quantinuum.hqs-lt-s1-apival", "metadata": null, "name":
+        "quantinuum-job", "id": "00000000-0000-0000-0000-000000000000", "status":
+        "Succeeded", "outputDataFormat": "honeywell.quantum-results.v1", "outputDataUri":
+        "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dquantinuum-job-00000000-0000-0000-0000-000000000000.output.json",
+        "creationTime": "2022-05-11T01:14:02.3870372+00:00", "beginExecutionTime":
+        "2022-05-11T01:14:03.056453+00:00", "endExecutionTime": "2022-05-11T01:14:03.05678+00:00",
+        "cancellationTime": null, "costEstimate": null, "errorData": null, "isCancelling":
+        false, "tags": [], "access_token": "fake_token"}'
+    headers:
+      content-length:
+      - '1362'
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+    url: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
+      x-ms-date:
+      - Wed, 11 May 2022 01:14:07 GMT
+      x-ms-range:
+      - bytes=0-33554431
+      x-ms-version:
+      - '2021-04-10'
+    method: GET
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dquantinuum-job-00000000-0000-0000-0000-000000000000.output.json
+  response:
+    body:
+      string: '{"c0": ["0"], "c1": ["000"], "access_token": "fake_token"}'
+    headers:
+      accept-ranges:
+      - bytes
+      content-length:
+      - '28'
+      content-range:
+      - bytes 0-27/28
+      content-type:
+      - application/octet-stream
+      x-ms-blob-content-md5:
+      - RNYTQPG2IMxqvJp0n7itZw==
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-creation-time:
+      - Wed, 11 May 2022 01:14:02 GMT
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2021-04-10'
+    status:
+      code: 206
+      message: Partial Content
+    url: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dquantinuum-job-00000000-0000-0000-0000-000000000000.output.json
 version: 1

--- a/azure-quantum/tests/unit/aio/recordings/test_streaming_problem_initial_terms.yaml
+++ b/azure-quantum/tests/unit/aio/recordings/test_streaming_problem_initial_terms.yaml
@@ -6,7 +6,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - azsdk-python-identity/1.7.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-identity/1.10.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
   response:
@@ -23,7 +23,7 @@ interactions:
       message: OK
     url: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
 - request:
-    body: 'b''{"containerName": "78c29c30-7977-11ec-9c89-acde48001122"}'''
+    body: 'b''{"containerName": "88e6fc91-d0c7-11ec-b9cb-2816a847b9a3"}'''
     headers:
       Accept:
       - application/json
@@ -32,16 +32,16 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
   response:
     body:
-      string: '{"sasUri": "https://mystorage.blob.core.windows.net/78c29c30-7977-11ec-9c89-acde48001122?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+      string: '{"sasUri": "https://mystorage.blob.core.windows.net/88e6fc91-d0c7-11ec-b9cb-2816a847b9a3?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
         "access_token": "fake_token"}'
     headers:
       content-length:
-      - '208'
+      - '207'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -56,41 +56,41 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:58 GMT
+      - Wed, 11 May 2022 01:13:16 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
-    uri: https://mystorage.blob.core.windows.net/78c29c30-7977-11ec-9c89-acde48001122?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    uri: https://mystorage.blob.core.windows.net/88e6fc91-d0c7-11ec-b9cb-2816a847b9a3?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
-        specified container does not exist.\nRequestId:34384c8b-c01e-0070-2d84-0d0b80000000\nTime:2022-01-19T22:30:58.8971108Z</Message></Error>"
+        specified container does not exist.\nRequestId:0e4c2a7c-e01e-004a-38d4-643c62000000\nTime:2022-05-11T01:13:16.3694711Z</Message></Error>"
     headers:
       content-length:
       - '225'
       content-type:
       - application/xml
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 404
       message: The specified container does not exist.
-    url: https://mystorage.blob.core.windows.net/78c29c30-7977-11ec-9c89-acde48001122?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    url: https://mystorage.blob.core.windows.net/88e6fc91-d0c7-11ec-b9cb-2816a847b9a3?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
 - request:
     body: null
     headers:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:58 GMT
+      - Wed, 11 May 2022 01:13:16 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
-    uri: https://mystorage.blob.core.windows.net/78c29c30-7977-11ec-9c89-acde48001122?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    uri: https://mystorage.blob.core.windows.net/88e6fc91-d0c7-11ec-b9cb-2816a847b9a3?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: ''
@@ -98,13 +98,13 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
-    url: https://mystorage.blob.core.windows.net/78c29c30-7977-11ec-9c89-acde48001122?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    url: https://mystorage.blob.core.windows.net/88e6fc91-d0c7-11ec-b9cb-2816a847b9a3?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
 - request:
-    body: b'\x1f\x8b\x08\x00"\x91\xe8a\x02\xff\\\x8cA\n\x830\x14D\xaf\xf2\x99\xf5\xa7\x18\xed*W\x91\xe0"\xa6\x92Ec1\xa9
+    body: b'\x1f\x8b\x08\x00\xac\r{b\x02\xff\\\x8cA\n\x830\x14D\xaf\xf2\x99\xf5\xa7\x18\xed*W\x91\xe0"\xa6\x92Ec1\xa9
       !w7\xb1`\xb4\xbb\x99\xf7\x98\x89\xd0\xb3\x0f\xc3\xeb\xebt\xb0\xb3\x83\x8cX\xcd\xe2\x8f\x08\xf1h\xc0\x08\xdb\xc7\xe4b\xbduS\xa9fy{\xc8>BC\x92h\x98`\xc7\x0c\xa8\xcfQ0\xb5*\xf1\xcf\xb5\x17W\x04Sw\xba\xbf\xd9\xc9\xc5}R\xbf*\xbf\xfdt\x95\xe7\xf8TI\xa5\xb4\x03\x00\x00\xff\xff\x03\x00\x89\xdb\\A\xd4\x00\x00\x00'
     headers:
       Accept:
@@ -114,13 +114,13 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:59 GMT
+      - Wed, 11 May 2022 01:13:16 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
-    uri: https://mystorage.blob.core.windows.net/78c29c30-7977-11ec-9c89-acde48001122/78c29c30-7977-11ec-9c89-acde48001122?comp=block&blockid=ICAgICAgICAgMA%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    uri: https://mystorage.blob.core.windows.net/88e6fc91-d0c7-11ec-b9cb-2816a847b9a3/88e6fc91-d0c7-11ec-b9cb-2816a847b9a3?comp=block&blockid=ICAgICAgICAgMA%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: ''
@@ -128,11 +128,11 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
-    url: https://mystorage.blob.core.windows.net/78c29c30-7977-11ec-9c89-acde48001122/78c29c30-7977-11ec-9c89-acde48001122?comp=block&blockid=ICAgICAgICAgMA%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    url: https://mystorage.blob.core.windows.net/88e6fc91-d0c7-11ec-b9cb-2816a847b9a3/88e6fc91-d0c7-11ec-b9cb-2816a847b9a3?comp=block&blockid=ICAgICAgICAgMA%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
 - request:
     body: b"<?xml version='1.0' encoding='utf-8'?>\n<BlockList><Latest>ICAgICAgICAgMA==</Latest></BlockList>"
     headers:
@@ -143,9 +143,9 @@ interactions:
       Content-Type:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:59 GMT
+      - Wed, 11 May 2022 01:13:16 GMT
       x-ms-meta-avg_coupling:
       - '2.3333333333333335'
       x-ms-meta-max_coupling:
@@ -157,9 +157,9 @@ interactions:
       x-ms-meta-type:
       - ising
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
-    uri: https://mystorage.blob.core.windows.net/78c29c30-7977-11ec-9c89-acde48001122/78c29c30-7977-11ec-9c89-acde48001122?comp=blocklist&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    uri: https://mystorage.blob.core.windows.net/88e6fc91-d0c7-11ec-b9cb-2816a847b9a3/88e6fc91-d0c7-11ec-b9cb-2816a847b9a3?comp=blocklist&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: ''
@@ -167,13 +167,13 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
-    url: https://mystorage.blob.core.windows.net/78c29c30-7977-11ec-9c89-acde48001122/78c29c30-7977-11ec-9c89-acde48001122?comp=blocklist&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    url: https://mystorage.blob.core.windows.net/88e6fc91-d0c7-11ec-b9cb-2816a847b9a3/88e6fc91-d0c7-11ec-b9cb-2816a847b9a3?comp=blocklist&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
 - request:
-    body: 'b''{"containerName": "78c29c30-7977-11ec-9c89-acde48001122"}'''
+    body: 'b''{"containerName": "88e6fc91-d0c7-11ec-b9cb-2816a847b9a3"}'''
     headers:
       Accept:
       - application/json
@@ -182,16 +182,16 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
   response:
     body:
-      string: '{"sasUri": "https://mystorage.blob.core.windows.net/78c29c30-7977-11ec-9c89-acde48001122?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+      string: '{"sasUri": "https://mystorage.blob.core.windows.net/88e6fc91-d0c7-11ec-b9cb-2816a847b9a3?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
         "access_token": "fake_token"}'
     headers:
       content-length:
-      - '214'
+      - '207'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -206,15 +206,15 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:30:59 GMT
+      - Wed, 11 May 2022 01:13:16 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
-    uri: https://mystorage.blob.core.windows.net/78c29c30-7977-11ec-9c89-acde48001122/78c29c30-7977-11ec-9c89-acde48001122?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    uri: https://mystorage.blob.core.windows.net/88e6fc91-d0c7-11ec-b9cb-2816a847b9a3/88e6fc91-d0c7-11ec-b9cb-2816a847b9a3?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: '{"cost_function": {"version": "1.0", "type": "ising", "terms": [{"c":
@@ -233,7 +233,7 @@ interactions:
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 19 Jan 2022 22:30:59 GMT
+      - Wed, 11 May 2022 01:13:16 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -251,9 +251,9 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 206
       message: Partial Content
-    url: https://mystorage.blob.core.windows.net/78c29c30-7977-11ec-9c89-acde48001122/78c29c30-7977-11ec-9c89-acde48001122?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    url: https://mystorage.blob.core.windows.net/88e6fc91-d0c7-11ec-b9cb-2816a847b9a3/88e6fc91-d0c7-11ec-b9cb-2816a847b9a3?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
 version: 1

--- a/azure-quantum/tests/unit/aio/recordings/test_streaming_problem_large_chunks.yaml
+++ b/azure-quantum/tests/unit/aio/recordings/test_streaming_problem_large_chunks.yaml
@@ -6,7 +6,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - azsdk-python-identity/1.7.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-identity/1.10.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
   response:
@@ -23,7 +23,7 @@ interactions:
       message: OK
     url: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
 - request:
-    body: 'b''{"containerName": "7a3d53a2-7977-11ec-9c89-acde48001122"}'''
+    body: 'b''{"containerName": "89a683ad-d0c7-11ec-8dc4-2816a847b9a3"}'''
     headers:
       Accept:
       - application/json
@@ -32,16 +32,16 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
   response:
     body:
-      string: '{"sasUri": "https://mystorage.blob.core.windows.net/7a3d53a2-7977-11ec-9c89-acde48001122?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+      string: '{"sasUri": "https://mystorage.blob.core.windows.net/89a683ad-d0c7-11ec-8dc4-2816a847b9a3?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
         "access_token": "fake_token"}'
     headers:
       content-length:
-      - '214'
+      - '203'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -56,41 +56,41 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:31:01 GMT
+      - Wed, 11 May 2022 01:13:17 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
-    uri: https://mystorage.blob.core.windows.net/7a3d53a2-7977-11ec-9c89-acde48001122?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    uri: https://mystorage.blob.core.windows.net/89a683ad-d0c7-11ec-8dc4-2816a847b9a3?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
-        specified container does not exist.\nRequestId:2eec0111-901e-0052-7b84-0dce9f000000\nTime:2022-01-19T22:31:01.5364021Z</Message></Error>"
+        specified container does not exist.\nRequestId:1c0b0f2f-801e-0073-1bd4-64c77e000000\nTime:2022-05-11T01:13:17.6768460Z</Message></Error>"
     headers:
       content-length:
       - '225'
       content-type:
       - application/xml
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 404
       message: The specified container does not exist.
-    url: https://mystorage.blob.core.windows.net/7a3d53a2-7977-11ec-9c89-acde48001122?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    url: https://mystorage.blob.core.windows.net/89a683ad-d0c7-11ec-8dc4-2816a847b9a3?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
 - request:
     body: null
     headers:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:31:01 GMT
+      - Wed, 11 May 2022 01:13:17 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
-    uri: https://mystorage.blob.core.windows.net/7a3d53a2-7977-11ec-9c89-acde48001122?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    uri: https://mystorage.blob.core.windows.net/89a683ad-d0c7-11ec-8dc4-2816a847b9a3?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: ''
@@ -98,30 +98,28 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
-    url: https://mystorage.blob.core.windows.net/7a3d53a2-7977-11ec-9c89-acde48001122?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    url: https://mystorage.blob.core.windows.net/89a683ad-d0c7-11ec-8dc4-2816a847b9a3?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
 - request:
-    body: 'b''{"cost_function":{"version":"1.0","type":"ising","terms":[{"c": 0, "ids":
-      [0, 1]},{"c": 1, "ids": [1, 2]},{"c": 2, "ids": [2, 3]},{"c": 3, "ids": [3,
-      4]}'''
+    body: b'\x1f\x8b\x08\x00\xad\r{b\x02\xffD\xc8A\n\x80 \x14E\xd1\xad\xc8\x1bKd6r+!\r\xcc\xc2A\x1aiA\x88{\xefW\x90\xb3{O\x86\t1\x8d\xf3\xe1Mr\xc1Ce\x9cv\x8foB4-8\xd2\xb5Y\x1a\x17\x9d_\x9e\xb5\xfb\x1a\xa1\x86\x0c\x03\xc5Z\xce\xe0&z6P\n]\xf8\xe7\xa2:e\xf7{W\x9dR\xfe.\xabS\xf6\xba\xe8Rn\x00\x00\x00\xff\xff\x03\x00\xc1\x1d\xe0X\x9c\x00\x00\x00'
     headers:
       Accept:
       - application/xml
       Content-Length:
-      - '153'
+      - '121'
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:31:01 GMT
+      - Wed, 11 May 2022 01:13:17 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
-    uri: https://mystorage.blob.core.windows.net/7a3d53a2-7977-11ec-9c89-acde48001122/7a3d53a2-7977-11ec-9c89-acde48001122?comp=block&blockid=ICAgICAgICAgMA%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    uri: https://mystorage.blob.core.windows.net/89a683ad-d0c7-11ec-8dc4-2816a847b9a3/89a683ad-d0c7-11ec-8dc4-2816a847b9a3?comp=block&blockid=ICAgICAgICAgMA%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: ''
@@ -129,53 +127,24 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
-    url: https://mystorage.blob.core.windows.net/7a3d53a2-7977-11ec-9c89-acde48001122/7a3d53a2-7977-11ec-9c89-acde48001122?comp=block&blockid=ICAgICAgICAgMA%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    url: https://mystorage.blob.core.windows.net/89a683ad-d0c7-11ec-8dc4-2816a847b9a3/89a683ad-d0c7-11ec-8dc4-2816a847b9a3?comp=block&blockid=ICAgICAgICAgMA%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
 - request:
-    body: b']}}'
+    body: b"<?xml version='1.0' encoding='utf-8'?>\n<BlockList><Latest>ICAgICAgICAgMA==</Latest></BlockList>"
     headers:
       Accept:
       - application/xml
       Content-Length:
-      - '3'
-      Content-Type:
-      - application/octet-stream
-      User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
-      x-ms-date:
-      - Wed, 19 Jan 2022 22:31:01 GMT
-      x-ms-version:
-      - '2020-10-02'
-    method: PUT
-    uri: https://mystorage.blob.core.windows.net/7a3d53a2-7977-11ec-9c89-acde48001122/7a3d53a2-7977-11ec-9c89-acde48001122?comp=block&blockid=ICAgICAgICAgMQ%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-  response:
-    body:
-      string: ''
-    headers:
-      content-length:
-      - '0'
-      x-ms-version:
-      - '2020-10-02'
-    status:
-      code: 201
-      message: Created
-    url: https://mystorage.blob.core.windows.net/7a3d53a2-7977-11ec-9c89-acde48001122/7a3d53a2-7977-11ec-9c89-acde48001122?comp=block&blockid=ICAgICAgICAgMQ%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-- request:
-    body: b"<?xml version='1.0' encoding='utf-8'?>\n<BlockList><Latest>ICAgICAgICAgMA==</Latest><Latest>ICAgICAgICAgMQ==</Latest></BlockList>"
-    headers:
-      Accept:
-      - application/xml
-      Content-Length:
-      - '128'
+      - '95'
       Content-Type:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:31:01 GMT
+      - Wed, 11 May 2022 01:13:17 GMT
       x-ms-meta-avg_coupling:
       - '2.0'
       x-ms-meta-max_coupling:
@@ -187,9 +156,9 @@ interactions:
       x-ms-meta-type:
       - ising
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
-    uri: https://mystorage.blob.core.windows.net/7a3d53a2-7977-11ec-9c89-acde48001122/7a3d53a2-7977-11ec-9c89-acde48001122?comp=blocklist&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    uri: https://mystorage.blob.core.windows.net/89a683ad-d0c7-11ec-8dc4-2816a847b9a3/89a683ad-d0c7-11ec-8dc4-2816a847b9a3?comp=blocklist&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: ''
@@ -197,13 +166,13 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
-    url: https://mystorage.blob.core.windows.net/7a3d53a2-7977-11ec-9c89-acde48001122/7a3d53a2-7977-11ec-9c89-acde48001122?comp=blocklist&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    url: https://mystorage.blob.core.windows.net/89a683ad-d0c7-11ec-8dc4-2816a847b9a3/89a683ad-d0c7-11ec-8dc4-2816a847b9a3?comp=blocklist&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
 - request:
-    body: 'b''{"containerName": "7a3d53a2-7977-11ec-9c89-acde48001122"}'''
+    body: 'b''{"containerName": "89a683ad-d0c7-11ec-8dc4-2816a847b9a3"}'''
     headers:
       Accept:
       - application/json
@@ -212,16 +181,16 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
   response:
     body:
-      string: '{"sasUri": "https://mystorage.blob.core.windows.net/7a3d53a2-7977-11ec-9c89-acde48001122?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+      string: '{"sasUri": "https://mystorage.blob.core.windows.net/89a683ad-d0c7-11ec-8dc4-2816a847b9a3?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
         "access_token": "fake_token"}'
     headers:
       content-length:
-      - '212'
+      - '201'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -236,15 +205,15 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:31:02 GMT
+      - Wed, 11 May 2022 01:13:18 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
-    uri: https://mystorage.blob.core.windows.net/7a3d53a2-7977-11ec-9c89-acde48001122/7a3d53a2-7977-11ec-9c89-acde48001122?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    uri: https://mystorage.blob.core.windows.net/89a683ad-d0c7-11ec-8dc4-2816a847b9a3/89a683ad-d0c7-11ec-8dc4-2816a847b9a3?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: '{"cost_function": {"version": "1.0", "type": "ising", "terms": [{"c":
@@ -256,13 +225,13 @@ interactions:
       content-length:
       - '156'
       content-range:
-      - bytes 0-155/156
+      - bytes 0-120/121
       content-type:
       - application/json
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 19 Jan 2022 22:31:02 GMT
+      - Wed, 11 May 2022 01:13:17 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -280,9 +249,9 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 206
       message: Partial Content
-    url: https://mystorage.blob.core.windows.net/7a3d53a2-7977-11ec-9c89-acde48001122/7a3d53a2-7977-11ec-9c89-acde48001122?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    url: https://mystorage.blob.core.windows.net/89a683ad-d0c7-11ec-8dc4-2816a847b9a3/89a683ad-d0c7-11ec-8dc4-2816a847b9a3?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
 version: 1

--- a/azure-quantum/tests/unit/aio/recordings/test_streaming_problem_large_chunks_compressed.yaml
+++ b/azure-quantum/tests/unit/aio/recordings/test_streaming_problem_large_chunks_compressed.yaml
@@ -6,7 +6,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - azsdk-python-identity/1.7.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-identity/1.10.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
   response:
@@ -23,7 +23,7 @@ interactions:
       message: OK
     url: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
 - request:
-    body: 'b''{"containerName": "7c072618-7977-11ec-9c89-acde48001122"}'''
+    body: 'b''{"containerName": "7d7a271a-d0bb-11ec-8b2c-2816a847b9a3"}'''
     headers:
       Accept:
       - application/json
@@ -32,16 +32,16 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
   response:
     body:
-      string: '{"sasUri": "https://mystorage.blob.core.windows.net/7c072618-7977-11ec-9c89-acde48001122?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+      string: '{"sasUri": "https://mystorage.blob.core.windows.net/7d7a271a-d0bb-11ec-8b2c-2816a847b9a3?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
         "access_token": "fake_token"}'
     headers:
       content-length:
-      - '210'
+      - '205'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -50,208 +50,4 @@ interactions:
       code: 200
       message: OK
     url: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/xml
-      User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
-      x-ms-date:
-      - Wed, 19 Jan 2022 22:31:03 GMT
-      x-ms-version:
-      - '2020-10-02'
-    method: GET
-    uri: https://mystorage.blob.core.windows.net/7c072618-7977-11ec-9c89-acde48001122?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-  response:
-    body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
-        specified container does not exist.\nRequestId:7c2febc9-d01e-0031-6584-0d5364000000\nTime:2022-01-19T22:31:04.3072673Z</Message></Error>"
-    headers:
-      content-length:
-      - '225'
-      content-type:
-      - application/xml
-      x-ms-version:
-      - '2020-10-02'
-    status:
-      code: 404
-      message: The specified container does not exist.
-    url: https://mystorage.blob.core.windows.net/7c072618-7977-11ec-9c89-acde48001122?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/xml
-      User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
-      x-ms-date:
-      - Wed, 19 Jan 2022 22:31:04 GMT
-      x-ms-version:
-      - '2020-10-02'
-    method: PUT
-    uri: https://mystorage.blob.core.windows.net/7c072618-7977-11ec-9c89-acde48001122?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-  response:
-    body:
-      string: ''
-    headers:
-      content-length:
-      - '0'
-      x-ms-version:
-      - '2020-10-02'
-    status:
-      code: 201
-      message: Created
-    url: https://mystorage.blob.core.windows.net/7c072618-7977-11ec-9c89-acde48001122?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-- request:
-    body: b"\x1f\x8b\x08\x00'\x91\xe8a\x02\xffD\xc8A\n\x80 \x14E\xd1\xad\xc8\x1bKd6r+!\r\xcc\xc2A\x1aiA\x88{\xefW\x90\xb3{O\x86\t1\x8d\xf3\xe1Mr\xc1Ce\x9cv\x8foB4-8\xd2\xb5Y\x1a\x17\x9d_\x9e\xb5\xfb\x1a\xa1\x86\x0c\x03\xc5Z\xce\xe0&z6P\n]\xf8\xe7\xa2:e\xf7{W\x9dR\xfe.\xabS\xf6\xba\xe8Rn\x00\x00\x00\xff\xff\x03\x00\xc1\x1d\xe0X\x9c\x00\x00\x00"
-    headers:
-      Accept:
-      - application/xml
-      Content-Length:
-      - '121'
-      Content-Type:
-      - application/octet-stream
-      User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
-      x-ms-date:
-      - Wed, 19 Jan 2022 22:31:04 GMT
-      x-ms-version:
-      - '2020-10-02'
-    method: PUT
-    uri: https://mystorage.blob.core.windows.net/7c072618-7977-11ec-9c89-acde48001122/7c072618-7977-11ec-9c89-acde48001122?comp=block&blockid=ICAgICAgICAgMA%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-  response:
-    body:
-      string: ''
-    headers:
-      content-length:
-      - '0'
-      x-ms-version:
-      - '2020-10-02'
-    status:
-      code: 201
-      message: Created
-    url: https://mystorage.blob.core.windows.net/7c072618-7977-11ec-9c89-acde48001122/7c072618-7977-11ec-9c89-acde48001122?comp=block&blockid=ICAgICAgICAgMA%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-- request:
-    body: b"<?xml version='1.0' encoding='utf-8'?>\n<BlockList><Latest>ICAgICAgICAgMA==</Latest></BlockList>"
-    headers:
-      Accept:
-      - application/xml
-      Content-Length:
-      - '95'
-      Content-Type:
-      - application/xml
-      User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
-      x-ms-date:
-      - Wed, 19 Jan 2022 22:31:04 GMT
-      x-ms-meta-avg_coupling:
-      - '2.0'
-      x-ms-meta-max_coupling:
-      - '2'
-      x-ms-meta-min_coupling:
-      - '2'
-      x-ms-meta-num_terms:
-      - '4'
-      x-ms-meta-type:
-      - ising
-      x-ms-version:
-      - '2020-10-02'
-    method: PUT
-    uri: https://mystorage.blob.core.windows.net/7c072618-7977-11ec-9c89-acde48001122/7c072618-7977-11ec-9c89-acde48001122?comp=blocklist&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-  response:
-    body:
-      string: ''
-    headers:
-      content-length:
-      - '0'
-      x-ms-version:
-      - '2020-10-02'
-    status:
-      code: 201
-      message: Created
-    url: https://mystorage.blob.core.windows.net/7c072618-7977-11ec-9c89-acde48001122/7c072618-7977-11ec-9c89-acde48001122?comp=blocklist&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-- request:
-    body: 'b''{"containerName": "7c072618-7977-11ec-9c89-acde48001122"}'''
-    headers:
-      Accept:
-      - application/json
-      Content-Length:
-      - '57'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
-    method: POST
-    uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
-  response:
-    body:
-      string: '{"sasUri": "https://mystorage.blob.core.windows.net/7c072618-7977-11ec-9c89-acde48001122?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "access_token": "fake_token"}'
-    headers:
-      content-length:
-      - '208'
-      content-type:
-      - application/json; charset=utf-8
-      transfer-encoding:
-      - chunked
-    status:
-      code: 200
-      message: OK
-    url: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/xml
-      User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
-      x-ms-date:
-      - Wed, 19 Jan 2022 22:31:04 GMT
-      x-ms-range:
-      - bytes=0-33554431
-      x-ms-version:
-      - '2020-10-02'
-    method: GET
-    uri: https://mystorage.blob.core.windows.net/7c072618-7977-11ec-9c89-acde48001122/7c072618-7977-11ec-9c89-acde48001122?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-  response:
-    body:
-      string: '{"cost_function": {"version": "1.0", "type": "ising", "terms": [{"c":
-        0, "ids": [0, 1]}, {"c": 1, "ids": [1, 2]}, {"c": 2, "ids": [2, 3]}, {"c":
-        3, "ids": [3, 4]}]}, "access_token": "fake_token"}'
-    headers:
-      accept-ranges:
-      - bytes
-      content-length:
-      - '156'
-      content-range:
-      - bytes 0-120/121
-      content-type:
-      - application/json
-      x-ms-blob-type:
-      - BlockBlob
-      x-ms-creation-time:
-      - Wed, 19 Jan 2022 22:31:04 GMT
-      x-ms-lease-state:
-      - available
-      x-ms-lease-status:
-      - unlocked
-      x-ms-meta-avg_coupling:
-      - '2.0'
-      x-ms-meta-max_coupling:
-      - '2'
-      x-ms-meta-min_coupling:
-      - '2'
-      x-ms-meta-num_terms:
-      - '4'
-      x-ms-meta-type:
-      - ising
-      x-ms-server-encrypted:
-      - 'true'
-      x-ms-version:
-      - '2020-10-02'
-    status:
-      code: 206
-      message: Partial Content
-    url: https://mystorage.blob.core.windows.net/7c072618-7977-11ec-9c89-acde48001122/7c072618-7977-11ec-9c89-acde48001122?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
 version: 1

--- a/azure-quantum/tests/unit/aio/recordings/test_streaming_problem_pubo.yaml
+++ b/azure-quantum/tests/unit/aio/recordings/test_streaming_problem_pubo.yaml
@@ -6,7 +6,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - azsdk-python-identity/1.7.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-identity/1.10.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
   response:
@@ -23,7 +23,7 @@ interactions:
       message: OK
     url: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
 - request:
-    body: 'b''{"containerName": "7d7bc7ce-7977-11ec-9c89-acde48001122"}'''
+    body: 'b''{"containerName": "8a7c3a5d-d0c7-11ec-8d24-2816a847b9a3"}'''
     headers:
       Accept:
       - application/json
@@ -32,16 +32,16 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
   response:
     body:
-      string: '{"sasUri": "https://mystorage.blob.core.windows.net/7d7bc7ce-7977-11ec-9c89-acde48001122?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+      string: '{"sasUri": "https://mystorage.blob.core.windows.net/8a7c3a5d-d0c7-11ec-8d24-2816a847b9a3?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
         "access_token": "fake_token"}'
     headers:
       content-length:
-      - '208'
+      - '201'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -56,41 +56,41 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:31:06 GMT
+      - Wed, 11 May 2022 01:13:18 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
-    uri: https://mystorage.blob.core.windows.net/7d7bc7ce-7977-11ec-9c89-acde48001122?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    uri: https://mystorage.blob.core.windows.net/8a7c3a5d-d0c7-11ec-8d24-2816a847b9a3?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
-        specified container does not exist.\nRequestId:2b3ba943-101e-0001-0b84-0dedab000000\nTime:2022-01-19T22:31:07.4767543Z</Message></Error>"
+        specified container does not exist.\nRequestId:de063092-601e-0019-57d4-641f56000000\nTime:2022-05-11T01:13:18.9795034Z</Message></Error>"
     headers:
       content-length:
       - '225'
       content-type:
       - application/xml
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 404
       message: The specified container does not exist.
-    url: https://mystorage.blob.core.windows.net/7d7bc7ce-7977-11ec-9c89-acde48001122?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    url: https://mystorage.blob.core.windows.net/8a7c3a5d-d0c7-11ec-8d24-2816a847b9a3?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
 - request:
     body: null
     headers:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:31:07 GMT
+      - Wed, 11 May 2022 01:13:19 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
-    uri: https://mystorage.blob.core.windows.net/7d7bc7ce-7977-11ec-9c89-acde48001122?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    uri: https://mystorage.blob.core.windows.net/8a7c3a5d-d0c7-11ec-8d24-2816a847b9a3?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: ''
@@ -98,29 +98,28 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
-    url: https://mystorage.blob.core.windows.net/7d7bc7ce-7977-11ec-9c89-acde48001122?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    url: https://mystorage.blob.core.windows.net/8a7c3a5d-d0c7-11ec-8d24-2816a847b9a3?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
 - request:
-    body: 'b''{"cost_function":{"version":"1.0","type":"pubo","terms":[{"c": 0, "ids":
-      [0, 1]}'''
+    body: b'\x1f\x8b\x08\x00\xae\r{b\x02\xff'
     headers:
       Accept:
       - application/xml
       Content-Length:
-      - '80'
+      - '10'
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:31:07 GMT
+      - Wed, 11 May 2022 01:13:19 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
-    uri: https://mystorage.blob.core.windows.net/7d7bc7ce-7977-11ec-9c89-acde48001122/7d7bc7ce-7977-11ec-9c89-acde48001122?comp=block&blockid=ICAgICAgICAgMA%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    uri: https://mystorage.blob.core.windows.net/8a7c3a5d-d0c7-11ec-8d24-2816a847b9a3/8a7c3a5d-d0c7-11ec-8d24-2816a847b9a3?comp=block&blockid=ICAgICAgICAgMA%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: ''
@@ -128,28 +127,28 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
-    url: https://mystorage.blob.core.windows.net/7d7bc7ce-7977-11ec-9c89-acde48001122/7d7bc7ce-7977-11ec-9c89-acde48001122?comp=block&blockid=ICAgICAgICAgMA%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    url: https://mystorage.blob.core.windows.net/8a7c3a5d-d0c7-11ec-8d24-2816a847b9a3/8a7c3a5d-d0c7-11ec-8d24-2816a847b9a3?comp=block&blockid=ICAgICAgICAgMA%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
 - request:
-    body: 'b'',{"c": 1, "ids": [1, 2]}'''
+    body: b"D\xc8A\n\x80 \x14E\xd1\xad\xc8\x1bK\xa46r+!Af\xd0\xa0\x8c\xd4 \xc4\xbd\xf7+\xc8\xd9\xbd'\xc3\xfa\x10\x879m6.~\x83\xce8\xdd\x11\xde\x84hZp\xc4kw4{\x1a\xfds\xeeX\x03t\x9fa\xa1Y\xcb\x19\x96\x89\x9e\xf5\x94\xc2\x14\xfe\xb9\xa8N)\x7f\x97\xd5)\xd5\xef\xaa:eg\x8a)\xe5\x06\x00\x00\xff\xff\x03\x00\xd3mJ\x10\x9b\x00\x00\x00"
     headers:
       Accept:
       - application/xml
       Content-Length:
-      - '24'
+      - '110'
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:31:07 GMT
+      - Wed, 11 May 2022 01:13:19 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
-    uri: https://mystorage.blob.core.windows.net/7d7bc7ce-7977-11ec-9c89-acde48001122/7d7bc7ce-7977-11ec-9c89-acde48001122?comp=block&blockid=ICAgICAgICAgMQ%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    uri: https://mystorage.blob.core.windows.net/8a7c3a5d-d0c7-11ec-8d24-2816a847b9a3/8a7c3a5d-d0c7-11ec-8d24-2816a847b9a3?comp=block&blockid=ICAgICAgICAgMQ%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: ''
@@ -157,111 +156,24 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
-    url: https://mystorage.blob.core.windows.net/7d7bc7ce-7977-11ec-9c89-acde48001122/7d7bc7ce-7977-11ec-9c89-acde48001122?comp=block&blockid=ICAgICAgICAgMQ%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    url: https://mystorage.blob.core.windows.net/8a7c3a5d-d0c7-11ec-8d24-2816a847b9a3/8a7c3a5d-d0c7-11ec-8d24-2816a847b9a3?comp=block&blockid=ICAgICAgICAgMQ%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
 - request:
-    body: 'b'',{"c": 2, "ids": [2, 3]}'''
+    body: b"<?xml version='1.0' encoding='utf-8'?>\n<BlockList><Latest>ICAgICAgICAgMA==</Latest><Latest>ICAgICAgICAgMQ==</Latest></BlockList>"
     headers:
       Accept:
       - application/xml
       Content-Length:
-      - '24'
-      Content-Type:
-      - application/octet-stream
-      User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
-      x-ms-date:
-      - Wed, 19 Jan 2022 22:31:07 GMT
-      x-ms-version:
-      - '2020-10-02'
-    method: PUT
-    uri: https://mystorage.blob.core.windows.net/7d7bc7ce-7977-11ec-9c89-acde48001122/7d7bc7ce-7977-11ec-9c89-acde48001122?comp=block&blockid=ICAgICAgICAgMg%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-  response:
-    body:
-      string: ''
-    headers:
-      content-length:
-      - '0'
-      x-ms-version:
-      - '2020-10-02'
-    status:
-      code: 201
-      message: Created
-    url: https://mystorage.blob.core.windows.net/7d7bc7ce-7977-11ec-9c89-acde48001122/7d7bc7ce-7977-11ec-9c89-acde48001122?comp=block&blockid=ICAgICAgICAgMg%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-- request:
-    body: 'b'',{"c": 3, "ids": [3, 4]}'''
-    headers:
-      Accept:
-      - application/xml
-      Content-Length:
-      - '24'
-      Content-Type:
-      - application/octet-stream
-      User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
-      x-ms-date:
-      - Wed, 19 Jan 2022 22:31:07 GMT
-      x-ms-version:
-      - '2020-10-02'
-    method: PUT
-    uri: https://mystorage.blob.core.windows.net/7d7bc7ce-7977-11ec-9c89-acde48001122/7d7bc7ce-7977-11ec-9c89-acde48001122?comp=block&blockid=ICAgICAgICAgMw%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-  response:
-    body:
-      string: ''
-    headers:
-      content-length:
-      - '0'
-      x-ms-version:
-      - '2020-10-02'
-    status:
-      code: 201
-      message: Created
-    url: https://mystorage.blob.core.windows.net/7d7bc7ce-7977-11ec-9c89-acde48001122/7d7bc7ce-7977-11ec-9c89-acde48001122?comp=block&blockid=ICAgICAgICAgMw%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-- request:
-    body: b']}}'
-    headers:
-      Accept:
-      - application/xml
-      Content-Length:
-      - '3'
-      Content-Type:
-      - application/octet-stream
-      User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
-      x-ms-date:
-      - Wed, 19 Jan 2022 22:31:08 GMT
-      x-ms-version:
-      - '2020-10-02'
-    method: PUT
-    uri: https://mystorage.blob.core.windows.net/7d7bc7ce-7977-11ec-9c89-acde48001122/7d7bc7ce-7977-11ec-9c89-acde48001122?comp=block&blockid=ICAgICAgICAgNA%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-  response:
-    body:
-      string: ''
-    headers:
-      content-length:
-      - '0'
-      x-ms-version:
-      - '2020-10-02'
-    status:
-      code: 201
-      message: Created
-    url: https://mystorage.blob.core.windows.net/7d7bc7ce-7977-11ec-9c89-acde48001122/7d7bc7ce-7977-11ec-9c89-acde48001122?comp=block&blockid=ICAgICAgICAgNA%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-- request:
-    body: b"<?xml version='1.0' encoding='utf-8'?>\n<BlockList><Latest>ICAgICAgICAgMA==</Latest><Latest>ICAgICAgICAgMQ==</Latest><Latest>ICAgICAgICAgMg==</Latest><Latest>ICAgICAgICAgMw==</Latest><Latest>ICAgICAgICAgNA==</Latest></BlockList>"
-    headers:
-      Accept:
-      - application/xml
-      Content-Length:
-      - '227'
+      - '128'
       Content-Type:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:31:08 GMT
+      - Wed, 11 May 2022 01:13:19 GMT
       x-ms-meta-avg_coupling:
       - '2.0'
       x-ms-meta-max_coupling:
@@ -273,9 +185,9 @@ interactions:
       x-ms-meta-type:
       - pubo
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
-    uri: https://mystorage.blob.core.windows.net/7d7bc7ce-7977-11ec-9c89-acde48001122/7d7bc7ce-7977-11ec-9c89-acde48001122?comp=blocklist&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    uri: https://mystorage.blob.core.windows.net/8a7c3a5d-d0c7-11ec-8d24-2816a847b9a3/8a7c3a5d-d0c7-11ec-8d24-2816a847b9a3?comp=blocklist&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: ''
@@ -283,13 +195,13 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
-    url: https://mystorage.blob.core.windows.net/7d7bc7ce-7977-11ec-9c89-acde48001122/7d7bc7ce-7977-11ec-9c89-acde48001122?comp=blocklist&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    url: https://mystorage.blob.core.windows.net/8a7c3a5d-d0c7-11ec-8d24-2816a847b9a3/8a7c3a5d-d0c7-11ec-8d24-2816a847b9a3?comp=blocklist&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
 - request:
-    body: 'b''{"containerName": "7d7bc7ce-7977-11ec-9c89-acde48001122"}'''
+    body: 'b''{"containerName": "8a7c3a5d-d0c7-11ec-8d24-2816a847b9a3"}'''
     headers:
       Accept:
       - application/json
@@ -298,16 +210,16 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
   response:
     body:
-      string: '{"sasUri": "https://mystorage.blob.core.windows.net/7d7bc7ce-7977-11ec-9c89-acde48001122?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+      string: '{"sasUri": "https://mystorage.blob.core.windows.net/8a7c3a5d-d0c7-11ec-8d24-2816a847b9a3?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
         "access_token": "fake_token"}'
     headers:
       content-length:
-      - '210'
+      - '203'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -322,15 +234,15 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:31:08 GMT
+      - Wed, 11 May 2022 01:13:19 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
-    uri: https://mystorage.blob.core.windows.net/7d7bc7ce-7977-11ec-9c89-acde48001122/7d7bc7ce-7977-11ec-9c89-acde48001122?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    uri: https://mystorage.blob.core.windows.net/8a7c3a5d-d0c7-11ec-8d24-2816a847b9a3/8a7c3a5d-d0c7-11ec-8d24-2816a847b9a3?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: '{"cost_function": {"version": "1.0", "type": "pubo", "terms": [{"c":
@@ -342,13 +254,13 @@ interactions:
       content-length:
       - '155'
       content-range:
-      - bytes 0-154/155
+      - bytes 0-119/120
       content-type:
       - application/json
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 19 Jan 2022 22:31:08 GMT
+      - Wed, 11 May 2022 01:13:19 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -366,9 +278,9 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 206
       message: Partial Content
-    url: https://mystorage.blob.core.windows.net/7d7bc7ce-7977-11ec-9c89-acde48001122/7d7bc7ce-7977-11ec-9c89-acde48001122?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    url: https://mystorage.blob.core.windows.net/8a7c3a5d-d0c7-11ec-8d24-2816a847b9a3/8a7c3a5d-d0c7-11ec-8d24-2816a847b9a3?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
 version: 1

--- a/azure-quantum/tests/unit/aio/recordings/test_streaming_problem_small_chunks.yaml
+++ b/azure-quantum/tests/unit/aio/recordings/test_streaming_problem_small_chunks.yaml
@@ -6,7 +6,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - azsdk-python-identity/1.7.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-identity/1.10.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
   response:
@@ -23,7 +23,7 @@ interactions:
       message: OK
     url: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
 - request:
-    body: 'b''{"containerName": "7f7cb916-7977-11ec-9c89-acde48001122"}'''
+    body: 'b''{"containerName": "8b7055b8-d0c7-11ec-86fe-2816a847b9a3"}'''
     headers:
       Accept:
       - application/json
@@ -32,16 +32,16 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
   response:
     body:
-      string: '{"sasUri": "https://mystorage.blob.core.windows.net/7f7cb916-7977-11ec-9c89-acde48001122?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+      string: '{"sasUri": "https://mystorage.blob.core.windows.net/8b7055b8-d0c7-11ec-86fe-2816a847b9a3?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
         "access_token": "fake_token"}'
     headers:
       content-length:
-      - '210'
+      - '203'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -56,41 +56,41 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:31:10 GMT
+      - Wed, 11 May 2022 01:13:20 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
-    uri: https://mystorage.blob.core.windows.net/7f7cb916-7977-11ec-9c89-acde48001122?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    uri: https://mystorage.blob.core.windows.net/8b7055b8-d0c7-11ec-86fe-2816a847b9a3?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
-        specified container does not exist.\nRequestId:4bc9f929-201e-001a-2c84-0dd3a8000000\nTime:2022-01-19T22:31:10.8075669Z</Message></Error>"
+        specified container does not exist.\nRequestId:b17308e6-d01e-007e-3ed4-640faa000000\nTime:2022-05-11T01:13:20.7460489Z</Message></Error>"
     headers:
       content-length:
       - '225'
       content-type:
       - application/xml
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 404
       message: The specified container does not exist.
-    url: https://mystorage.blob.core.windows.net/7f7cb916-7977-11ec-9c89-acde48001122?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    url: https://mystorage.blob.core.windows.net/8b7055b8-d0c7-11ec-86fe-2816a847b9a3?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
 - request:
     body: null
     headers:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:31:10 GMT
+      - Wed, 11 May 2022 01:13:20 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
-    uri: https://mystorage.blob.core.windows.net/7f7cb916-7977-11ec-9c89-acde48001122?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    uri: https://mystorage.blob.core.windows.net/8b7055b8-d0c7-11ec-86fe-2816a847b9a3?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: ''
@@ -98,29 +98,28 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
-    url: https://mystorage.blob.core.windows.net/7f7cb916-7977-11ec-9c89-acde48001122?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    url: https://mystorage.blob.core.windows.net/8b7055b8-d0c7-11ec-86fe-2816a847b9a3?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
 - request:
-    body: 'b''{"cost_function":{"version":"1.0","type":"ising","terms":[{"c": 0, "ids":
-      [0, 1]}'''
+    body: b'\x1f\x8b\x08\x00\xb0\r{b\x02\xff'
     headers:
       Accept:
       - application/xml
       Content-Length:
-      - '81'
+      - '10'
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:31:10 GMT
+      - Wed, 11 May 2022 01:13:20 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
-    uri: https://mystorage.blob.core.windows.net/7f7cb916-7977-11ec-9c89-acde48001122/7f7cb916-7977-11ec-9c89-acde48001122?comp=block&blockid=ICAgICAgICAgMA%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    uri: https://mystorage.blob.core.windows.net/8b7055b8-d0c7-11ec-86fe-2816a847b9a3/8b7055b8-d0c7-11ec-86fe-2816a847b9a3?comp=block&blockid=ICAgICAgICAgMA%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: ''
@@ -128,28 +127,28 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
-    url: https://mystorage.blob.core.windows.net/7f7cb916-7977-11ec-9c89-acde48001122/7f7cb916-7977-11ec-9c89-acde48001122?comp=block&blockid=ICAgICAgICAgMA%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    url: https://mystorage.blob.core.windows.net/8b7055b8-d0c7-11ec-86fe-2816a847b9a3/8b7055b8-d0c7-11ec-86fe-2816a847b9a3?comp=block&blockid=ICAgICAgICAgMA%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
 - request:
-    body: 'b'',{"c": 1, "ids": [1, 2]}'''
+    body: b'D\xc8A\n\x80 \x14E\xd1\xad\xc8\x1bKd6r+!\r\xcc\xc2A\x1aiA\x88{\xefW\x90\xb3{O\x86\t1\x8d\xf3\xe1Mr\xc1Ce\x9cv\x8foB4-8\xd2\xb5Y\x1a\x17\x9d_\x9e\xb5\xfb\x1a\xa1\x86\x0c\x03\xc5Z\xce\xe0&z6P\n]\xf8\xe7\xa2:e\xf7{W\x9dR\xfe.\xabS\xf6\xba\xe8Rn\x00\x00\x00\xff\xff\x03\x00\xc1\x1d\xe0X\x9c\x00\x00\x00'
     headers:
       Accept:
       - application/xml
       Content-Length:
-      - '24'
+      - '111'
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:31:11 GMT
+      - Wed, 11 May 2022 01:13:20 GMT
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
-    uri: https://mystorage.blob.core.windows.net/7f7cb916-7977-11ec-9c89-acde48001122/7f7cb916-7977-11ec-9c89-acde48001122?comp=block&blockid=ICAgICAgICAgMQ%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    uri: https://mystorage.blob.core.windows.net/8b7055b8-d0c7-11ec-86fe-2816a847b9a3/8b7055b8-d0c7-11ec-86fe-2816a847b9a3?comp=block&blockid=ICAgICAgICAgMQ%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: ''
@@ -157,111 +156,24 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
-    url: https://mystorage.blob.core.windows.net/7f7cb916-7977-11ec-9c89-acde48001122/7f7cb916-7977-11ec-9c89-acde48001122?comp=block&blockid=ICAgICAgICAgMQ%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    url: https://mystorage.blob.core.windows.net/8b7055b8-d0c7-11ec-86fe-2816a847b9a3/8b7055b8-d0c7-11ec-86fe-2816a847b9a3?comp=block&blockid=ICAgICAgICAgMQ%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
 - request:
-    body: 'b'',{"c": 2, "ids": [2, 3]}'''
+    body: b"<?xml version='1.0' encoding='utf-8'?>\n<BlockList><Latest>ICAgICAgICAgMA==</Latest><Latest>ICAgICAgICAgMQ==</Latest></BlockList>"
     headers:
       Accept:
       - application/xml
       Content-Length:
-      - '24'
-      Content-Type:
-      - application/octet-stream
-      User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
-      x-ms-date:
-      - Wed, 19 Jan 2022 22:31:11 GMT
-      x-ms-version:
-      - '2020-10-02'
-    method: PUT
-    uri: https://mystorage.blob.core.windows.net/7f7cb916-7977-11ec-9c89-acde48001122/7f7cb916-7977-11ec-9c89-acde48001122?comp=block&blockid=ICAgICAgICAgMg%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-  response:
-    body:
-      string: ''
-    headers:
-      content-length:
-      - '0'
-      x-ms-version:
-      - '2020-10-02'
-    status:
-      code: 201
-      message: Created
-    url: https://mystorage.blob.core.windows.net/7f7cb916-7977-11ec-9c89-acde48001122/7f7cb916-7977-11ec-9c89-acde48001122?comp=block&blockid=ICAgICAgICAgMg%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-- request:
-    body: 'b'',{"c": 3, "ids": [3, 4]}'''
-    headers:
-      Accept:
-      - application/xml
-      Content-Length:
-      - '24'
-      Content-Type:
-      - application/octet-stream
-      User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
-      x-ms-date:
-      - Wed, 19 Jan 2022 22:31:11 GMT
-      x-ms-version:
-      - '2020-10-02'
-    method: PUT
-    uri: https://mystorage.blob.core.windows.net/7f7cb916-7977-11ec-9c89-acde48001122/7f7cb916-7977-11ec-9c89-acde48001122?comp=block&blockid=ICAgICAgICAgMw%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-  response:
-    body:
-      string: ''
-    headers:
-      content-length:
-      - '0'
-      x-ms-version:
-      - '2020-10-02'
-    status:
-      code: 201
-      message: Created
-    url: https://mystorage.blob.core.windows.net/7f7cb916-7977-11ec-9c89-acde48001122/7f7cb916-7977-11ec-9c89-acde48001122?comp=block&blockid=ICAgICAgICAgMw%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-- request:
-    body: b']}}'
-    headers:
-      Accept:
-      - application/xml
-      Content-Length:
-      - '3'
-      Content-Type:
-      - application/octet-stream
-      User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
-      x-ms-date:
-      - Wed, 19 Jan 2022 22:31:11 GMT
-      x-ms-version:
-      - '2020-10-02'
-    method: PUT
-    uri: https://mystorage.blob.core.windows.net/7f7cb916-7977-11ec-9c89-acde48001122/7f7cb916-7977-11ec-9c89-acde48001122?comp=block&blockid=ICAgICAgICAgNA%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-  response:
-    body:
-      string: ''
-    headers:
-      content-length:
-      - '0'
-      x-ms-version:
-      - '2020-10-02'
-    status:
-      code: 201
-      message: Created
-    url: https://mystorage.blob.core.windows.net/7f7cb916-7977-11ec-9c89-acde48001122/7f7cb916-7977-11ec-9c89-acde48001122?comp=block&blockid=ICAgICAgICAgNA%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-- request:
-    body: b"<?xml version='1.0' encoding='utf-8'?>\n<BlockList><Latest>ICAgICAgICAgMA==</Latest><Latest>ICAgICAgICAgMQ==</Latest><Latest>ICAgICAgICAgMg==</Latest><Latest>ICAgICAgICAgMw==</Latest><Latest>ICAgICAgICAgNA==</Latest></BlockList>"
-    headers:
-      Accept:
-      - application/xml
-      Content-Length:
-      - '227'
+      - '128'
       Content-Type:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:31:11 GMT
+      - Wed, 11 May 2022 01:13:21 GMT
       x-ms-meta-avg_coupling:
       - '2.0'
       x-ms-meta-max_coupling:
@@ -273,9 +185,9 @@ interactions:
       x-ms-meta-type:
       - ising
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: PUT
-    uri: https://mystorage.blob.core.windows.net/7f7cb916-7977-11ec-9c89-acde48001122/7f7cb916-7977-11ec-9c89-acde48001122?comp=blocklist&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    uri: https://mystorage.blob.core.windows.net/8b7055b8-d0c7-11ec-86fe-2816a847b9a3/8b7055b8-d0c7-11ec-86fe-2816a847b9a3?comp=blocklist&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: ''
@@ -283,13 +195,13 @@ interactions:
       content-length:
       - '0'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 201
       message: Created
-    url: https://mystorage.blob.core.windows.net/7f7cb916-7977-11ec-9c89-acde48001122/7f7cb916-7977-11ec-9c89-acde48001122?comp=blocklist&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    url: https://mystorage.blob.core.windows.net/8b7055b8-d0c7-11ec-86fe-2816a847b9a3/8b7055b8-d0c7-11ec-86fe-2816a847b9a3?comp=blocklist&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
 - request:
-    body: 'b''{"containerName": "7f7cb916-7977-11ec-9c89-acde48001122"}'''
+    body: 'b''{"containerName": "8b7055b8-d0c7-11ec-86fe-2816a847b9a3"}'''
     headers:
       Accept:
       - application/json
@@ -298,16 +210,16 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
   response:
     body:
-      string: '{"sasUri": "https://mystorage.blob.core.windows.net/7f7cb916-7977-11ec-9c89-acde48001122?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+      string: '{"sasUri": "https://mystorage.blob.core.windows.net/8b7055b8-d0c7-11ec-86fe-2816a847b9a3?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
         "access_token": "fake_token"}'
     headers:
       content-length:
-      - '212'
+      - '203'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -322,15 +234,15 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.11.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
       x-ms-date:
-      - Wed, 19 Jan 2022 22:31:12 GMT
+      - Wed, 11 May 2022 01:13:21 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     method: GET
-    uri: https://mystorage.blob.core.windows.net/7f7cb916-7977-11ec-9c89-acde48001122/7f7cb916-7977-11ec-9c89-acde48001122?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    uri: https://mystorage.blob.core.windows.net/8b7055b8-d0c7-11ec-86fe-2816a847b9a3/8b7055b8-d0c7-11ec-86fe-2816a847b9a3?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
   response:
     body:
       string: '{"cost_function": {"version": "1.0", "type": "ising", "terms": [{"c":
@@ -342,13 +254,13 @@ interactions:
       content-length:
       - '156'
       content-range:
-      - bytes 0-155/156
+      - bytes 0-120/121
       content-type:
       - application/json
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 19 Jan 2022 22:31:11 GMT
+      - Wed, 11 May 2022 01:13:21 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -366,9 +278,9 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-10-02'
+      - '2021-04-10'
     status:
       code: 206
       message: Partial Content
-    url: https://mystorage.blob.core.windows.net/7f7cb916-7977-11ec-9c89-acde48001122/7f7cb916-7977-11ec-9c89-acde48001122?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
+    url: https://mystorage.blob.core.windows.net/8b7055b8-d0c7-11ec-86fe-2816a847b9a3/8b7055b8-d0c7-11ec-86fe-2816a847b9a3?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
 version: 1

--- a/azure-quantum/tests/unit/aio/recordings/test_streaming_problem_small_chunks_compressed.yaml
+++ b/azure-quantum/tests/unit/aio/recordings/test_streaming_problem_small_chunks_compressed.yaml
@@ -6,7 +6,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - azsdk-python-identity/1.7.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-identity/1.10.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
   response:
@@ -23,7 +23,7 @@ interactions:
       message: OK
     url: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
 - request:
-    body: 'b''{"containerName": "81d44ef4-7977-11ec-9c89-acde48001122"}'''
+    body: 'b''{"containerName": "7e04c7cd-d0bb-11ec-b983-2816a847b9a3"}'''
     headers:
       Accept:
       - application/json
@@ -32,16 +32,16 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
   response:
     body:
-      string: '{"sasUri": "https://mystorage.blob.core.windows.net/81d44ef4-7977-11ec-9c89-acde48001122?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+      string: '{"sasUri": "https://mystorage.blob.core.windows.net/7e04c7cd-d0bb-11ec-b983-2816a847b9a3?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
         "access_token": "fake_token"}'
     headers:
       content-length:
-      - '212'
+      - '207'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -50,237 +50,4 @@ interactions:
       code: 200
       message: OK
     url: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/xml
-      User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
-      x-ms-date:
-      - Wed, 19 Jan 2022 22:31:13 GMT
-      x-ms-version:
-      - '2020-10-02'
-    method: GET
-    uri: https://mystorage.blob.core.windows.net/81d44ef4-7977-11ec-9c89-acde48001122?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-  response:
-    body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
-        specified container does not exist.\nRequestId:0df401a5-701e-004a-6884-0d11f8000000\nTime:2022-01-19T22:31:14.4654220Z</Message></Error>"
-    headers:
-      content-length:
-      - '225'
-      content-type:
-      - application/xml
-      x-ms-version:
-      - '2020-10-02'
-    status:
-      code: 404
-      message: The specified container does not exist.
-    url: https://mystorage.blob.core.windows.net/81d44ef4-7977-11ec-9c89-acde48001122?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/xml
-      User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
-      x-ms-date:
-      - Wed, 19 Jan 2022 22:31:14 GMT
-      x-ms-version:
-      - '2020-10-02'
-    method: PUT
-    uri: https://mystorage.blob.core.windows.net/81d44ef4-7977-11ec-9c89-acde48001122?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-  response:
-    body:
-      string: ''
-    headers:
-      content-length:
-      - '0'
-      x-ms-version:
-      - '2020-10-02'
-    status:
-      code: 201
-      message: Created
-    url: https://mystorage.blob.core.windows.net/81d44ef4-7977-11ec-9c89-acde48001122?restype=container&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-- request:
-    body: b'\x1f\x8b\x08\x001\x91\xe8a\x02\xff'
-    headers:
-      Accept:
-      - application/xml
-      Content-Length:
-      - '10'
-      Content-Type:
-      - application/octet-stream
-      User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
-      x-ms-date:
-      - Wed, 19 Jan 2022 22:31:14 GMT
-      x-ms-version:
-      - '2020-10-02'
-    method: PUT
-    uri: https://mystorage.blob.core.windows.net/81d44ef4-7977-11ec-9c89-acde48001122/81d44ef4-7977-11ec-9c89-acde48001122?comp=block&blockid=ICAgICAgICAgMA%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-  response:
-    body:
-      string: ''
-    headers:
-      content-length:
-      - '0'
-      x-ms-version:
-      - '2020-10-02'
-    status:
-      code: 201
-      message: Created
-    url: https://mystorage.blob.core.windows.net/81d44ef4-7977-11ec-9c89-acde48001122/81d44ef4-7977-11ec-9c89-acde48001122?comp=block&blockid=ICAgICAgICAgMA%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-- request:
-    body: b'D\xc8A\n\x80 \x14E\xd1\xad\xc8\x1bKd6r+!\r\xcc\xc2A\x1aiA\x88{\xefW\x90\xb3{O\x86\t1\x8d\xf3\xe1Mr\xc1Ce\x9cv\x8foB4-8\xd2\xb5Y\x1a\x17\x9d_\x9e\xb5\xfb\x1a\xa1\x86\x0c\x03\xc5Z\xce\xe0&z6P\n]\xf8\xe7\xa2:e\xf7{W\x9dR\xfe.\xabS\xf6\xba\xe8Rn\x00\x00\x00\xff\xff\x03\x00\xc1\x1d\xe0X\x9c\x00\x00\x00'
-    headers:
-      Accept:
-      - application/xml
-      Content-Length:
-      - '111'
-      Content-Type:
-      - application/octet-stream
-      User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
-      x-ms-date:
-      - Wed, 19 Jan 2022 22:31:14 GMT
-      x-ms-version:
-      - '2020-10-02'
-    method: PUT
-    uri: https://mystorage.blob.core.windows.net/81d44ef4-7977-11ec-9c89-acde48001122/81d44ef4-7977-11ec-9c89-acde48001122?comp=block&blockid=ICAgICAgICAgMQ%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-  response:
-    body:
-      string: ''
-    headers:
-      content-length:
-      - '0'
-      x-ms-version:
-      - '2020-10-02'
-    status:
-      code: 201
-      message: Created
-    url: https://mystorage.blob.core.windows.net/81d44ef4-7977-11ec-9c89-acde48001122/81d44ef4-7977-11ec-9c89-acde48001122?comp=block&blockid=ICAgICAgICAgMQ%3D%3D&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-- request:
-    body: b"<?xml version='1.0' encoding='utf-8'?>\n<BlockList><Latest>ICAgICAgICAgMA==</Latest><Latest>ICAgICAgICAgMQ==</Latest></BlockList>"
-    headers:
-      Accept:
-      - application/xml
-      Content-Length:
-      - '128'
-      Content-Type:
-      - application/xml
-      User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
-      x-ms-date:
-      - Wed, 19 Jan 2022 22:31:14 GMT
-      x-ms-meta-avg_coupling:
-      - '2.0'
-      x-ms-meta-max_coupling:
-      - '2'
-      x-ms-meta-min_coupling:
-      - '2'
-      x-ms-meta-num_terms:
-      - '4'
-      x-ms-meta-type:
-      - ising
-      x-ms-version:
-      - '2020-10-02'
-    method: PUT
-    uri: https://mystorage.blob.core.windows.net/81d44ef4-7977-11ec-9c89-acde48001122/81d44ef4-7977-11ec-9c89-acde48001122?comp=blocklist&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-  response:
-    body:
-      string: ''
-    headers:
-      content-length:
-      - '0'
-      x-ms-version:
-      - '2020-10-02'
-    status:
-      code: 201
-      message: Created
-    url: https://mystorage.blob.core.windows.net/81d44ef4-7977-11ec-9c89-acde48001122/81d44ef4-7977-11ec-9c89-acde48001122?comp=blocklist&sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-- request:
-    body: 'b''{"containerName": "81d44ef4-7977-11ec-9c89-acde48001122"}'''
-    headers:
-      Accept:
-      - application/json
-      Content-Length:
-      - '57'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
-    method: POST
-    uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
-  response:
-    body:
-      string: '{"sasUri": "https://mystorage.blob.core.windows.net/81d44ef4-7977-11ec-9c89-acde48001122?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "access_token": "fake_token"}'
-    headers:
-      content-length:
-      - '212'
-      content-type:
-      - application/json; charset=utf-8
-      transfer-encoding:
-      - chunked
-    status:
-      code: 200
-      message: OK
-    url: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/xml
-      User-Agent:
-      - azsdk-python-storage-blob/12.9.0 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
-      x-ms-date:
-      - Wed, 19 Jan 2022 22:31:15 GMT
-      x-ms-range:
-      - bytes=0-33554431
-      x-ms-version:
-      - '2020-10-02'
-    method: GET
-    uri: https://mystorage.blob.core.windows.net/81d44ef4-7977-11ec-9c89-acde48001122/81d44ef4-7977-11ec-9c89-acde48001122?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
-  response:
-    body:
-      string: '{"cost_function": {"version": "1.0", "type": "ising", "terms": [{"c":
-        0, "ids": [0, 1]}, {"c": 1, "ids": [1, 2]}, {"c": 2, "ids": [2, 3]}, {"c":
-        3, "ids": [3, 4]}]}, "access_token": "fake_token"}'
-    headers:
-      accept-ranges:
-      - bytes
-      content-length:
-      - '156'
-      content-range:
-      - bytes 0-120/121
-      content-type:
-      - application/json
-      x-ms-blob-type:
-      - BlockBlob
-      x-ms-creation-time:
-      - Wed, 19 Jan 2022 22:31:15 GMT
-      x-ms-lease-state:
-      - available
-      x-ms-lease-status:
-      - unlocked
-      x-ms-meta-avg_coupling:
-      - '2.0'
-      x-ms-meta-max_coupling:
-      - '2'
-      x-ms-meta-min_coupling:
-      - '2'
-      x-ms-meta-num_terms:
-      - '4'
-      x-ms-meta-type:
-      - ising
-      x-ms-server-encrypted:
-      - 'true'
-      x-ms-version:
-      - '2020-10-02'
-    status:
-      code: 206
-      message: Partial Content
-    url: https://mystorage.blob.core.windows.net/81d44ef4-7977-11ec-9c89-acde48001122/81d44ef4-7977-11ec-9c89-acde48001122?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw
 version: 1

--- a/azure-quantum/tests/unit/aio/recordings/test_workspace_get_targets.yaml
+++ b/azure-quantum/tests/unit/aio/recordings/test_workspace_get_targets.yaml
@@ -6,7 +6,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - azsdk-python-identity/1.7.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-identity/1.10.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
   response:
@@ -28,16 +28,13 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/providerStatus
   response:
     body:
       string: '{"value": [{"id": "Microsoft", "currentAvailability": "Available",
-        "targets": [{"id": "microsoft.simulatedannealing.fpga", "currentAvailability":
-        "Available", "averageQueueTime": 0, "statusPage": null}, {"id": "microsoft.simulatedannealing-parameterfree.fpga",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null},
-        {"id": "microsoft.paralleltempering-parameterfree.cpu", "currentAvailability":
+        "targets": [{"id": "microsoft.paralleltempering-parameterfree.cpu", "currentAvailability":
         "Available", "averageQueueTime": 0, "statusPage": null}, {"id": "microsoft.paralleltempering.cpu",
         "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null},
         {"id": "microsoft.simulatedannealing-parameterfree.cpu", "currentAvailability":
@@ -52,17 +49,55 @@ interactions:
         "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null},
         {"id": "microsoft.substochasticmontecarlo.cpu", "currentAvailability": "Available",
         "averageQueueTime": 0, "statusPage": null}, {"id": "microsoft.substochasticmontecarlo-parameterfree.cpu",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null},
-        {"id": "microsoft.populationannealing-parameterfree.cpu", "currentAvailability":
-        "Available", "averageQueueTime": 0, "statusPage": null}]}, {"id": "ionq",
-        "currentAvailability": "Available", "targets": [{"id": "ionq.qpu", "currentAvailability":
-        "Available", "averageQueueTime": 252, "statusPage": "https://status.ionq.co"},
-        {"id": "ionq.simulator", "currentAvailability": "Available", "averageQueueTime":
-        3, "statusPage": "https://status.ionq.co"}]}], "nextLink": null, "access_token":
-        "fake_token"}'
+        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
+        {"id": "toshiba", "currentAvailability": "Available", "targets": [{"id": "toshiba.sbm.ising",
+        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": "https://aq-sbm.net/v1/service_monitor/index.html"}]},
+        {"id": "honeywell", "currentAvailability": "Degraded", "targets": [{"id":
+        "honeywell.hqs-lt-s1", "currentAvailability": "Unavailable", "averageQueueTime":
+        0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        "honeywell.hqs-lt-s1-apival", "currentAvailability": "Available", "averageQueueTime":
+        0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        "honeywell.hqs-lt-s2", "currentAvailability": "Unavailable", "averageQueueTime":
+        0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        "honeywell.hqs-lt-s2-apival", "currentAvailability": "Available", "averageQueueTime":
+        0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        "honeywell.hqs-lt-s1-sim", "currentAvailability": "Available", "averageQueueTime":
+        0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}, {"id":
+        "honeywell.hqs-lt", "currentAvailability": "Unavailable", "averageQueueTime":
+        0, "statusPage": "https://www.honeywell.com/en-us/company/quantum"}]}, {"id":
+        "Microsoft.Simulator", "currentAvailability": "Available", "targets": [{"id":
+        "microsoft.simulator.fullstate", "currentAvailability": "Available", "averageQueueTime":
+        0, "statusPage": null}]}, {"id": "1qbit", "currentAvailability": "Available",
+        "targets": [{"id": "1qbit.tabu", "currentAvailability": "Available", "averageQueueTime":
+        0, "statusPage": "https://status.1qbit.com/"}, {"id": "1qbit.pathrelinking",
+        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": "https://status.1qbit.com/"},
+        {"id": "1qbit.pticm", "currentAvailability": "Available", "averageQueueTime":
+        0, "statusPage": "https://status.1qbit.com/"}]}, {"id": "ionq", "currentAvailability":
+        "Available", "targets": [{"id": "ionq.qpu", "currentAvailability": "Available",
+        "averageQueueTime": 4221, "statusPage": "https://status.ionq.co"}, {"id":
+        "ionq.simulator", "currentAvailability": "Available", "averageQueueTime":
+        2, "statusPage": "https://status.ionq.co"}]}, {"id": "quantinuum", "currentAvailability":
+        "Degraded", "targets": [{"id": "quantinuum.hqs-lt-s1", "currentAvailability":
+        "Unavailable", "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"},
+        {"id": "quantinuum.hqs-lt-s1-apival", "currentAvailability": "Available",
+        "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"},
+        {"id": "quantinuum.hqs-lt-s2", "currentAvailability": "Unavailable", "averageQueueTime":
+        0, "statusPage": "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.hqs-lt-s2-apival",
+        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"},
+        {"id": "quantinuum.hqs-lt-s1-sim", "currentAvailability": "Available", "averageQueueTime":
+        0, "statusPage": "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.hqs-lt-s2-sim",
+        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"},
+        {"id": "quantinuum.hqs-lt", "currentAvailability": "Unavailable", "averageQueueTime":
+        0, "statusPage": "https://www.quantinuum.com/products/h1"}]}, {"id": "rigetti",
+        "currentAvailability": "Degraded", "targets": [{"id": "rigetti.sim.qvm", "currentAvailability":
+        "Available", "averageQueueTime": 5, "statusPage": "https://rigetti.statuspage.io/"},
+        {"id": "rigetti.qpu.aspen-11", "currentAvailability": "Degraded", "averageQueueTime":
+        5, "statusPage": "https://rigetti.statuspage.io/"}, {"id": "rigetti.qpu.aspen-m-1",
+        "currentAvailability": "Available", "averageQueueTime": 5, "statusPage": "https://rigetti.statuspage.io/"}]}],
+        "nextLink": null, "access_token": "fake_token"}'
     headers:
       content-length:
-      - '2060'
+      - '4977'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:

--- a/azure-quantum/tests/unit/aio/recordings/test_workspace_job_quotas.yaml
+++ b/azure-quantum/tests/unit/aio/recordings/test_workspace_job_quotas.yaml
@@ -6,7 +6,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - azsdk-python-identity/1.7.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - azsdk-python-identity/1.10.0 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: POST
     uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
   response:
@@ -28,29 +28,34 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.7.12 (Darwin-21.2.0-x86_64-i386-64bit)
+      - async-testapp azsdk-python-quantum/0.0.0.1 Python/3.9.12 (Windows-10-10.0.19042-SP0)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/quotas
   response:
     body:
       string: '{"value": [{"dimension": "combined_job_hours", "scope": "Workspace",
-        "providerId": "Microsoft", "utilization": 0.011223818027777777, "holds": 0.0,
-        "limit": 5.0, "period": "Monthly"}, {"dimension": "combined_job_hours", "scope":
-        "Subscription", "providerId": "Microsoft", "utilization": 0.011223818027777777,
+        "providerId": "Microsoft", "utilization": 0.047923176972222224, "holds": 0.0,
+        "limit": 20.0, "period": "Monthly"}, {"dimension": "combined_job_hours", "scope":
+        "Subscription", "providerId": "Microsoft", "utilization": 0.047923176972222224,
         "holds": 0.0, "limit": 1000.0, "period": "Monthly"}, {"dimension": "concurrent_cpu_jobs",
         "scope": "Workspace", "providerId": "Microsoft", "utilization": 0.0, "holds":
-        0.0, "limit": 5.0, "period": "None"}, {"dimension": "fpga_job_hours", "scope":
+        0.0, "limit": 5.0, "period": "None"}, {"dimension": "concurrent_fpga_jobs",
+        "scope": "Workspace", "providerId": "Microsoft", "utilization": 0.0, "holds":
+        0.0, "limit": 2.0, "period": "None"}, {"dimension": "fpga_job_hours", "scope":
         "Workspace", "providerId": "Microsoft", "utilization": 0.0, "holds": 0.0,
         "limit": 1.0, "period": "Monthly"}, {"dimension": "fpga_job_hours", "scope":
         "Subscription", "providerId": "Microsoft", "utilization": 0.0, "holds": 0.0,
-        "limit": 1000.0, "period": "Monthly"}, {"dimension": "concurrent_fpga_jobs",
-        "scope": "Workspace", "providerId": "Microsoft", "utilization": 0.0, "holds":
-        0.0, "limit": 1.0, "period": "None"}, {"dimension": "qgs", "scope": "Subscription",
-        "providerId": "ionq", "utilization": 0.0, "holds": 0.0, "limit": 16666667.0,
-        "period": "Infinite"}], "nextLink": null, "access_token": "fake_token"}'
+        "limit": 1000.0, "period": "Monthly"}, {"dimension": "simulator_job_hours",
+        "scope": "Workspace", "providerId": "Microsoft.Simulator", "utilization":
+        0.0, "holds": 0.0, "limit": 20.0, "period": "Monthly"}, {"dimension": "simulator_job_hours",
+        "scope": "Subscription", "providerId": "Microsoft.Simulator", "utilization":
+        0.0, "holds": 0.0, "limit": 1000.0, "period": "Monthly"}, {"dimension": "concurrent_simulator_jobs",
+        "scope": "Workspace", "providerId": "Microsoft.Simulator", "utilization":
+        0.0, "holds": 0.0, "limit": 5.0, "period": "None"}], "nextLink": null, "access_token":
+        "fake_token"}'
     headers:
       content-length:
-      - '1040'
+      - '1375'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:

--- a/azure-quantum/tests/unit/aio/test_aio_job.py
+++ b/azure-quantum/tests/unit/aio/test_aio_job.py
@@ -279,6 +279,50 @@ class TestJob(QuantumTestBase):
                 assert job.details.status == "Succeeded"
 
 
+    @pytest.mark.live_test
+    @pytest.mark.qio
+    @pytest.mark.asyncio
+    def test_job_attachments(self):
+        self.get_async_result(self._test_job_attachments())
+
+    async def _test_job_attachments(self):
+        workspace = self.create_async_workspace()
+        
+        solver = microsoft.SimulatedAnnealing(workspace)
+
+        with unittest.mock.patch.object(
+            Job,
+            self.mock_create_job_id_name,
+            return_value=self.get_test_job_id(),
+        ):
+            expected_1 = "Some data 1".encode('utf-8')
+            expected_2 = "Some other random data 2".encode('utf-8')
+            problem = self.create_problem(name="test_job_attachments")
+
+            job = await solver.submit(problem)
+
+            url1 = await job.upload_attachment("test-1", expected_1)
+            self.assertTrue(job.id in url1)
+            self.assertTrue("test-1" in url1)
+
+            url2 = await job.upload_attachment("test-2", expected_2)
+            self.assertTrue(job.id in url2)
+            self.assertTrue("test-2" in url2)
+
+            actual_1 = await job.download_attachment("test-1")
+            self.assertEqual(expected_1, actual_1)
+
+            actual_2 = await job.download_attachment("test-2")
+            self.assertEqual(expected_2, actual_2)
+
+            # Check if download_attachment can successfully download other blobs 
+            # automatically created
+            problem_as_json = await job.download_attachment("inputData")
+            downloaded_problem = Problem.deserialize(input_problem=problem_as_json)
+            actual = downloaded_problem.serialize()
+            expected = problem.serialize()
+            self.assertEqual(expected, actual)
+
     def create_problem(
             self,
             name: str,

--- a/azure-quantum/tests/unit/aio/test_aio_streaming_problem.py
+++ b/azure-quantum/tests/unit/aio/test_aio_streaming_problem.py
@@ -84,26 +84,19 @@ class TestStreamingProblem(QuantumTestBase):
         return default
 
     def test_streaming_problem_small_chunks(self):
-        self.get_async_result(self.__test_upload_problem(4, 1, 1, False))
+        self.get_async_result(self.__test_upload_problem(4, 1, 1))
 
     def test_streaming_problem_large_chunks(self):
-        self.get_async_result(self.__test_upload_problem(4, 1000, 10e6, False))
-
-    def test_streaming_problem_small_chunks_compressed(self):
-        self.get_async_result(self.__test_upload_problem(4, 1, 1, True))
-
-    def test_streaming_problem_large_chunks_compressed(self):
-        self.get_async_result(self.__test_upload_problem(4, 1000, 10e6, True))
+        self.get_async_result(self.__test_upload_problem(4, 1000, 10e6))
 
     def test_streaming_problem_pubo(self):
-        self.get_async_result(self.__test_upload_problem(4, 1, 1, False, ProblemType.pubo))
+        self.get_async_result(self.__test_upload_problem(4, 1, 1, ProblemType.pubo))
 
     def test_streaming_problem_initial_terms(self):
         self.get_async_result( self.__test_upload_problem(
             4,
             1,
             1,
-            False,
             initial_terms=[
                 Term(w=10, indices=[0, 1, 2]),
                 Term(w=20, indices=[1, 2, 3]),
@@ -115,7 +108,5 @@ class TestStreamingProblem(QuantumTestBase):
     def check_all(self):
         self.test_streaming_problem_small_chunks()
         self.test_streaming_problem_large_chunks()
-        self.test_streaming_problem_small_chunks_compressed()
-        self.test_streaming_problem_large_chunks_compressed()
         self.test_streaming_problem_pubo()
         self.test_streaming_problem_initial_terms()


### PR DESCRIPTION
Found a couple of places where the async API was either broken or incorrect, in particular:
* StreamingProblem was not working correctly. The sync version runs the upload in a different thread; however since the code in aio is async by definition it can be easily simplified
* UploadAttachment: It had a bug in the code 
* QIO job submission: some changes on the sync version were not propagated causing problems on how the payload is uploaded and encoded.

Also, added a lot of missing `close()` calls and fixed tests.