### PR TITLE
Submit QIR Job From Qiskit to IonQ

### DIFF
--- a/azure-quantum/azure/quantum/qiskit/backends/ionq.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/ionq.py
@@ -53,9 +53,9 @@ class IonQBackend(AzureBackend):
 
     def _translate_input(self, circuit, data_format, input_params, to_qir_kwargs={}):
         """ Translates the input values to the format expected by the AzureBackend. """
-        if "targetCapability" in input_params and input_params["targetCapability"] == "BasicExecution":
+        if "targetCapability" in input_params:
             return super()._translate_input(circuit, "qir.v1", input_params, to_qir_kwargs)
-        elif data_format == "ionq.circuit.v1":
+        else:
             ionq_circ, _, _ = qiskit_circ_to_ionq_circ(circuit, gateset=self.gateset())
             input_data = {
                 "gateset": self.gateset(),
@@ -63,8 +63,6 @@ class IonQBackend(AzureBackend):
                 "circuit": ionq_circ,
             }
             return (IonQ._encode_input_data(input_data), data_format, input_params)
-        else:
-            return super()._translate_input(circuit, data_format, input_params, to_qir_kwargs)
 
     def gateset(self):
         return self._gateset

--- a/azure-quantum/azure/quantum/qiskit/backends/ionq.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/ionq.py
@@ -31,7 +31,7 @@ class IonQBackend(AzureBackend):
 
     @classmethod
     def _default_options(cls):
-        return Options(shots=500)
+        return Options(shots=500, targetCapability="ionq")
 
     @classmethod
     def _azure_config(cls):
@@ -53,7 +53,7 @@ class IonQBackend(AzureBackend):
 
     def _translate_input(self, circuit, data_format, input_params, to_qir_kwargs={}):
         """ Translates the input values to the format expected by the AzureBackend. """
-        if data_format == "ionq.circuit.v1":
+        if data_format == "ionq.circuit.v1" and not input_params["targetCapability"] == "BasicExecution":
             ionq_circ, _, _ = qiskit_circ_to_ionq_circ(circuit, gateset=self.gateset())
             input_data = {
                 "gateset": self.gateset(),
@@ -62,7 +62,7 @@ class IonQBackend(AzureBackend):
             }
             return (IonQ._encode_input_data(input_data), data_format, input_params)
         else:
-            return super()._translate_input(circuit, data_format, input_params, to_qir_kwargs)
+            return super()._translate_input(circuit, "qir.v1", input_params, to_qir_kwargs)
 
     def gateset(self):
         return self._gateset

--- a/azure-quantum/azure/quantum/qiskit/backends/ionq.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/ionq.py
@@ -53,7 +53,9 @@ class IonQBackend(AzureBackend):
 
     def _translate_input(self, circuit, data_format, input_params, to_qir_kwargs={}):
         """ Translates the input values to the format expected by the AzureBackend. """
-        if data_format == "ionq.circuit.v1" and not input_params["targetCapability"] == "BasicExecution":
+        if "targetCapability" in input_params and input_params["targetCapability"] == "BasicExecution":
+            return super()._translate_input(circuit, "qir.v1", input_params, to_qir_kwargs)
+        elif data_format == "ionq.circuit.v1":
             ionq_circ, _, _ = qiskit_circ_to_ionq_circ(circuit, gateset=self.gateset())
             input_data = {
                 "gateset": self.gateset(),
@@ -62,7 +64,7 @@ class IonQBackend(AzureBackend):
             }
             return (IonQ._encode_input_data(input_data), data_format, input_params)
         else:
-            return super()._translate_input(circuit, "qir.v1", input_params, to_qir_kwargs)
+            return super()._translate_input(circuit, data_format, input_params, to_qir_kwargs)
 
     def gateset(self):
         return self._gateset

--- a/azure-quantum/azure/quantum/qiskit/backends/ionq.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/ionq.py
@@ -31,7 +31,7 @@ class IonQBackend(AzureBackend):
 
     @classmethod
     def _default_options(cls):
-        return Options(shots=500, targetCapability="ionq")
+        return Options(shots=500)
 
     @classmethod
     def _azure_config(cls):

--- a/azure-quantum/azure/quantum/target/microsoft/qio/quantum_monte_carlo.py
+++ b/azure-quantum/azure/quantum/target/microsoft/qio/quantum_monte_carlo.py
@@ -12,9 +12,9 @@ from azure.quantum.workspace import Workspace
 logger = logging.getLogger(__name__)
 
 class QuantumMonteCarlo(Solver):
-    target_names = (
+    target_names = [
         "microsoft.qmc.cpu"
-    )
+    ]
     def __init__(
         self,
         workspace: Workspace,

--- a/azure-quantum/azure/quantum/target/microsoft/qio/simulated_annealing.py
+++ b/azure-quantum/azure/quantum/target/microsoft/qio/simulated_annealing.py
@@ -16,10 +16,10 @@ logger = logging.getLogger(__name__)
 
 
 class SimulatedAnnealing(Solver):
-    target_names = [
+    target_names = (
         "microsoft.simulatedannealing.cpu",
         "microsoft.simulatedannealing-parameterfree.cpu"
-    ]
+    )
     def __init__(
         self,
         workspace: Workspace,

--- a/azure-quantum/tests/unit/test_qiskit.py
+++ b/azure-quantum/tests/unit/test_qiskit.py
@@ -172,29 +172,6 @@ class TestQiskit(QuantumTestBase):
 
     @pytest.mark.ionq
     @pytest.mark.live_test
-    def test_qiskit_submit_ionq_invalid_input_format(self):
-        with unittest.mock.patch.object(
-            Job,
-            self.mock_create_job_id_name,
-            return_value=self.get_test_job_id(),
-        ):
-            workspace = self.create_workspace()
-            provider = AzureQuantumProvider(workspace=workspace)
-            assert "azure-quantum-qiskit" in provider._workspace.user_agent
-            backend = provider.get_backend("ionq.simulator")
-
-            circuit = self._5_qubit_superposition()
-            circuit.metadata = { "some": "data" }
-
-            with pytest.raises(ValueError) as excinfo:
-                qiskit_job = backend.run(
-                    circuit=circuit,
-                    input_data_format="some.invalid.format"
-                )
-            assert "some.invalid.format is not a supported data format for target ionq.simulator." == str(excinfo.value)
-
-    @pytest.mark.ionq
-    @pytest.mark.live_test
     def test_plugins_submit_qiskit_multi_circuit_experiment_to_ionq(self):
         circuit = self._3_qubit_ghz()
 


### PR DESCRIPTION
Allows for the submission of QIR jobs from Qiskit python to IonQ targets. 