### PR TITLE
Qiskit expects literal bitstring results

### DIFF
--- a/azure-quantum/azure/quantum/qiskit/job.py
+++ b/azure-quantum/azure/quantum/qiskit/job.py
@@ -213,7 +213,8 @@ class AzureQuantumJob(JobV1):
         if (len(histogram) % 2) == 0:
             items = range(0, len(histogram), 2)
             for i in items:
-                bitstring = re.sub("[^01]", "", histogram[i])  # Qiskit expects a literal bitstring, QIR returns it as an array, remove superfluos characters.
+                bitstring = re.sub("[^01]", "", histogram[i])  # Qiskit expects a literal bitstring, QIR returns it as an array, remove superfluous characters.
+
                 value = histogram[i + 1]
                 probabilities[bitstring] = value
         else:

--- a/azure-quantum/azure/quantum/qiskit/job.py
+++ b/azure-quantum/azure/quantum/qiskit/job.py
@@ -15,6 +15,7 @@ To install run: pip install azure-quantum[qiskit]"
     )
 
 import json
+import re
 from azure.quantum import Job
 
 import logging
@@ -212,7 +213,7 @@ class AzureQuantumJob(JobV1):
         if (len(histogram) % 2) == 0:
             items = range(0, len(histogram), 2)
             for i in items:
-                bitstring = histogram[i]
+                bitstring = re.sub("[^01]", "", histogram[i])  # Qiskit expects a literal bitstring, QIR returns it as an array, remove superfluos characters.
                 value = histogram[i + 1]
                 probabilities[bitstring] = value
         else:

--- a/azure-quantum/tests/unit/test_qiskit.py
+++ b/azure-quantum/tests/unit/test_qiskit.py
@@ -506,8 +506,8 @@ class TestQiskit(QuantumTestBase):
                 result = qiskit_job.result()
                 print(result)
                 assert sum(result.data()["counts"].values()) == shots
-                assert np.isclose(result.data()["counts"]["[0, 0, 0]"], shots//2, 20)
-                assert np.isclose(result.data()["counts"]["[1, 1, 1]"], shots//2, 20)
+                assert np.isclose(result.data()["counts"]["000"], shots//2, 20)
+                assert np.isclose(result.data()["counts"]["111"], shots//2, 20)
                 counts = result.get_counts()
                 assert counts == result.data()["counts"]
                 assert hasattr(result.results[0].header, "num_qubits")
@@ -586,8 +586,8 @@ class TestQiskit(QuantumTestBase):
                 result = qiskit_job.result()
                 print(result)
                 assert sum(result.data()["counts"].values()) == shots
-                assert np.isclose(result.data()["counts"]["[0, 0, 0]"], shots//2, 20)
-                assert np.isclose(result.data()["counts"]["[1, 1, 1]"], shots//2, 20)
+                assert np.isclose(result.data()["counts"]["000"], shots//2, 20)
+                assert np.isclose(result.data()["counts"]["111"], shots//2, 20)
                 counts = result.get_counts()
                 assert counts == result.data()["counts"]
                 assert hasattr(result.results[0].header, "num_qubits")


### PR DESCRIPTION
QIR returns its output as an array of bits, as in: `[0, 1, 0]`
We use these as the keys for the counts and probabilities dictionaries in the Results object, however, Qiskit normally returns the keys in the values to be a literal bitstring and certain libraries (like VQE) assumes this always be the case, so if the value is differently it will fail.
This change removes the superfluos characters and makes sure the key is just a bitstring.