### PR TITLE
Tuple should be list in QMC target

### DIFF
--- a/azure-quantum/azure/quantum/target/microsoft/qio/quantum_monte_carlo.py
+++ b/azure-quantum/azure/quantum/target/microsoft/qio/quantum_monte_carlo.py
@@ -12,9 +12,9 @@ from azure.quantum.workspace import Workspace
 logger = logging.getLogger(__name__)
 
 class QuantumMonteCarlo(Solver):
-    target_names = (
+    target_names = [
         "microsoft.qmc.cpu"
-    )
+    ]
     def __init__(
         self,
         workspace: Workspace,


### PR DESCRIPTION
In the current code, when iterating over all targets, it equals iterating over all the characters of the string. This change fixes this behavior.