### PR TITLE
Added support for legacy target

### DIFF
--- a/azure-quantum/azure/quantum/target/microsoft/qio/parallel_tempering.py
+++ b/azure-quantum/azure/quantum/target/microsoft/qio/parallel_tempering.py
@@ -18,6 +18,8 @@ class ParallelTempering(Solver):
         "microsoft.paralleltempering-parameterfree.cpu",
         "microsoft.paralleltempering.cpu.experimental",
         "microsoft.paralleltempering-parameterfree.cpu.experimental"
+        "microsoft.paralleltempering.cpu.legacy",
+        "microsoft.paralleltempering-parameterfree.cpu.legacy"
     )
     def __init__(
         self,
@@ -56,10 +58,7 @@ class ParallelTempering(Solver):
         if platform == HardwarePlatform.FPGA:
             name = "microsoft.paralleltempering.fpga"
         elif param_free:
-            if "experimental" in name:
-                name = "microsoft.paralleltempering-parameterfree.cpu.experimental"
-            else:
-                name = "microsoft.paralleltempering-parameterfree.cpu"
+            name = name.replace(".paralleltempering.", ".paralleltempering-parameterfree.")
  
         super().__init__(
             workspace=workspace,
@@ -88,11 +87,11 @@ class ParallelTempering(Solver):
                 )
 
     def supports_grouped_terms(self):
-        if "experimental" in self.name:
-            return True
-        return False
+        if "legacy" in self.name or "fpga" in self.name:
+            return False
+        return True
     
     def supports_protobuf(self):
-        if "experimental" in self.name:
-            return True
-        return False
+        if "legacy" in self.name or "fpga" in self.name:
+            return False
+        return True

--- a/azure-quantum/azure/quantum/target/microsoft/qio/quantum_monte_carlo.py
+++ b/azure-quantum/azure/quantum/target/microsoft/qio/quantum_monte_carlo.py
@@ -14,7 +14,8 @@ logger = logging.getLogger(__name__)
 class QuantumMonteCarlo(Solver):
     target_names = (
         "microsoft.qmc.cpu",
-        "microsoft.qmc.cpu.experimental"
+        "microsoft.qmc.cpu.experimental",
+        "microsoft.qmc.cpu.legacy"
     )
     def __init__(
         self,
@@ -71,11 +72,11 @@ class QuantumMonteCarlo(Solver):
         self.set_one_param("restarts", restarts)
 
     def supports_grouped_terms(self):
-        if "experimental" in self.name:
-            return True
-        return False
+        if "legacy" in self.name:
+            return False
+        return True
     
     def supports_protobuf(self):
-        if "experimental" in self.name:
-            return True
-        return False
+        if "legacy" in self.name:
+            return False
+        return True

--- a/azure-quantum/azure/quantum/target/microsoft/qio/simulated_annealing.py
+++ b/azure-quantum/azure/quantum/target/microsoft/qio/simulated_annealing.py
@@ -22,7 +22,9 @@ class SimulatedAnnealing(Solver):
         "microsoft.simulatedannealing.cpu",
         "microsoft.simulatedannealing-parameterfree.cpu",
         "microsoft.simulatedannealing.cpu.experimental",
-        "microsoft.simulatedannealing-parameterfree.cpu.experimental"
+        "microsoft.simulatedannealing-parameterfree.cpu.experimental",
+        "microsoft.simulatedannealing.cpu.legacy",
+        "microsoft.simulatedannealing-parameterfree.cpu.experimental.legacy"
     ]
     def __init__(
         self,
@@ -75,10 +77,7 @@ class SimulatedAnnealing(Solver):
                 else "microsoft.simulatedannealing.fpga"
             )
         elif param_free:
-            if "experimental" in name:
-                name = "microsoft.simulatedannealing-parameterfree.cpu.experimental"
-            else:
-                name = "microsoft.simulatedannealing-parameterfree.cpu"
+            name = name.replace(".simulatedannealing.", ".simulatedannealing-parameterfree.")
 
         super().__init__(
             workspace=workspace,
@@ -109,7 +108,7 @@ class SimulatedAnnealing(Solver):
         :return: Target instance
         :rtype: Target
         """
-        if status.id.endswith("cpu") or status.id.endswith("cpu.experimental"):
+        if ".cpu" in status.id:
             platform = HardwarePlatform.CPU
         elif status.id.endswith("fpga"):
             platform = HardwarePlatform.FPGA
@@ -124,11 +123,11 @@ class SimulatedAnnealing(Solver):
         )
 
     def supports_grouped_terms(self):
-        if "experimental" in self.name:
-            return True
-        return False
+        if "legacy" in self.name or "fpga" in self.name:
+            return False
+        return True
     
     def supports_protobuf(self):
-        if "experimental" in self.name:
-            return True
-        return False
+        if "legacy" in self.name or "fpga" in self.name:
+            return False
+        return True

--- a/azure-quantum/azure/quantum/target/microsoft/qio/tabu.py
+++ b/azure-quantum/azure/quantum/target/microsoft/qio/tabu.py
@@ -16,7 +16,9 @@ class Tabu(Solver):
         "microsoft.tabu.cpu",
         "microsoft.tabu-parameterfree.cpu",
         "microsoft.tabu.cpu.experimental",
-        "microsoft.tabu-parameterfree.cpu.experimental"
+        "microsoft.tabu-parameterfree.cpu.experimental",
+        "microsoft.tabu.cpu.legacy",
+        "microsoft.tabu-parameterfree.cpu.legacy"
     )
     def __init__(
         self,
@@ -52,10 +54,7 @@ class Tabu(Solver):
         """
         param_free = sweeps is None and tabu_tenure is None and restarts is None
         if param_free:
-            if "experimental" in name:
-                name = "microsoft.tabu-parameterfree.cpu.experimental"
-            else:
-                name = "microsoft.tabu-parameterfree.cpu"
+            name = name.replace(".tabu.", ".tabu-parameterfree.")
 
         super().__init__(
             workspace=workspace,
@@ -73,11 +72,11 @@ class Tabu(Solver):
         self.set_one_param("restarts", restarts)
 
     def supports_grouped_terms(self):
-        if "experimental" in self.name:
-            return True
-        return False
+        if "legacy" in self.name:
+            return False
+        return True
     
     def supports_protobuf(self):
-        if "experimental" in self.name:
-            return True
-        return False
+        if "legacy" in self.name:
+            return False
+        return True

--- a/azure-quantum/tests/unit/test_optimization.py
+++ b/azure-quantum/tests/unit/test_optimization.py
@@ -425,8 +425,8 @@ class TestSolvers(QuantumTestBase):
             "microsoft.paralleltempering-parameterfree.cpu", good.name
         )
         self.assertEqual({"timeout": 1011}, good.params["params"])
-        self.assertEqual(False, good.supports_grouped_terms())
-        self.assertEqual(False, good.supports_protobuf())
+        self.assertEqual(True, good.supports_grouped_terms())
+        self.assertEqual(True, good.supports_protobuf())
 
         good = ParallelTempering(ws, seed=20)
         self.assertIsNotNone(good)
@@ -434,8 +434,8 @@ class TestSolvers(QuantumTestBase):
             "microsoft.paralleltempering-parameterfree.cpu", good.name
         )
         self.assertEqual({"seed": 20}, good.params["params"])
-        self.assertEqual(False, good.supports_grouped_terms())
-        self.assertEqual(False, good.supports_protobuf())
+        self.assertEqual(True, good.supports_grouped_terms())
+        self.assertEqual(True, good.supports_protobuf())
 
         good = ParallelTempering(
             ws, sweeps=20, replicas=3, all_betas=[3, 5, 9]
@@ -446,8 +446,8 @@ class TestSolvers(QuantumTestBase):
             {"sweeps": 20, "replicas": 3, "all_betas": [3, 5, 9]},
             good.params["params"],
         )
-        self.assertEqual(False, good.supports_grouped_terms())
-        self.assertEqual(False, good.supports_protobuf())
+        self.assertEqual(True, good.supports_grouped_terms())
+        self.assertEqual(True, good.supports_protobuf())
 
         good = ParallelTempering(ws, sweeps=20, all_betas=[3, 9])
         self.assertIsNotNone(good)
@@ -456,8 +456,8 @@ class TestSolvers(QuantumTestBase):
             {"sweeps": 20, "replicas": 2, "all_betas": [3, 9]},
             good.params["params"],
         )
-        self.assertEqual(False, good.supports_grouped_terms())
-        self.assertEqual(False, good.supports_protobuf())
+        self.assertEqual(True, good.supports_grouped_terms())
+        self.assertEqual(True, good.supports_protobuf())
 
         with self.assertRaises(ValueError):
             _ = ParallelTempering(
@@ -512,6 +512,53 @@ class TestSolvers(QuantumTestBase):
                 ws, name = "microsoft.paralleltempering.cpu.experimental", sweeps=20, replicas=3, all_betas=[1, 3, 5, 7, 9]
             )
 
+    def test_ParallelTempering_legacy_input_params(self):
+        ws = self.create_workspace()
+
+        good = ParallelTempering(ws, name = "microsoft.paralleltempering.cpu.legacy", timeout=1011)
+        self.assertIsNotNone(good)
+        self.assertEqual(
+            "microsoft.paralleltempering-parameterfree.cpu.legacy", good.name
+        )
+        self.assertEqual({"timeout": 1011}, good.params["params"])
+        self.assertEqual(True, good.supports_grouped_terms())
+        self.assertEqual(True, good.supports_protobuf())
+
+        good = ParallelTempering(ws, name = "microsoft.paralleltempering.cpu.legacy", seed=20)
+        self.assertIsNotNone(good)
+        self.assertEqual(
+            "microsoft.paralleltempering-parameterfree.cpu.legacy", good.name
+        )
+        self.assertEqual({"seed": 20}, good.params["params"])
+        self.assertEqual(True, good.supports_grouped_terms())
+        self.assertEqual(True, good.supports_protobuf())
+
+        good = ParallelTempering(
+            ws, name = "microsoft.paralleltempering.cpu.legacy", sweeps=20, replicas=3, all_betas=[3, 5, 9]
+        )
+        self.assertIsNotNone(good)
+        self.assertEqual("microsoft.paralleltempering.cpu.legacy", good.name)
+        self.assertEqual(
+            {"sweeps": 20, "replicas": 3, "all_betas": [3, 5, 9]},
+            good.params["params"],
+        )
+        self.assertEqual(False, good.supports_grouped_terms())
+        self.assertEqual(False, good.supports_protobuf())
+
+        good = ParallelTempering(ws, name = "microsoft.paralleltempering.cpu.legacy", sweeps=20, all_betas=[3, 9])
+        self.assertIsNotNone(good)
+        self.assertEqual("microsoft.paralleltempering.cpu.legacy", good.name)
+        self.assertEqual(
+            {"sweeps": 20, "replicas": 2, "all_betas": [3, 9]},
+            good.params["params"],
+        )
+        self.assertEqual(True, good.supports_grouped_terms())
+        self.assertEqual(True, good.supports_protobuf())
+
+        with self.assertRaises(ValueError):
+            _ = ParallelTempering(
+                ws, name = "microsoft.paralleltempering.cpu.legacy", sweeps=20, replicas=3, all_betas=[1, 3, 5, 7, 9]
+            )
 
     def test_SimulatedAnnealing_input_params(self):
         ws = self.create_workspace()
@@ -524,8 +571,8 @@ class TestSolvers(QuantumTestBase):
         self.assertEqual(
             {"timeout": 1011, "seed": 4321}, good.params["params"]
         )
-        self.assertEqual(False, good.supports_grouped_terms())
-        self.assertEqual(False, good.supports_protobuf())
+        self.assertEqual(True, good.supports_grouped_terms())
+        self.assertEqual(True, good.supports_protobuf())
 
         good = SimulatedAnnealing(
             ws, timeout=1011, seed=4321, platform=HardwarePlatform.FPGA
@@ -542,8 +589,8 @@ class TestSolvers(QuantumTestBase):
         self.assertIsNotNone(good)
         self.assertEqual("microsoft.simulatedannealing.cpu", good.name)
         self.assertEqual({"beta_start": 21}, good.params["params"])
-        self.assertEqual(False, good.supports_grouped_terms())
-        self.assertEqual(False, good.supports_protobuf())
+        self.assertEqual(True, good.supports_grouped_terms())
+        self.assertEqual(True, good.supports_protobuf())
 
 
         good = SimulatedAnnealing(
@@ -574,6 +621,27 @@ class TestSolvers(QuantumTestBase):
         self.assertEqual(True, good.supports_grouped_terms())
         self.assertEqual(True, good.supports_protobuf())
 
+    def test_SimulatedAnnealing_legacy_input_params(self):
+        ws = self.create_workspace()
+
+        good = SimulatedAnnealing(ws, name = "microsoft.simulatedannealing.cpu.legacy", timeout=1011, seed=4321)
+        self.assertIsNotNone(good)
+        self.assertEqual(
+            "microsoft.simulatedannealing-parameterfree.cpu.legacy", good.name
+        )
+        self.assertEqual(
+            {"timeout": 1011, "seed": 4321}, good.params["params"]
+        )
+        self.assertEqual(False, good.supports_grouped_terms())
+        self.assertEqual(False, good.supports_protobuf())
+
+        good = SimulatedAnnealing(ws, name = "microsoft.simulatedannealing.cpu.legacy", beta_start=21)
+        self.assertIsNotNone(good)
+        self.assertEqual("microsoft.simulatedannealing.cpu.legacy", good.name)
+        self.assertEqual({"beta_start": 21}, good.params["params"])
+        self.assertEqual(False, good.supports_grouped_terms())
+        self.assertEqual(False, good.supports_protobuf())
+
     def test_QuantumMonteCarlo_input_params(self):
         ws = self.create_workspace()
         good = QuantumMonteCarlo(ws, trotter_number=100, seed=4321)
@@ -582,8 +650,8 @@ class TestSolvers(QuantumTestBase):
         self.assertEqual(
             {"trotter_number": 100, "seed": 4321}, good.params["params"]
         )
-        self.assertEqual(False, good.supports_grouped_terms())
-        self.assertEqual(False, good.supports_protobuf())
+        self.assertEqual(True, good.supports_grouped_terms())
+        self.assertEqual(True, good.supports_protobuf())
 
 
     def test_QuantumMonteCarlo_experimental_input_params(self):
@@ -597,6 +665,16 @@ class TestSolvers(QuantumTestBase):
         self.assertEqual(True, good.supports_grouped_terms())
         self.assertEqual(True, good.supports_protobuf())
 
+    def test_QuantumMonteCarlo_legacy_input_params(self):
+        ws = self.create_workspace()
+        good = QuantumMonteCarlo(ws, name = "microsoft.qmc.cpu.legacy", trotter_number=100, seed=4321)
+        self.assertIsNotNone(good)
+        self.assertEqual("microsoft.qmc.cpu.leagacy", good.name)
+        self.assertEqual(
+            {"trotter_number": 100, "seed": 4321}, good.params["params"]
+        )
+        self.assertEqual(False, good.supports_grouped_terms())
+        self.assertEqual(False, good.supports_protobuf())
 
     def test_PopulationAnnealing_input_params(self):
         ws = self.create_workspace()


### PR DESCRIPTION
Introducing a new “legacy” naming for the solvers, which will call the executable for the legacy QIO solvers. 

Keeping the “experimental” naming for the solvers unchanged, continuing to call the QIOTE solver executables. 

Modifying the existing default targets, so that instead of calling the legacy QIO solver executables, they instead call the QIOTE solver executables. 

This will have the effect of switching the experimental solvers to default, whilst still allowing for the legacy and experimental targets to remain in use until the QDK updates have been made. No changes should be made to the FPGA solvers. 