### PR TITLE
Fix azure-storage-blob version and max version for protobuf

### DIFF
--- a/azure-quantum/environment-cirq-beta.yml
+++ b/azure-quantum/environment-cirq-beta.yml
@@ -16,6 +16,7 @@ dependencies:
   - pip:
     - azure-core==1.19.1 # see https://github.com/microsoft/qdk-python/issues/220 
     - azure-devtools>=1.2.0
+    - azure-storage-blob==12.11.0 # see https://github.com/microsoft/qdk-python/issues/220
     - --pre cirq-core>=0.13.1
     - cirq-ionq>=0.13.1
     - qiskit-ionq>=0.1.4

--- a/azure-quantum/environment.yml
+++ b/azure-quantum/environment.yml
@@ -16,6 +16,7 @@ dependencies:
   - pip:
     - azure-core==1.19.1 # see https://github.com/microsoft/qdk-python/issues/220
     - azure-devtools>=1.2.0
+    - azure-storage-blob==12.11.0 # see https://github.com/microsoft/qdk-python/issues/220
     - cirq-core>=0.13.1
     - cirq-ionq>=0.13.1
     - qiskit-ionq>=0.1.4

--- a/azure-quantum/requirements.txt
+++ b/azure-quantum/requirements.txt
@@ -6,4 +6,4 @@ numpy>=1.21.0
 deprecated>=1.2.12
 aiohttp>=3.7.0
 aiofile>=3.7.2
-protobuf>=3.14.0
+protobuf>=3.14.0,4.0

--- a/azure-quantum/requirements.txt
+++ b/azure-quantum/requirements.txt
@@ -6,4 +6,4 @@ numpy>=1.21.0
 deprecated>=1.2.12
 aiohttp>=3.7.0
 aiofile>=3.7.2
-protobuf>=3.14.0,4.0
+protobuf>=3.14.0,<4.0


### PR DESCRIPTION
The new version of azure-storage-blob (12.12.0) requires azure-core>=1.23.1, but becuase #220 we can't pick it up.
Changing the conda environments to make sure the tests run successfully.