### PR TITLE
Copy options instead of passing as reference

### DIFF
--- a/azure-quantum/azure/quantum/qiskit/backends/backend.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/backend.py
@@ -105,7 +105,7 @@ class AzureBackend(Backend):
         metadata = kwargs.pop("metadata") if "metadata" in kwargs else self._prepare_job_metadata(circuit)
 
         # Backend options are mapped to input_params.
-        input_params = vars(self.options)
+        input_params = vars(self.options).copy()
 
         # The shots/count number can be specified in different ways for different providers,
         # so let's get it first. Values in 'kwargs' take precedence over options, and to keep


### PR DESCRIPTION
When initializing `input_params` in the backend the values from `self.options` should be copied. Currently, a reference is taken which causes `self.options` to be updated when `input_params` is modified later in the code. This then causes input arguments to persist over multiple runs on the same backend instance, leading to unexpected behaviour.

CC @xinyi-joffre 