### PR TITLE
[Draft - Do not merge] Add Quantinuum h1-2 target names

### DIFF
--- a/azure-quantum/azure/quantum/target/quantinuum.py
+++ b/azure-quantum/azure/quantum/target/quantinuum.py
@@ -19,7 +19,10 @@ class Quantinuum(Target):
         "quantinuum.hqs-lt-s1-sim",
         "quantinuum.qpu.h1-1",
         "quantinuum.sim.h1-1sc",
-        "quantinuum.sim.h1-1e"
+        "quantinuum.sim.h1-1e",
+        "quantinuum.qpu.h1-2",
+        "quantinuum.sim.h1-2sc",
+        "quantinuum.sim.h1-2e"
     )
 
     def __init__(

--- a/azure-quantum/tests/unit/test_cirq.py
+++ b/azure-quantum/tests/unit/test_cirq.py
@@ -76,6 +76,7 @@ class TestCirq(QuantumTestBase):
         assert "ionq.simulator" in target_names
         assert "quantinuum.hqs-lt-s1-apival" in target_names
         assert "quantinuum.sim.h1-1sc" in target_names
+        assert "quantinuum.sim.h1-2sc" in target_names
 
     def test_plugins_estimate_cost_cirq_ionq(self):
         workspace = self.create_workspace()
@@ -209,6 +210,13 @@ class TestCirq(QuantumTestBase):
         cost = service.estimate_cost(
             program=self._3_qubit_ghz_cirq(),
             repetitions=100e3,
+            target="quantinuum.sim.h1-2sc"
+        )
+        assert cost.estimated_total == 0.0
+
+        cost = service.estimate_cost(
+            program=self._3_qubit_ghz_cirq(),
+            repetitions=100e3,
             target="quantinuum.hqs-lt-s1"
         )
         assert np.round(cost.estimated_total) == 725.0
@@ -217,6 +225,13 @@ class TestCirq(QuantumTestBase):
             program=self._3_qubit_ghz_cirq(),
             repetitions=100e3,
             target="quantinuum.qpu.h1-1"
+        )
+        assert np.round(cost.estimated_total) == 725.0
+
+        cost = service.estimate_cost(
+            program=self._3_qubit_ghz_cirq(),
+            repetitions=100e3,
+            target="quantinuum.qpu.h1-2"
         )
         assert np.round(cost.estimated_total) == 725.0
 

--- a/azure-quantum/tests/unit/test_quantinuum.py
+++ b/azure-quantum/tests/unit/test_quantinuum.py
@@ -81,6 +81,16 @@ class TestQuantinuum(QuantumTestBase):
             cost = target.estimate_cost(circuit, num_shots=100e3)
             assert cost.estimated_total == 845.0
 
+            target = Quantinuum(workspace=workspace, name="quantinuum.sim.h1-2sc")
+
+            cost = target.estimate_cost(circuit, num_shots=100e3)
+            assert cost.estimated_total == 0.0
+
+            target = Quantinuum(workspace=workspace, name="quantinuum.qpu.h1-2")
+
+            cost = target.estimate_cost(circuit, num_shots=100e3)
+            assert cost.estimated_total == 845.0
+
     @pytest.mark.quantinuum
     @pytest.mark.live_test
     def test_job_submit_quantinuum(self):

--- a/azure-quantum/tests/unit/test_target.py
+++ b/azure-quantum/tests/unit/test_target.py
@@ -230,6 +230,18 @@ class TestHoneywell(QuantumTestBase):
             cost = target.estimate_cost(circuit, num_shots=100e3)
             assert cost.estimated_total == 845.0
 
+            target = Honeywell(workspace=workspace, name="honeywell.hqs-lt-s2-apival") if provider_id == "honeywell" \
+                     else Quantinuum(workspace=workspace, name="quantinuum.sim.h1-2sc")
+
+            cost = target.estimate_cost(circuit, num_shots=100e3)
+            assert cost.estimated_total == 0.0
+
+            target = Honeywell(workspace=workspace, name="honeywell.hqs-lt-s2") if provider_id == "honeywell" \
+                     else Quantinuum(workspace=workspace, name="quantinuum.qpu.h1-2")
+
+            cost = target.estimate_cost(circuit, num_shots=100e3)
+            assert cost.estimated_total == 845.0
+
     @pytest.mark.honeywell
     @pytest.mark.live_test
     def test_job_submit_honeywell(self, provider_id="honeywell"):

--- a/azure-quantum/tests/unit/test_workspace.py
+++ b/azure-quantum/tests/unit/test_workspace.py
@@ -122,6 +122,10 @@ class TestWorkspace(QuantumTestBase):
                 'quantinuum.sim.h1-1sc'
             ])
             assert test_targets.issubset(set([t.name for t in targets]))
+            test_targets = set([
+                'quantinuum.sim.h1-2sc'
+            ])
+            assert test_targets.issubset(set([t.name for t in targets]))
 
     @pytest.mark.qio
     @pytest.mark.live_test


### PR DESCRIPTION
**NOTE: This PR has been closed because its changes have been incorporated as into [PR 389](https://github.com/microsoft/qdk-python/pull/389)**
---

Add the Quantinuum "h1-2" target names.  These names map to the old target names as shown here:

Old name | New name
-- | --
quantinuum.hqs-lt-s2 | quantinuum.qpu.h1-2
quantinuum.hqs-lt-s2-apival | quantinuum.sim.h1-2sc
quantinuum.hqs-lt-s2-sim | quantinuum.sim.h1-2e

This is a follow-up to [PR 368](https://github.com/microsoft/qdk-python/pull/368) and depends on the completion of [PR 371](https://github.com/microsoft/qdk-python/pull/371/).

The deprecation date for the old target names is TBD.