### PR TITLE
Skip async from live tests

### DIFF
--- a/azure-quantum/tests.live/Run.ps1
+++ b/azure-quantum/tests.live/Run.ps1
@@ -74,12 +74,12 @@ if (Test-Path Env:AZURE_QUANTUM_CAPABILITIES) {
 
 pip install pytest pytest-azurepipelines | Write-Host
 
-$logs = Join-Path $env:BUILD_ARTIFACTSTAGINGDIRECTORY "qdk-python-logs.txt"
+$logs = Join-Path $env:BUILD_ARTIFACTSTAGINGDIRECTORY "logs" "qdk-python.txt"
 " ==> Generating logs to $logs" | Write-Host
 
 python -m pytest -v `
     --junitxml=junit/test-results.xml `
-    --log-level=DEBUG `
+    --log-level=INFO `
     --log-file-format="%(asctime)s %(levelname)s %(message)s" `
     --log-file=$logs `
     -m $MarkExpr 

--- a/azure-quantum/tests.live/Run.ps1
+++ b/azure-quantum/tests.live/Run.ps1
@@ -59,9 +59,6 @@ function PyTestMarkExpr() {
     return $MarkExpr
 }
 
-# Copy unit tests without recordings and run Pytest
-Copy-Item -Path (Join-Path $PackageDir "tests" "unit" "*.py") -Destination $PSScriptRoot
-Copy-Item -Path (Join-Path $PackageDir "tests" "unit" "conftest.py") -Destination $PSScriptRoot
 if (Test-Path Env:AZURE_QUANTUM_CAPABILITIES) {
     Write-Host "##[info]Using AZURE_QUANTUM_CAPABILITIES env variable: $Env:AZURE_QUANTUM_CAPABILITIES"
     $AzureQuantumCapabilities = $Env:AZURE_QUANTUM_CAPABILITIES -Split ";" | ForEach-Object { $_.trim().ToLower() }
@@ -76,6 +73,9 @@ pip install pytest pytest-azurepipelines | Write-Host
 
 $logs = Join-Path $env:BUILD_ARTIFACTSTAGINGDIRECTORY "logs" "qdk-python.txt"
 " ==> Generating logs to $logs" | Write-Host
+
+# Copy unit tests without recordings and run Pytest
+Copy-Item -Path (Join-Path $PackageDir "tests" "unit" "*.py") -Destination $PSScriptRoot
 
 python -m pytest -v `
     --junitxml=junit/test-results.xml `

--- a/azure-quantum/tests.live/Run.ps1
+++ b/azure-quantum/tests.live/Run.ps1
@@ -78,4 +78,9 @@ pip install pytest pytest-azurepipelines | Write-Host
 $logs = Join-Path $env:BUILD_ARTIFACTSTAGINGDIRECTORY "qdk-python-logs.txt"
 " ==> Generating logs to $logs" | Write-Host
 
-python -m pytest --junitxml=junit/test-results.xml --log-level=INFO --log-file=$logs -v -m $MarkExpr
+python -m pytest -v `
+    --junitxml=junit/test-results.xml `
+    --log-level=DEBUG `
+    --log-file-format="%(asctime)s %(levelname)s %(message)s" `
+    --log-file=$logs `
+    -m $MarkExpr 

--- a/azure-quantum/tests.live/Run.ps1
+++ b/azure-quantum/tests.live/Run.ps1
@@ -17,6 +17,7 @@ $PackageDir = Split-Path -parent $PSScriptRoot;
 $PackageName = $PackageDir | Split-Path -Leaf;
 $RootDir = Split-Path -parent $PackageDir;
 Import-Module (Join-Path $RootDir "build" "conda-utils.psm1");
+Import-Module (Join-Path $RootDir "build" "package-utils.psm1");
 
 if ($True -eq $SkipInstall) {
     Write-Host "##[info]Skipping install."
@@ -72,4 +73,9 @@ if (Test-Path Env:AZURE_QUANTUM_CAPABILITIES) {
     $MarkExpr = "live_test"
 }
 
-python -m pytest --junitxml=junit/test-results.xml -v -m $MarkExpr
+pip install pytest pytest-azurepipelines | Write-Host
+
+$logs = Join-Path $env:BUILD_ARTIFACTSTAGINGDIRECTORY "qdk-python-logs.txt"
+" ==> Generating logs to $logs" | Write-Host
+
+python -m pytest --junitxml=junit/test-results.xml --log-level=INFO --log-file=$logs -v -m $MarkExpr

--- a/azure-quantum/tests.live/Run.ps1
+++ b/azure-quantum/tests.live/Run.ps1
@@ -60,9 +60,8 @@ function PyTestMarkExpr() {
 }
 
 # Copy unit tests without recordings and run Pytest
-Copy-Item -Path (Join-Path $PackageDir "tests" "unit" "*.py") -Destination $PSScriptRoot;
-Copy-Item -Path (Join-Path $PackageDir "tests" "unit" "aio" "*.py") -Destination $PSScriptRoot;
-Copy-Item -Path (Join-Path $PackageDir "tests" "unit" "conftest.py") -Destination $PSScriptRoot;
+Copy-Item -Path (Join-Path $PackageDir "tests" "unit" "*.py") -Destination $PSScriptRoot
+Copy-Item -Path (Join-Path $PackageDir "tests" "unit" "conftest.py") -Destination $PSScriptRoot
 if (Test-Path Env:AZURE_QUANTUM_CAPABILITIES) {
     Write-Host "##[info]Using AZURE_QUANTUM_CAPABILITIES env variable: $Env:AZURE_QUANTUM_CAPABILITIES"
     $AzureQuantumCapabilities = $Env:AZURE_QUANTUM_CAPABILITIES -Split ";" | ForEach-Object { $_.trim().ToLower() }


### PR DESCRIPTION
There is some problem with the aio tests, as it takes over 40 mins to execute them during live integration tests.
Since they don't cover any high-priority scenarios, we are going to disable until we can find the root cause of the problem.