### PR TITLE
remove experimental targets and associated tests

### DIFF
--- a/azure-quantum/azure/quantum/target/microsoft/qio/parallel_tempering.py
+++ b/azure-quantum/azure/quantum/target/microsoft/qio/parallel_tempering.py
@@ -16,8 +16,6 @@ class ParallelTempering(Solver):
         "microsoft.paralleltempering.fpga",
         "microsoft.paralleltempering.cpu",
         "microsoft.paralleltempering-parameterfree.cpu",
-        "microsoft.paralleltempering.cpu.experimental",
-        "microsoft.paralleltempering-parameterfree.cpu.experimental",
         "microsoft.paralleltempering.cpu.legacy",
         "microsoft.paralleltempering-parameterfree.cpu.legacy"
     )

--- a/azure-quantum/azure/quantum/target/microsoft/qio/quantum_monte_carlo.py
+++ b/azure-quantum/azure/quantum/target/microsoft/qio/quantum_monte_carlo.py
@@ -14,7 +14,6 @@ logger = logging.getLogger(__name__)
 class QuantumMonteCarlo(Solver):
     target_names = (
         "microsoft.qmc.cpu",
-        "microsoft.qmc.cpu.experimental",
         "microsoft.qmc.cpu.legacy"
     )
     def __init__(

--- a/azure-quantum/azure/quantum/target/microsoft/qio/simulated_annealing.py
+++ b/azure-quantum/azure/quantum/target/microsoft/qio/simulated_annealing.py
@@ -21,8 +21,6 @@ class SimulatedAnnealing(Solver):
         "microsoft.simulatedannealing.fpga",
         "microsoft.simulatedannealing.cpu",
         "microsoft.simulatedannealing-parameterfree.cpu",
-        "microsoft.simulatedannealing.cpu.experimental",
-        "microsoft.simulatedannealing-parameterfree.cpu.experimental",
         "microsoft.simulatedannealing.cpu.legacy",
         "microsoft.simulatedannealing-parameterfree.cpu.legacy"
     ]

--- a/azure-quantum/azure/quantum/target/microsoft/qio/tabu.py
+++ b/azure-quantum/azure/quantum/target/microsoft/qio/tabu.py
@@ -15,8 +15,6 @@ class Tabu(Solver):
     target_names = (
         "microsoft.tabu.cpu",
         "microsoft.tabu-parameterfree.cpu",
-        "microsoft.tabu.cpu.experimental",
-        "microsoft.tabu-parameterfree.cpu.experimental",
         "microsoft.tabu.cpu.legacy",
         "microsoft.tabu-parameterfree.cpu.legacy"
     )

--- a/azure-quantum/tests/unit/test_optimization.py
+++ b/azure-quantum/tests/unit/test_optimization.py
@@ -464,54 +464,6 @@ class TestSolvers(QuantumTestBase):
                 ws, sweeps=20, replicas=3, all_betas=[1, 3, 5, 7, 9]
             )
 
-    def test_ParallelTempering_experimental_input_params(self):
-        ws = self.create_workspace()
-
-        good = ParallelTempering(ws, name = "microsoft.paralleltempering.cpu.experimental", timeout=1011)
-        self.assertIsNotNone(good)
-        self.assertEqual(
-            "microsoft.paralleltempering-parameterfree.cpu.experimental", good.name
-        )
-        self.assertEqual({"timeout": 1011}, good.params["params"])
-        self.assertEqual(True, good.supports_grouped_terms())
-        self.assertEqual(True, good.supports_protobuf())
-
-        good = ParallelTempering(ws, name = "microsoft.paralleltempering.cpu.experimental", seed=20)
-        self.assertIsNotNone(good)
-        self.assertEqual(
-            "microsoft.paralleltempering-parameterfree.cpu.experimental", good.name
-        )
-        self.assertEqual({"seed": 20}, good.params["params"])
-        self.assertEqual(True, good.supports_grouped_terms())
-        self.assertEqual(True, good.supports_protobuf())
-
-        good = ParallelTempering(
-            ws, name = "microsoft.paralleltempering.cpu.experimental", sweeps=20, replicas=3, all_betas=[3, 5, 9]
-        )
-        self.assertIsNotNone(good)
-        self.assertEqual("microsoft.paralleltempering.cpu.experimental", good.name)
-        self.assertEqual(
-            {"sweeps": 20, "replicas": 3, "all_betas": [3, 5, 9]},
-            good.params["params"],
-        )
-        self.assertEqual(True, good.supports_grouped_terms())
-        self.assertEqual(True, good.supports_protobuf())
-
-        good = ParallelTempering(ws, name = "microsoft.paralleltempering.cpu.experimental", sweeps=20, all_betas=[3, 9])
-        self.assertIsNotNone(good)
-        self.assertEqual("microsoft.paralleltempering.cpu.experimental", good.name)
-        self.assertEqual(
-            {"sweeps": 20, "replicas": 2, "all_betas": [3, 9]},
-            good.params["params"],
-        )
-        self.assertEqual(True, good.supports_grouped_terms())
-        self.assertEqual(True, good.supports_protobuf())
-
-        with self.assertRaises(ValueError):
-            _ = ParallelTempering(
-                ws, name = "microsoft.paralleltempering.cpu.experimental", sweeps=20, replicas=3, all_betas=[1, 3, 5, 7, 9]
-            )
-
     def test_ParallelTempering_legacy_input_params(self):
         ws = self.create_workspace()
 
@@ -600,27 +552,6 @@ class TestSolvers(QuantumTestBase):
         self.assertEqual("microsoft.simulatedannealing.fpga", good.name)
         self.assertEqual({"beta_start": 21}, good.params["params"])
 
-    def test_SimulatedAnnealing_experimental_input_params(self):
-        ws = self.create_workspace()
-
-        good = SimulatedAnnealing(ws, name = "microsoft.simulatedannealing.cpu.experimental", timeout=1011, seed=4321)
-        self.assertIsNotNone(good)
-        self.assertEqual(
-            "microsoft.simulatedannealing-parameterfree.cpu.experimental", good.name
-        )
-        self.assertEqual(
-            {"timeout": 1011, "seed": 4321}, good.params["params"]
-        )
-        self.assertEqual(True, good.supports_grouped_terms())
-        self.assertEqual(True, good.supports_protobuf())
-
-        good = SimulatedAnnealing(ws, name = "microsoft.simulatedannealing.cpu.experimental", beta_start=21)
-        self.assertIsNotNone(good)
-        self.assertEqual("microsoft.simulatedannealing.cpu.experimental", good.name)
-        self.assertEqual({"beta_start": 21}, good.params["params"])
-        self.assertEqual(True, good.supports_grouped_terms())
-        self.assertEqual(True, good.supports_protobuf())
-
     def test_SimulatedAnnealing_legacy_input_params(self):
         ws = self.create_workspace()
 
@@ -647,18 +578,6 @@ class TestSolvers(QuantumTestBase):
         good = QuantumMonteCarlo(ws, trotter_number=100, seed=4321)
         self.assertIsNotNone(good)
         self.assertEqual("microsoft.qmc.cpu", good.name)
-        self.assertEqual(
-            {"trotter_number": 100, "seed": 4321}, good.params["params"]
-        )
-        self.assertEqual(True, good.supports_grouped_terms())
-        self.assertEqual(True, good.supports_protobuf())
-
-
-    def test_QuantumMonteCarlo_experimental_input_params(self):
-        ws = self.create_workspace()
-        good = QuantumMonteCarlo(ws, name = "microsoft.qmc.cpu.experimental", trotter_number=100, seed=4321)
-        self.assertIsNotNone(good)
-        self.assertEqual("microsoft.qmc.cpu.experimental", good.name)
         self.assertEqual(
             {"trotter_number": 100, "seed": 4321}, good.params["params"]
         )
@@ -1017,28 +936,6 @@ class TestSolvers(QuantumTestBase):
         self.assertEqual({"tabu_tenure": 4}, good.params["params"])
         self.assertEqual(True, good.supports_grouped_terms())
         self.assertEqual(True, good.supports_protobuf())
-
-
-    def test_Tabu_experimental_input_params(self):
-        ws = self.create_workspace()
-        good = Tabu(ws, name = "microsoft.tabu.cpu.experimental",  timeout=1011, seed=4321)
-        self.assertIsNotNone(good)
-        self.assertEqual(
-            "microsoft.tabu-parameterfree.cpu.experimental", good.name
-        )
-        self.assertEqual(
-            {"timeout": 1011, "seed": 4321}, good.params["params"]
-        )
-        self.assertEqual(True, good.supports_grouped_terms())
-        self.assertEqual(True, good.supports_protobuf())
-
-        good = Tabu(ws, name = "microsoft.tabu.cpu.experimental",  tabu_tenure=4)
-        self.assertIsNotNone(good)
-        self.assertEqual("microsoft.tabu.cpu.experimental", good.name)
-        self.assertEqual({"tabu_tenure": 4}, good.params["params"])
-        self.assertEqual(True, good.supports_grouped_terms())
-        self.assertEqual(True, good.supports_protobuf())
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
removes "experimental" target from QDK, as experimental solvers have been switched to default