### PR TITLE
Fix link in Python package description.

### DIFF
--- a/azure-quantum/README.md
+++ b/azure-quantum/README.md
@@ -79,7 +79,7 @@ result = job.get_results()
 
 ## Contributing ##
 
-For details on contributing to this repository, see the [contributing guide](https://github.com/microsoft/qdk-python/blob/main/CONTRIBUTING.md).
+For details on contributing to this package, see the [contributing guide](https://github.com/microsoft/qdk-python/blob/main/CONTRIBUTING.md).
 
 This project welcomes contributions and suggestions. Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit
 https://cla.microsoft.com.

--- a/azure-quantum/README.md
+++ b/azure-quantum/README.md
@@ -79,7 +79,7 @@ result = job.get_results()
 
 ## Contributing ##
 
-For details on contributing to this repository, see the [contributing guide](../CONTRIBUTING.md).
+For details on contributing to this repository, see the [contributing guide](https://github.com/microsoft/qdk-python/blob/main/CONTRIBUTING.md).
 
 This project welcomes contributions and suggestions. Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit
 https://cla.microsoft.com.


### PR DESCRIPTION
The link to the contributing guidelines was broken on the pypi package, as it was a relative link to the CONTRIBUTING.md file. This updates the README to point to the full URL.