### PR TITLE
Added Default Target Capability to IonQ

### DIFF
--- a/azure-quantum/azure/quantum/qiskit/backends/ionq.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/ionq.py
@@ -53,7 +53,7 @@ class IonQBackend(AzureBackend):
 
     def _translate_input(self, circuit, data_format, input_params, to_qir_kwargs={}):
         """ Translates the input values to the format expected by the AzureBackend. """
-        if input_params["targetCapability"] != "ionq":
+        if input_params["targetCapability"] == "ionq":
             del input_params["targetCapability"]
             ionq_circ, _, _ = qiskit_circ_to_ionq_circ(circuit, gateset=self.gateset())
             input_data = {

--- a/azure-quantum/azure/quantum/qiskit/backends/ionq.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/ionq.py
@@ -53,9 +53,9 @@ class IonQBackend(AzureBackend):
 
     def _translate_input(self, circuit, data_format, input_params, to_qir_kwargs={}):
         """ Translates the input values to the format expected by the AzureBackend. """
-        if input_params["targetCapabilty"] == "ionq":
+        if "targetCapabilty" in input_params and input_params["targetCapabilty"] == "ionq":
             del input_params["targetCapability"]
-            
+
         if "targetCapability" in input_params:
             return super()._translate_input(circuit, "qir.v1", input_params, to_qir_kwargs)
         else:

--- a/azure-quantum/azure/quantum/qiskit/backends/ionq.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/ionq.py
@@ -53,8 +53,12 @@ class IonQBackend(AzureBackend):
 
     def _translate_input(self, circuit, data_format, input_params, to_qir_kwargs={}):
         """ Translates the input values to the format expected by the AzureBackend. """
-        if input_params["targetCapability"] == "ionq":
+        if input_params["targetCapabilty"] == "ionq":
             del input_params["targetCapability"]
+            
+        if "targetCapability" in input_params:
+            return super()._translate_input(circuit, "qir.v1", input_params, to_qir_kwargs)
+        else:
             ionq_circ, _, _ = qiskit_circ_to_ionq_circ(circuit, gateset=self.gateset())
             input_data = {
                 "gateset": self.gateset(),
@@ -62,9 +66,6 @@ class IonQBackend(AzureBackend):
                 "circuit": ionq_circ,
             }
             return (IonQ._encode_input_data(input_data), data_format, input_params)
-        else:
-            return super()._translate_input(circuit, "qir.v1", input_params, to_qir_kwargs)
-            
 
     def gateset(self):
         return self._gateset

--- a/azure-quantum/azure/quantum/qiskit/backends/ionq.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/ionq.py
@@ -31,7 +31,7 @@ class IonQBackend(AzureBackend):
 
     @classmethod
     def _default_options(cls):
-        return Options(shots=500)
+        return Options(shots=500, targetCapability="ionq")
 
     @classmethod
     def _azure_config(cls):
@@ -53,9 +53,8 @@ class IonQBackend(AzureBackend):
 
     def _translate_input(self, circuit, data_format, input_params, to_qir_kwargs={}):
         """ Translates the input values to the format expected by the AzureBackend. """
-        if "targetCapability" in input_params:
-            return super()._translate_input(circuit, "qir.v1", input_params, to_qir_kwargs)
-        else:
+        if input_params["targetCapability"] != "ionq":
+            del input_params["targetCapability"]
             ionq_circ, _, _ = qiskit_circ_to_ionq_circ(circuit, gateset=self.gateset())
             input_data = {
                 "gateset": self.gateset(),
@@ -63,6 +62,9 @@ class IonQBackend(AzureBackend):
                 "circuit": ionq_circ,
             }
             return (IonQ._encode_input_data(input_data), data_format, input_params)
+        else:
+            return super()._translate_input(circuit, "qir.v1", input_params, to_qir_kwargs)
+            
 
     def gateset(self):
         return self._gateset

--- a/azure-quantum/azure/quantum/qiskit/backends/ionq.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/ionq.py
@@ -53,7 +53,7 @@ class IonQBackend(AzureBackend):
 
     def _translate_input(self, circuit, data_format, input_params, to_qir_kwargs={}):
         """ Translates the input values to the format expected by the AzureBackend. """
-        if "targetCapabilty" in input_params and input_params["targetCapabilty"] == "ionq":
+        if "targetCapability" in input_params and input_params["targetCapability"] == "ionq":
             del input_params["targetCapability"]
 
         if "targetCapability" in input_params:


### PR DESCRIPTION
The IonQ target needs to have a default targetCapability so that targetCapability can propagate through to the translation.