### PR TITLE
add error message for FPGA deprecation

### DIFF
--- a/azure-quantum/azure/quantum/target/microsoft/qio/simulated_annealing.py
+++ b/azure-quantum/azure/quantum/target/microsoft/qio/simulated_annealing.py
@@ -64,6 +64,9 @@ class SimulatedAnnealing(Solver):
             and restarts is None
         )
 
+        if platform == HardwarePlatform.FPGA:
+            raise ValueError(f"The FPGA hardware option for Microsoft QIO solvers has been deprecated. Please remove the ‘platform’ parameter from your solver declaration and resubmit your problem.")
+
         if param_free:
             name = name.replace(".simulatedannealing.", ".simulatedannealing-parameterfree.")
 

--- a/azure-quantum/azure/quantum/target/microsoft/qio/simulated_annealing.py
+++ b/azure-quantum/azure/quantum/target/microsoft/qio/simulated_annealing.py
@@ -64,11 +64,10 @@ class SimulatedAnnealing(Solver):
             and restarts is None
         )
 
-        if platform == HardwarePlatform.FPGA:
-            raise ValueError(f"The FPGA hardware option for Microsoft QIO solvers has been deprecated. Please remove the ‘platform’ parameter from your solver declaration and resubmit your problem.")
-
         if param_free:
             name = name.replace(".simulatedannealing.", ".simulatedannealing-parameterfree.")
+
+        self.check_supported_hardware(platform)
 
         super().__init__(
             workspace=workspace,

--- a/azure-quantum/azure/quantum/target/solvers.py
+++ b/azure-quantum/azure/quantum/target/solvers.py
@@ -24,7 +24,8 @@ __all__ = [
 
 
 class HardwarePlatform(Enum):
-    CPU = 1
+    CPU = 1,
+    FPGA = 2
 
 
 class RangeSchedule:
@@ -407,3 +408,20 @@ class Solver(Target):
                     f"{lower_bound_inclusive}; found "
                     f"{parameter_name}={parameter_value}."
                 )
+
+    def check_supported_hardware(
+        self,
+        platform
+    ):
+        """Check whether `platform` is a supported hardware type.
+
+        :param platform:
+            Name of the hardware platform, either CPU or FPGA.
+        """
+        if platform == HardwarePlatform.FPGA:
+            raise ValueError(
+                f"The FPGA hardware option for Microsoft QIO "
+                f"solvers has been deprecated. Please remove "
+                f"the 'platform' parameter from your solver "
+                f"declaration and resubmit your problem.")
+

--- a/azure-quantum/tests/unit/test_optimization.py
+++ b/azure-quantum/tests/unit/test_optimization.py
@@ -486,6 +486,16 @@ class TestSolvers(QuantumTestBase):
         self.assertEqual(True, good.supports_grouped_terms())
         self.assertEqual(True, good.supports_protobuf())
 
+        good = SimulatedAnnealing(
+            ws, 
+            timeout=1011, 
+            seed=4321, 
+            platform=HardwarePlatform.CPU)
+        self.assertIsNotNone(good)
+        self.assertEqual(
+            "microsoft.simulatedannealing-parameterfree.cpu", good.name
+        )
+
     def test_Simulated_Annealing_bad_input_params(self):
         ws = self.create_workspace()
 

--- a/azure-quantum/tests/unit/test_optimization.py
+++ b/azure-quantum/tests/unit/test_optimization.py
@@ -486,6 +486,20 @@ class TestSolvers(QuantumTestBase):
         self.assertEqual(True, good.supports_grouped_terms())
         self.assertEqual(True, good.supports_protobuf())
 
+    def test_Simulated_Annealing_bad_input_params(self):
+        ws = self.create_workspace()
+
+        bad_solver = None
+        with self.assertRaises(ValueError) as context:
+            bad_solver = SimulatedAnnealing(
+                ws, platform=HardwarePlatform.FPGA
+            )
+        self.assertTrue(
+                ("The FPGA hardware option for Microsoft QIO "
+                "solvers has been deprecated. Please remove "
+                "the 'platform' parameter from your solver "
+                "declaration and resubmit your problem.") in str(context.exception))
+        self.assertTrue(bad_solver is None)
 
     def test_QuantumMonteCarlo_input_params(self):
         ws = self.create_workspace()


### PR DESCRIPTION
adds a user warning if `HardwarePlatform.FPGA` is used