### PR TITLE
Pass gateset value when preparing Qiskit job metadata

### DIFF
--- a/azure-quantum/azure/quantum/qiskit/backends/ionq.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/ionq.py
@@ -44,7 +44,7 @@ class IonQBackend(AzureBackend):
         }
 
     def _prepare_job_metadata(self, circuit, **kwargs):
-        _, _, meas_map = qiskit_circ_to_ionq_circ(circuit)
+        _, _, meas_map = qiskit_circ_to_ionq_circ(circuit, gateset=self.gateset())
         
         metadata = super()._prepare_job_metadata(circuit, **kwargs);
         metadata["meas_map"] = meas_map


### PR DESCRIPTION
This is a fix for an omission when preparing the job metadata for a Qiskit submission to IonQ where the gateset is specified. 