### PR TITLE
Use basis_gates for qiskit circuit transpilation.

### DIFF
--- a/azure-quantum/azure/quantum/qiskit/backends/backend.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/backend.py
@@ -66,7 +66,7 @@ class AzureBackend(Backend):
             # We'll only log the QIR again if we performed a transpilation.
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug(f"QIR (Post-transpilation):\n{to_qir(circuit, capability, **to_qir_kwargs)}")
-        emit_barrier_calls = "barrier" in qir_supported_instructions
+        emit_barrier_calls = "barrier" in config.basis_gates
         qir = bytes(to_qir_bitcode(circuit, capability, emit_barrier_calls=emit_barrier_calls, **to_qir_kwargs))
         return (qir, data_format, input_params)
 

--- a/azure-quantum/azure/quantum/qiskit/backends/backend.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/backend.py
@@ -61,7 +61,7 @@ class AzureBackend(Backend):
         if not input_params.get("skipTranspile", False):
             # Set of gates supported by QIR targets.
             config = self.configuration()
-            circuit = transpile(circuit, basis_gates=config.basis_gates)
+            circuit = transpile(circuit, basis_gates=config.basis_gates, optimization_level=0)
 
             # We'll only log the QIR again if we performed a transpilation.
             if logger.isEnabledFor(logging.DEBUG):

--- a/azure-quantum/azure/quantum/qiskit/backends/backend.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/backend.py
@@ -62,7 +62,7 @@ class AzureBackend(Backend):
         if not input_params.get("skipTranspile", False):
             # Set of gates supported by QIR targets.
             config = self.configuration()
-            qir_supported_instructions = config["basis_gates"]
+            qir_supported_instructions = config.basis_gates
             circuit = RemoveBarriers()(circuit) if "barrier" not in qir_supported_instructions else circuit
             circuit = transpile(circuit, basis_gates = qir_supported_instructions)
 

--- a/azure-quantum/azure/quantum/qiskit/backends/microsoft.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/microsoft.py
@@ -10,7 +10,28 @@ from .backend import AzureBackend
 
 from qiskit.providers.models import BackendConfiguration
 from qiskit.providers import Options
-from qiskit_qir import SUPPORTED_INSTRUCTIONS as QIR_BASIS_GATES
+
+QIR_BASIS_GATES = [
+    "measure",
+    "m",
+    "ccx",
+    "cx",
+    "cz",
+    "h",
+    "reset",
+    "rx",
+    "ry",
+    "rz",
+    "s",
+    "sdg",
+    "swap",
+    "t",
+    "tdg",
+    "x",
+    "y",
+    "z",
+    "id"
+]
 
 if TYPE_CHECKING:
     from azure.quantum.qiskit import AzureQuantumProvider

--- a/azure-quantum/azure/quantum/qiskit/backends/qci.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/qci.py
@@ -12,7 +12,28 @@ from .backend import AzureBackend
 
 from qiskit.providers.models import BackendConfiguration
 from qiskit.providers import Options
-from qiskit_qir import SUPPORTED_INSTRUCTIONS as QIR_BASIS_GATES
+
+QIR_BASIS_GATES = [
+    "measure",
+    "m",
+    "barrier",
+    "cx",
+    "cz",
+    "h",
+    "reset",
+    "rx",
+    "ry",
+    "rz",
+    "s",
+    "sdg",
+    "swap",
+    "t",
+    "tdg",
+    "x",
+    "y",
+    "z",
+    "id"
+]
 
 if TYPE_CHECKING:
     from azure.quantum.qiskit import AzureQuantumProvider

--- a/azure-quantum/azure/quantum/qiskit/backends/rigetti.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/rigetti.py
@@ -13,7 +13,25 @@ from .backend import AzureBackend
 
 from qiskit.providers.models import BackendConfiguration
 from qiskit.providers import Options
-from qiskit_qir import SUPPORTED_INSTRUCTIONS as QIR_BASIS_GATES
+QIR_BASIS_GATES = [
+    "measure",
+    "m",
+    "cx",
+    "cz",
+    "h",
+    "reset",
+    "rx",
+    "ry",
+    "rz",
+    "s",
+    "sdg",
+    "t",
+    "tdg",
+    "x",
+    "y",
+    "z",
+    "id"
+]
 
 if TYPE_CHECKING:
     from azure.quantum.qiskit import AzureQuantumProvider

--- a/azure-quantum/environment-cirq-beta.yml
+++ b/azure-quantum/environment-cirq-beta.yml
@@ -13,7 +13,7 @@ dependencies:
     - cirq-ionq>=1.0.0
     - qiskit-ionq>=0.3.3
     - qiskit-terra>=0.19.1
-    - qiskit-qir>=0.1.0b12
+    - qiskit-qir>=0.1.0b13
     - azure-devtools>=1.2.0
     - asyncmock>=0.4.0
     - Markdown>=3.4.1

--- a/azure-quantum/environment-cirq-beta.yml
+++ b/azure-quantum/environment-cirq-beta.yml
@@ -13,7 +13,7 @@ dependencies:
     - cirq-ionq>=1.0.0
     - qiskit-ionq>=0.3.3
     - qiskit-terra>=0.19.1
-    - qiskit-qir>=0.1.0b13
+    - qiskit-qir>=0.2,<0.3
     - azure-devtools>=1.2.0
     - asyncmock>=0.4.0
     - Markdown>=3.4.1

--- a/azure-quantum/environment.yml
+++ b/azure-quantum/environment.yml
@@ -13,7 +13,7 @@ dependencies:
     - cirq-ionq>=1.0.0
     - qiskit-ionq>=0.3.3
     - qiskit-terra>=0.19.1
-    - qiskit-qir>=0.1.0b12
+    - qiskit-qir>=0.1.0b13
     - azure-devtools>=1.2.0
     - asyncmock>=0.4.0
     - Markdown>=3.4.1

--- a/azure-quantum/environment.yml
+++ b/azure-quantum/environment.yml
@@ -13,7 +13,7 @@ dependencies:
     - cirq-ionq>=1.0.0
     - qiskit-ionq>=0.3.3
     - qiskit-terra>=0.19.1
-    - qiskit-qir>=0.1.0b13
+    - qiskit-qir>=0.2,<0.3
     - azure-devtools>=1.2.0
     - asyncmock>=0.4.0
     - Markdown>=3.4.1

--- a/azure-quantum/setup.py
+++ b/azure-quantum/setup.py
@@ -83,7 +83,7 @@ setuptools.setup(
         "qiskit": [
             "qiskit-ionq>=0.3.3",
             "qiskit-terra>=0.19.1",
-            "qiskit-qir>=0.1.0b13",
+            "qiskit-qir>=0.2,<0.3",
             "Markdown>=3.4.1",
             "python-markdown-math>=0.8"
         ],

--- a/azure-quantum/setup.py
+++ b/azure-quantum/setup.py
@@ -83,7 +83,7 @@ setuptools.setup(
         "qiskit": [
             "qiskit-ionq>=0.3.3",
             "qiskit-terra>=0.19.1",
-            "qiskit-qir>=0.1.0b12",
+            "qiskit-qir>=0.1.0b13",
             "Markdown>=3.4.1",
             "python-markdown-math>=0.8"
         ],


### PR DESCRIPTION
This changes each QIR backend to use its own basis gates as the providers don't use a consistent set. It also runs a pass to remove barriers as `transpile` will not remove them despite what is supplied in the basis gates.

This PR will also update the version of qiskit-qir used which has `ccx`, `swap`, and `barrier` support.