### PR TITLE
Fix estimation for quantinuum EHQC

### DIFF
--- a/azure-quantum/azure/quantum/target/quantinuum.py
+++ b/azure-quantum/azure/quantum/target/quantinuum.py
@@ -152,6 +152,8 @@ class Quantinuum(Target):
 
         if "apival" in self.name or "sc" in self.name:
             HQC = 0.0
+        else if currency_code == "EHQC":
+            HQC = 5 + 2 * num_shots * (N_1q + 10 * N_2q + 5 * N_m) / 5000
         else:
             HQC = 5 + num_shots * (N_1q + 10 * N_2q + 5 * N_m) / 5000
 


### PR DESCRIPTION
Quantinuum uses a slightly different formula for EHQC.

Currently, the estimate_cost function returns the same value for HQC (hardware targets) and EHQC (emulator targets).

This fixes that behavior and applies the ~2 x multiplier that is missing.