### PR TITLE
Adding unique backends for QIR and pass through.

### DIFF
--- a/azure-quantum/azure/quantum/qiskit/backends/__init__.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/__init__.py
@@ -7,32 +7,35 @@ from azure.quantum.qiskit.backends.ionq import (
     IonQBackend,
     IonQQPUBackend,
     IonQAriaBackend,
-    IonQSimulatorBackend
+    IonQSimulatorBackend,
+    IonQQPUQirBackend,
+    IonQAriaQirBackend,
+    IonQSimulatorQirBackend,
 )
 
 from azure.quantum.qiskit.backends.quantinuum import (
     QuantinuumBackend,
     QuantinuumQPUBackend,
     QuantinuumSyntaxCheckerBackend,
-    QuantinuumEmulatorBackend
+    QuantinuumEmulatorBackend,
+    QuantinuumQPUQirBackend,
+    QuantinuumSyntaxCheckerQirBackend,
+    QuantinuumEmulatorQirBackend,
 )
 
 from azure.quantum.qiskit.backends.rigetti import (
     RigettiBackend,
     RigettiQPUBackend,
-    RigettiSimulatorBackend
+    RigettiSimulatorBackend,
 )
 
 from azure.quantum.qiskit.backends.qci import (
     QCIBackend,
     QCISimulatorBackend,
+    QCIQPUBackend,
 )
 
 from azure.quantum.qiskit.backends.microsoft import (
     MicrosoftBackend,
-    MicrosoftResourceEstimationBackend
+    MicrosoftResourceEstimationBackend,
 )
-
-# Default targets to use when there is no target class
-# associated with a given target ID
-DEFAULT_TARGETS = {}

--- a/azure-quantum/azure/quantum/qiskit/backends/backend.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/backend.py
@@ -53,7 +53,7 @@ class AzureBackendBase(Backend):
         """Returns the Job instance associated with the given id."""
         return self._provider.get_job(job_id)
 
-    def _get_output_data_format(self, **options) -> str:
+    def _get_output_data_format(self, options : Dict[str, Any] = {}) -> str:
         config: BackendConfiguration = self.configuration()
         # output data format default depends on the number of experiments. QIR backends
         # that don't define a default in their azure config will use this value
@@ -123,7 +123,7 @@ class AzureBackendBase(Backend):
         input_data_format = options.pop(
             "input_data_format", config.azure["input_data_format"]
         )
-        output_data_format = self._get_output_data_format(**options)
+        output_data_format = self._get_output_data_format(options)
 
         job = AzureQuantumJob(
             backend=self,
@@ -363,7 +363,7 @@ class AzureBackend(AzureBackendBase):
         job_name = options.pop("job_name", circuit.name)
         metadata = options.pop("metadata", self._prepare_job_metadata(circuit))
 
-        input_params = self._get_input_params(**options)
+        input_params = self._get_input_params(options)
 
         input_data = self._translate_input(circuit)
 

--- a/azure-quantum/azure/quantum/qiskit/backends/backend.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/backend.py
@@ -253,16 +253,10 @@ class AzureQirBackend(AzureBackendBase):
             circuits, targetCapability, **to_qir_kwargs
         )
 
-        # TODO: Do we ever forsee the need to support separate arguments for each entry point?
         arguments = input_params.pop("arguments", [])
-        if len(entry_points) == 1:
-            # TODO: Do we need to support both entry point defs?
-            input_params["entryPoint"] = entry_points[0]
-            input_params["arguments"] = arguments
-        else:
-            input_params["items"] = [
-                {"entryPoint": name, "arguments": arguments} for name in entry_points
-            ]
+        input_params["items"] = [
+            {"entryPoint": name, "arguments": arguments} for name in entry_points
+        ]
 
         return input_data
 

--- a/azure-quantum/azure/quantum/qiskit/backends/backend.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/backend.py
@@ -46,7 +46,7 @@ class AzureBackendBase(Backend):
         pass
 
     @abstractmethod
-    def _azure_config(self) -> dict[str, str]:
+    def _azure_config(self) -> Dict[str, str]:
         pass
 
     def retrieve_job(self, job_id) -> AzureQuantumJob:
@@ -171,7 +171,7 @@ class AzureQirBackend(AzureBackendBase):
     ):
         super().__init__(configuration, provider, **fields)
 
-    def _azure_config(self) -> dict[str, str]:
+    def _azure_config(self) -> Dict[str, str]:
         return {
             "blob_name": "inputData",
             "content_type": "qir.v1",

--- a/azure-quantum/azure/quantum/qiskit/backends/backend.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/backend.py
@@ -8,9 +8,13 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-from typing import Union, List
+from typing import Any, Dict, Tuple, Union, List
 from azure.quantum.version import __version__
-from azure.quantum.qiskit.job import AzureQuantumJob
+from azure.quantum.qiskit.job import (
+    MICROSOFT_OUTPUT_DATA_FORMAT,
+    MICROSOFT_OUTPUT_DATA_FORMAT_V2,
+    AzureQuantumJob,
+)
 from abc import abstractmethod
 
 try:
@@ -23,12 +27,15 @@ try:
 
 except ImportError:
     raise ImportError(
-    "Missing optional 'qiskit' dependencies. \
+        "Missing optional 'qiskit' dependencies. \
 To install run: pip install azure-quantum[qiskit]"
-)
+    )
+
 
 class AzureBackendBase(Backend):
-    def __init__(self, configuration: BackendConfiguration, provider: Provider=None, **fields):
+    def __init__(
+        self, configuration: BackendConfiguration, provider: Provider = None, **fields
+    ):
         super().__init__(configuration, provider, **fields)
 
     @classmethod
@@ -40,80 +47,79 @@ class AzureBackendBase(Backend):
     def _azure_config(self) -> dict[str, str]:
         pass
 
-class AzureQirBackend(AzureBackendBase):
-    def __init__(self, configuration: BackendConfiguration, provider: Provider=None, **fields):
-        super().__init__(configuration, provider, **fields)
+    def retrieve_job(self, job_id) -> AzureQuantumJob:
+        """Returns the Job instance associated with the given id."""
+        return self._provider.get_job(job_id)
 
-    def _azure_config(self) -> dict[str, str]:
-        return {
-            "blob_name": "inputData",
-            "content_type": "qir.v1",
-            "input_data_format": "qir.v1",
-        }
-
-    def run(self, run_input: Union[QuantumCircuit, List[QuantumCircuit]], **options) -> AzureQuantumJob:
-        circuits = list([])
-        if isinstance(run_input, QuantumCircuit):
-            circuits = [run_input]
-        else:
-            circuits = run_input
-
-        if not circuits:
-            raise ValueError("No QuantumCircuits provided")
-        
-        max_circuits_per_job = self.configuration().max_experiments
-        if len(circuits) > max_circuits_per_job:
-            raise NotImplementedError(f"This backend only supports running a maximum of {max_circuits_per_job} circuits per job.")
-
-        record_output: bool = True
-        
-        # Backend options are mapped to input_params.
-        input_params = vars(self.options).copy()
-
-        targetCapability = options.pop("targetCapability", self.options.get("targetCapability", "AdaptiveExecution"))
-        from qiskit_qir import to_qir_bitcode_with_entry_points
-        (input_data, entry_points) = to_qir_bitcode_with_entry_points(
-            circuits, targetCapability, record_output=record_output
+    def _get_output_data_format(self, **options) -> str:
+        config: BackendConfiguration = self.configuration()
+        # output data format default depends on the number of experiments. QIR backends
+        # that don't define a default in their azure config will use this value
+        # Once more than one experiment is supported, we should always use the v2 format
+        default_output_data_format = (
+            MICROSOFT_OUTPUT_DATA_FORMAT
+            if config.max_experiments == 1
+            else MICROSOFT_OUTPUT_DATA_FORMAT_V2
         )
+
+        azure_config: Dict[str, Any] = config.azure
+        # if the backend defines an output format, use that over the default
+        azure_defined_override = azure_config.get(
+            "output_data_format", default_output_data_format
+        )
+        # if the user specifies an output format, use that over the default azure config
+        output_data_format = options.pop("output_data_format", azure_defined_override)
+
+        return output_data_format
+
+    def _get_input_params(self, **options) -> Dict[str, Any]:
+        # Backend options are mapped to input_params.
+        input_params: Dict[str, Any] = vars(self.options).copy()
 
         # The shots/count number can be specified in different ways for different providers,
         # so let's get it first. Values in 'kwargs' take precedence over options, and to keep
         # the convention, 'count' takes precedence over 'shots' afterwards.
-        shots_count = \
-            options["count"] if "count" in options else \
-            options["shots"] if "shots" in options else \
-            input_params["count"] if "count" in input_params else \
-            input_params["shots"] if "shots" in input_params else None
+        shots_count = (
+            options["count"]
+            if "count" in options
+            else options["shots"]
+            if "shots" in options
+            else input_params["count"]
+            if "count" in input_params
+            else input_params["shots"]
+            if "shots" in input_params
+            else None
+        )
 
-        # define entryPoints which contain arguments
-        input_params["shots"] = shots_count
+        # Let's clear the options of both properties regardless of which one was used to prevent
+        # double specification of the value.
+        options.pop("shots", None)
+        options.pop("count", None)
+
+        # Take also into consideration options passed in the options, as the take precedence
+        # over default values:
+        for opt in options.copy():
+            if opt in input_params:
+                input_params[opt] = options.pop(opt)
+
         input_params["count"] = shots_count
+        input_params["shots"] = shots_count
 
-        if len(circuits) == 1:
-            # TODO: Do we need to support both entry point defs?
-            input_params["entryPoint"] = entry_points[0]
-            input_params["arguments"] = []
-        else:
-            input_params["items"] = [
-                {"entryPoint": name, "arguments": []} for name in entry_points
-            ]
+        return input_params
 
-        job_name = ""
-        if len(entry_points) > 1:
-            job_name = f"batch-{len(entry_points)}-{shots_count}"
-        else:
-            job_name = circuits[0].name
-        job_name = options.pop("job_name", job_name)
+    def _run(self, job_name, input_data, input_params, metadata, **options):
+        logger.info(f"Submitting new job for backend {self.name()}")
 
         # The default of these job parameters come from the AzureBackend configuration:
         config = self.configuration()
         blob_name = options.pop("blob_name", config.azure["blob_name"])
         content_type = options.pop("content_type", config.azure["content_type"])
         provider_id = options.pop("provider_id", config.azure["provider_id"])
-        input_data_format = options.pop("input_data_format", config.azure["input_data_format"])
-        output_data_format = options.pop("output_data_format", config.azure["output_data_format"])
+        input_data_format = options.pop(
+            "input_data_format", config.azure["input_data_format"]
+        )
+        output_data_format = self._get_output_data_format(**options)
 
-        logger.info(f"Submitting new job for backend {self.name()}")
         job = AzureQuantumJob(
             backend=self,
             target=self.name(),
@@ -124,21 +130,146 @@ class AzureQirBackend(AzureBackendBase):
             provider_id=provider_id,
             input_data_format=input_data_format,
             output_data_format=output_data_format,
-            input_params = input_params,
-            **options
+            input_params=input_params,
+            metadata=metadata,
+            **options,
         )
-
-        logger.info(f"Submitted job with id '{job.id()}' with shot count of {shots_count}:")
-        logger.info(input_data)
 
         return job
 
+
+class AzureQirBackend(AzureBackendBase):
+    def __init__(
+        self, configuration: BackendConfiguration, provider: Provider = None, **fields
+    ):
+        super().__init__(configuration, provider, **fields)
+
+    def _azure_config(self) -> dict[str, str]:
+        return {
+            "blob_name": "inputData",
+            "content_type": "qir.v1",
+            "input_data_format": "qir.v1",
+        }
+
+    def run(
+        self, run_input: Union[QuantumCircuit, List[QuantumCircuit]], **options
+    ) -> AzureQuantumJob:
+        circuits = list([])
+        if isinstance(run_input, QuantumCircuit):
+            circuits = [run_input]
+        else:
+            circuits = run_input
+
+        if not circuits:
+            raise ValueError("No QuantumCircuits provided")
+
+        max_circuits_per_job = self.configuration().max_experiments
+        if len(circuits) > max_circuits_per_job:
+            raise NotImplementedError(
+                f"This backend only supports running a maximum of {max_circuits_per_job} circuits per job."
+            )
+
+        # config normalization
+        input_params = self._get_input_params(**options)
+
+        shots_count = input_params["count"]
+
+        job_name = ""
+        if len(circuits) > 1:
+            job_name = f"batch-{len(circuits)}-{shots_count}"
+        else:
+            job_name = circuits[0].name
+        job_name = options.pop("job_name", job_name)
+
+        metadata = options.pop("metadata", {})
+
+        input_data = self._translate_input(circuits, input_params)
+
+        job = super()._run(job_name, input_data, input_params, metadata, **options)
+        logger.info(
+            f"Submitted job with id '{job.id()}' with shot count of {shots_count}:"
+        )
+
+        return job
+
+    def _generate_qir(
+        self, circuits, targetCapability, **to_qir_kwargs
+    ) -> Tuple[bytes, List[str]]:
+        from qiskit_qir import to_qir_bitcode_with_entry_points
+
+        config = self.configuration()
+        # Barriers aren't removed by transpilation and must be explicitly removed in the Qiskit to QIR translation.
+        emit_barrier_calls = "barrier" in config.basis_gates
+        return to_qir_bitcode_with_entry_points(
+            circuits,
+            targetCapability,
+            emit_barrier_calls=emit_barrier_calls,
+            **to_qir_kwargs,
+        )
+
+    def _get_qir_str(self, circuits, targetCapability, **to_qir_kwargs) -> str:
+        from pyqir import Module
+
+        input_data, _ = self._generate_qir(circuits, targetCapability, **to_qir_kwargs)
+        return str(Module.from_bitcode(input_data))
+
+    def _translate_input(
+        self, circuits: List[QuantumCircuit], input_params: Dict[str, Any]
+    ) -> bytes:
+        """Translates the input values to the QIR expected by the Backend."""
+        logger.info(f"Using QIR as the job's payload format.")
+        config = self.configuration()
+
+        # Override QIR translation parameters
+        # We will record the output by default, but allow the backend to override this, and allow the user to override the backend.
+        to_qir_kwargs = input_params.pop(
+            "to_qir_kwargs", config.azure.get("to_qir_kwargs", {"record_output": True})
+        )
+        targetCapability = input_params.pop(
+            "targetCapability",
+            self.options.get("targetCapability", "AdaptiveExecution"),
+        )
+
+        if logger.isEnabledFor(logging.DEBUG):
+            qir = self._get_qir_str(circuits, targetCapability, **to_qir_kwargs)
+            logger.debug(f"QIR:\n{qir}")
+
+        # We'll transpile automatically to the supported gates in QIR unless explicitly skipped.
+        if not input_params.pop("skipTranspile", False):
+            # Set of gates supported by QIR targets.
+            circuits = transpile(
+                circuits, basis_gates=config.basis_gates, optimization_level=0
+            )
+            # We'll only log the QIR again if we performed a transpilation.
+            if logger.isEnabledFor(logging.DEBUG):
+                qir = self._get_qir_str(circuits, targetCapability, **to_qir_kwargs)
+                logger.debug(f"QIR (Post-transpilation):\n{qir}")
+
+        (input_data, entry_points) = self._generate_qir(
+            circuits, targetCapability, **to_qir_kwargs
+        )
+
+        # TODO: Do we ever forsee the need to support separate arguments for each entry point?
+        arguments = input_params.pop("arguments", [])
+        if len(entry_points) == 1:
+            # TODO: Do we need to support both entry point defs?
+            input_params["entryPoint"] = entry_points[0]
+            input_params["arguments"] = arguments
+        else:
+            input_params["items"] = [
+                {"entryPoint": name, "arguments": arguments} for name in entry_points
+            ]
+
+        return input_data
+
+
 class AzureBackend(AzureBackendBase):
     """Base class for interfacing with a backend in Azure Quantum"""
+
     backend_name = None
 
     def _prepare_job_metadata(self, circuit):
-        """ Returns the metadata relative to the given circuit that will be attached to the Job"""
+        """Returns the metadata relative to the given circuit that will be attached to the Job"""
         return {
             "qiskit": True,
             "name": circuit.name,
@@ -146,43 +277,12 @@ class AzureBackend(AzureBackendBase):
             "metadata": json.dumps(circuit.metadata),
         }
 
-    def _translate_input(self, circuit, data_format, input_params, to_qir_kwargs={}):
-        """ Translates the input values to the format expected by the AzureBackend. """
-        if data_format != "qir.v1":
-            target = self.name()
-            raise ValueError(f"{data_format} is not a supported data format for target {target}.")
-
-        logger.info(f"Using QIR as the job's payload format.")
-        from qiskit_qir import to_qir_bitcode, to_qir
-
-
-        capability = input_params["targetCapability"] if "targetCapability" in input_params else "AdaptiveExecution"
-
-        if logger.isEnabledFor(logging.DEBUG):
-            logger.debug(f"QIR:\n{to_qir(circuit, capability, **to_qir_kwargs)}")
-
-        # all qir payload needs to define an entryPoint and arguments:
-        if not "entryPoint" in input_params:
-            input_params["entryPoint"] = "main"
-        if not "arguments" in input_params:
-            input_params["arguments"] = []
-
-        # We'll transpile automatically to the supported gates in QIR unless explicitly skipped.
-        if not input_params.get("skipTranspile", False):
-            # Set of gates supported by QIR targets.
-            config = self.configuration()
-            circuit = transpile(circuit, basis_gates=config.basis_gates, optimization_level=0)
-
-            # We'll only log the QIR again if we performed a transpilation.
-            if logger.isEnabledFor(logging.DEBUG):
-                logger.debug(f"QIR (Post-transpilation):\n{to_qir(circuit, capability, **to_qir_kwargs)}")
-        emit_barrier_calls = "barrier" in config.basis_gates
-        qir = bytes(to_qir_bitcode(circuit, capability, emit_barrier_calls=emit_barrier_calls, **to_qir_kwargs))
-        return (qir, data_format, input_params)
+    @abstractmethod
+    def _translate_input(self, circuit):
+        pass
 
     def run(self, circuit, **kwargs):
-        """Submits the given circuit to run on an Azure Quantum backend."""        
-
+        """Submits the given circuit to run on an Azure Quantum backend."""
         # Some Qiskit features require passing lists of circuits, so unpack those here.
         # We currently only support single-experiment jobs.
         if isinstance(circuit, (list, tuple)):
@@ -194,79 +294,29 @@ class AzureBackend(AzureBackendBase):
         # disassemble into QASM here
         if isinstance(circuit, QasmQobj) or isinstance(circuit, Qobj):
             from qiskit.assembler import disassemble
+
             circuits, run, _ = disassemble(circuit)
             circuit = circuits[0]
             if kwargs.get("shots") is None:
                 # Note that the default number of shots for QObj is 1024
                 # unless the user specifies the backend.
                 kwargs["shots"] = run["shots"]
-        
-        # The default of these job parameters come from the AzureBackend configuration:
-        config = self.configuration()
-        blob_name = kwargs.pop("blob_name", config.azure["blob_name"])
-        content_type = kwargs.pop("content_type", config.azure["content_type"])
-        provider_id = kwargs.pop("provider_id", config.azure["provider_id"])
-        input_data_format = kwargs.pop("input_data_format", config.azure["input_data_format"])
-        output_data_format = kwargs.pop("output_data_format", config.azure["output_data_format"])
 
-        # Override QIR translation parameters
-        to_qir_kwargs = config.azure.get("to_qir_kwargs", {})
-
-        # If not provided as kwargs, the values of these parameters 
+        # If not provided as kwargs, the values of these parameters
         # are calculated from the circuit itself:
         job_name = kwargs.pop("job_name", circuit.name)
-        metadata = kwargs.pop("metadata") if "metadata" in kwargs else self._prepare_job_metadata(circuit)
+        metadata = kwargs.pop("metadata", self._prepare_job_metadata(circuit))
 
-        # Backend options are mapped to input_params.
-        input_params = vars(self.options).copy()
+        input_params = self._get_input_params(**kwargs)
 
-        # The shots/count number can be specified in different ways for different providers,
-        # so let's get it first. Values in 'kwargs' take precedence over options, and to keep
-        # the convention, 'count' takes precedence over 'shots' afterwards.
-        shots_count = \
-            kwargs["count"] if "count" in kwargs else \
-            kwargs["shots"] if "shots" in kwargs else \
-            input_params["count"] if "count" in input_params else \
-            input_params["shots"] if "shots" in input_params else None
+        input_data = self._translate_input(circuit)
 
-        # Let's clear the kwargs of both properties regardless of which one was used to prevent
-        # double specification of the value.
-        kwargs.pop("shots", None)
-        kwargs.pop("count", None)
+        job = super()._run(job_name, input_data, input_params, metadata, **kwargs)
 
-        # Take also into consideration options passed in the kwargs, as the take precedence
-        # over default values:
-        for opt in kwargs.copy():
-            if opt in input_params:
-                input_params[opt] = kwargs.pop(opt)
-
-        input_params["count"] = shots_count
-        input_params["shots"] = shots_count
-
-        # translate
-        (input_data, input_data_format, input_params) = self._translate_input(circuit, input_data_format, input_params, to_qir_kwargs)
-
-        logger.info(f"Submitting new job for backend {self.name()}")
-        job = AzureQuantumJob(
-            backend=self,
-            target=self.name(),
-            name=job_name,
-            input_data=input_data,
-            blob_name=blob_name,
-            content_type=content_type,
-            provider_id=provider_id,
-            input_data_format=input_data_format,
-            output_data_format=output_data_format,
-            input_params = input_params,
-            metadata=metadata,
-            **kwargs
+        shots_count = input_params["count"]
+        logger.info(
+            f"Submitted job with id '{job.id()}' for circuit '{circuit.name}' with shot count of {shots_count}:"
         )
-
-        logger.info(f"Submitted job with id '{job.id()}' for circuit '{circuit.name}' with shot count of {shots_count}:")
         logger.info(input_data)
 
         return job
-
-    def retrieve_job(self, job_id) -> AzureQuantumJob:
-        """ Returns the Job instance associated with the given id."""
-        return self._provider.get_job(job_id)

--- a/azure-quantum/azure/quantum/qiskit/backends/backend.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/backend.py
@@ -156,7 +156,25 @@ class AzureQirBackend(AzureBackendBase):
     def run(
         self, run_input: Union[QuantumCircuit, List[QuantumCircuit]], **options
     ) -> AzureQuantumJob:
-        # TODO: override doc comments instead of using the base class doc comments
+        """Run on the backend.
+
+        This method returns a 
+        :class:`~azure.quantum.qiskit.job.AzureQuantumJob` object
+        that runs circuits. This is an async call.
+
+        Args:
+            run_input (QuantumCircuit or List[QuantumCircuit]): An individual or a
+            list of :class:`~qiskit.circuits.QuantumCircuit` to run on the backend.
+              
+            options: Any kwarg options to pass to the backend for running the
+            config. If a key is also present in the options
+            attribute/object then the expectation is that the value
+            specified will be used instead of what's set in the options
+            object.
+
+        Returns:
+            Job: The job object for the run
+        """
 
         circuits = list([])
         if isinstance(run_input, QuantumCircuit):

--- a/azure-quantum/azure/quantum/qiskit/backends/backend.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/backend.py
@@ -74,7 +74,7 @@ class AzureBackendBase(Backend):
 
         return output_data_format
 
-    def _get_input_params(self, **options) -> Dict[str, Any]:
+    def _get_input_params(self, options) -> Dict[str, Any]:
         # Backend options are mapped to input_params.
         input_params: Dict[str, Any] = vars(self.options).copy()
 
@@ -97,6 +97,9 @@ class AzureBackendBase(Backend):
         # double specification of the value.
         options.pop("shots", None)
         options.pop("count", None)
+
+        if "items" in options:
+            input_params["items"] = options.pop("items")
 
         # Take also into consideration options passed in the options, as the take precedence
         # over default values:
@@ -217,7 +220,7 @@ class AzureQirBackend(AzureBackendBase):
             )
 
         # config normalization
-        input_params = self._get_input_params(**options)
+        input_params = self._get_input_params(options)
 
         shots_count = input_params["count"]
 
@@ -296,10 +299,11 @@ class AzureQirBackend(AzureBackendBase):
             circuits, targetCapability, **to_qir_kwargs
         )
 
-        arguments = input_params.pop("arguments", [])
-        input_params["items"] = [
-            {"entryPoint": name, "arguments": arguments} for name in entry_points
-        ]
+        if not "items" in input_params:
+            arguments = input_params.pop("arguments", [])
+            input_params["items"] = [
+                {"entryPoint": name, "arguments": arguments} for name in entry_points
+            ]
 
         return input_data
 

--- a/azure-quantum/azure/quantum/qiskit/backends/backend.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/backend.py
@@ -44,13 +44,11 @@ class AzureQirBackend(AzureBackendBase):
     def __init__(self, configuration: BackendConfiguration, provider: Provider=None, **fields):
         super().__init__(configuration, provider, **fields)
 
-    @classmethod
-    def _azure_config(cls) -> dict[str, str]:
+    def _azure_config(self) -> dict[str, str]:
         return {
             "blob_name": "inputData",
             "content_type": "qir.v1",
             "input_data_format": "qir.v1",
-            "output_data_format": "microsoft.quantum-results.v2",
         }
 
     def run(self, run_input: Union[QuantumCircuit, List[QuantumCircuit]], **options) -> AzureQuantumJob:

--- a/azure-quantum/azure/quantum/qiskit/backends/ionq.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/ionq.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 ##
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict
 from azure.quantum import __version__
 from azure.quantum.target.ionq import IonQ
 from abc import abstractmethod
@@ -53,7 +53,7 @@ class IonQQirBackendBase(AzureQirBackend):
     def _default_options(cls) -> Options:
         return Options(shots=500, targetCapability="BasicExecution")
 
-    def _azure_config(self) -> dict[str, str]:
+    def _azure_config(self) -> Dict[str, str]:
         config = super()._azure_config()
         config.update(
             {
@@ -174,7 +174,7 @@ class IonQBackend(AzureBackend):
     def _default_options(cls):
         return Options(shots=500)
 
-    def _azure_config(self):
+    def _azure_config(self) -> Dict[str, str]:
         return {
             "blob_name": "inputData",
             "content_type": "application/json",
@@ -256,7 +256,7 @@ class IonQSimulatorNativeBackend(IonQSimulatorBackend):
             kwargs["gateset"] = "native"
         super().__init__(name, provider, **kwargs)
 
-    def _azure_config(self) -> dict[str, str]:
+    def _azure_config(self) -> Dict[str, str]:
         config = super()._azure_config()
         config.update(
             {
@@ -305,7 +305,7 @@ class IonQQPUNativeBackend(IonQQPUBackend):
             kwargs["gateset"] = "native"
         super().__init__(name, provider, **kwargs)
 
-    def _azure_config(self) -> dict[str, str]:
+    def _azure_config(self) -> Dict[str, str]:
         config = super()._azure_config()
         config.update(
             {
@@ -354,7 +354,7 @@ class IonQAriaNativeBackend(IonQAriaBackend):
             kwargs["gateset"] = "native"
         super().__init__(name, provider, **kwargs)
 
-    def _azure_config(self) -> dict[str, str]:
+    def _azure_config(self) -> Dict[str, str]:
         config = super()._azure_config()
         config.update(
             {

--- a/azure-quantum/azure/quantum/qiskit/backends/ionq.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/ionq.py
@@ -46,7 +46,6 @@ class IonQQirBackendBase(AzureQirBackend):
         config.update(
             {
                 "provider_id": "ionq",
-                "output_data_format": "microsoft.quantum-results.v2",
             }
         )
         return config
@@ -175,7 +174,7 @@ class IonQBackend(AzureBackend):
 
         return metadata
 
-    def _translate_input(self, circuit, data_format, input_params, to_qir_kwargs={}):
+    def _translate_input(self, circuit):
         """ Translates the input values to the format expected by the AzureBackend. """
         ionq_circ, _, _ = qiskit_circ_to_ionq_circ(circuit, gateset=self.gateset())
         input_data = {
@@ -183,7 +182,7 @@ class IonQBackend(AzureBackend):
             "qubits": circuit.num_qubits,
             "circuit": ionq_circ,
         }
-        return (IonQ._encode_input_data(input_data), data_format, input_params)
+        return IonQ._encode_input_data(input_data)
 
     def gateset(self):
         return self._gateset

--- a/azure-quantum/azure/quantum/qiskit/backends/ionq.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/ionq.py
@@ -41,11 +41,12 @@ class IonQQirBackendBase(AzureQirBackend):
     def _default_options(cls) -> Options:
         return Options(shots=500, targetCapability="BasicExecution")
 
-    def _azure_config(cls) -> dict[str, str]:
+    def _azure_config(self) -> dict[str, str]:
         config = super()._azure_config()
         config.update(
             {
                 "provider_id": "ionq",
+                "output_data_format": "microsoft.quantum-results.v2",
             }
         )
         return config
@@ -156,8 +157,7 @@ class IonQBackend(AzureBackend):
     def _default_options(cls):
         return Options(shots=500)
 
-    @classmethod
-    def _azure_config(cls):
+    def _azure_config(self):
         return {
             "blob_name": "inputData",
             "content_type": "application/json",

--- a/azure-quantum/azure/quantum/qiskit/backends/ionq.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/ionq.py
@@ -4,34 +4,157 @@
 ##
 from typing import TYPE_CHECKING
 from azure.quantum import __version__
-from azure.quantum.qiskit.job import AzureQuantumJob
 from azure.quantum.target.ionq import IonQ
-import json
 
-from .backend import AzureBackend
+from .backend import AzureBackend, AzureQirBackend
 
 from qiskit.providers.models import BackendConfiguration
 from qiskit.providers import Options
-from qiskit.qobj import Qobj, QasmQobj
 
-from qiskit_ionq.helpers import GATESET_MAP, qiskit_circ_to_ionq_circ
+from qiskit_ionq.helpers import (
+    ionq_basis_gates,
+    GATESET_MAP,
+    qiskit_circ_to_ionq_circ,
+)
 
 if TYPE_CHECKING:
     from azure.quantum.qiskit import AzureQuantumProvider
 
 import logging
+
 logger = logging.getLogger(__name__)
 
-__all__ = ["IonQBackend", "IonQQPUBackend", "IonQSimulatorBackend", "IonQAriaBackend"]
+__all__ = [
+    "IonQBackend",
+    "IonQQPUBackend",
+    "IonQSimulatorBackend",
+    "IonQAriaBackend",
+    "IonQQirBackend",
+    "IonQSimulatorQirBackend",
+    "IonQQPUQirBackend",
+    "IonQAriaQirBackend",
+]
+
+
+class IonQQirBackendBase(AzureQirBackend):
+    @classmethod
+    def _default_options(cls) -> Options:
+        return Options(shots=500, targetCapability="BasicExecution")
+
+    def _azure_config(cls) -> dict[str, str]:
+        config = super()._azure_config()
+        config.update(
+            {
+                "provider_id": "ionq",
+            }
+        )
+        return config
+
+
+class IonQSimulatorQirBackend(IonQQirBackendBase):
+    backend_names = ("ionq.simulator",)
+
+    def __init__(self, name: str, provider: "AzureQuantumProvider", **kwargs):
+        """Base class for interfacing with an IonQ QIR Simulator backend"""
+
+        default_config = BackendConfiguration.from_dict(
+            {
+                "backend_name": name,
+                "backend_version": __version__,
+                "simulator": True,
+                "local": False,
+                "coupling_map": None,
+                "description": "IonQ simulator on Azure Quantum",
+                "basis_gates": ionq_basis_gates,
+                "memory": False,
+                "n_qubits": 29,
+                "conditional": False,
+                "max_shots": None,
+                "max_experiments": 1,
+                "open_pulse": False,
+                "gates": [{"name": "TODO", "parameters": [], "qasm_def": "TODO"}],
+                "azure": self._azure_config(),
+            }
+        )
+        logger.info("Initializing IonQSimulatorQirBackend")
+        configuration: BackendConfiguration = kwargs.pop(
+            "configuration", default_config
+        )
+        super().__init__(configuration=configuration, provider=provider, **kwargs)
+
+
+class IonQQPUQirBackend(IonQQirBackendBase):
+    backend_names = ("ionq.qpu",)
+
+    def __init__(self, name: str, provider: "AzureQuantumProvider", **kwargs):
+        """Base class for interfacing with an IonQ QPU backend"""
+
+        default_config = BackendConfiguration.from_dict(
+            {
+                "backend_name": name,
+                "backend_version": __version__,
+                "simulator": False,
+                "local": False,
+                "coupling_map": None,
+                "description": "IonQ QPU on Azure Quantum",
+                "basis_gates": ionq_basis_gates,
+                "memory": False,
+                "n_qubits": 11,
+                "conditional": False,
+                "max_shots": 10000,
+                "max_experiments": 1,
+                "open_pulse": False,
+                "gates": [{"name": "TODO", "parameters": [], "qasm_def": "TODO"}],
+                "azure": self._azure_config(),
+            }
+        )
+        logger.info("Initializing IonQQPUQirBackend")
+        configuration: BackendConfiguration = kwargs.pop(
+            "configuration", default_config
+        )
+        super().__init__(configuration=configuration, provider=provider, **kwargs)
+
+
+class IonQAriaQirBackend(IonQQirBackendBase):
+    backend_names = ("ionq.qpu.aria-1",)
+
+    def __init__(self, name: str, provider: "AzureQuantumProvider", **kwargs):
+        """Base class for interfacing with an IonQ Aria QPU backend"""
+
+        default_config = BackendConfiguration.from_dict(
+            {
+                "backend_name": name,
+                "backend_version": __version__,
+                "simulator": False,
+                "local": False,
+                "coupling_map": None,
+                "description": "IonQ Aria QPU on Azure Quantum",
+                "basis_gates": ionq_basis_gates,
+                "memory": False,
+                "n_qubits": 23,
+                "conditional": False,
+                "max_shots": 10000,
+                "max_experiments": 1,
+                "open_pulse": False,
+                "gates": [{"name": "TODO", "parameters": [], "qasm_def": "TODO"}],
+                "azure": self._azure_config(),
+            }
+        )
+        logger.info("Initializing IonQAriaQirBackend")
+        configuration: BackendConfiguration = kwargs.pop(
+            "configuration", default_config
+        )
+        super().__init__(configuration=configuration, provider=provider, **kwargs)
 
 
 class IonQBackend(AzureBackend):
     """Base class for interfacing with an IonQ backend in Azure Quantum"""
+
     backend_name = None
 
     @classmethod
     def _default_options(cls):
-        return Options(shots=500, targetCapability="ionq")
+        return Options(shots=500)
 
     @classmethod
     def _azure_config(cls):
@@ -41,31 +164,26 @@ class IonQBackend(AzureBackend):
             "provider_id": "ionq",
             "input_data_format": "ionq.circuit.v1",
             "output_data_format": "ionq.quantum-results.v1",
+            "is_default": True,
         }
 
     def _prepare_job_metadata(self, circuit, **kwargs):
         _, _, meas_map = qiskit_circ_to_ionq_circ(circuit, gateset=self.gateset())
-        
-        metadata = super()._prepare_job_metadata(circuit, **kwargs);
+
+        metadata = super()._prepare_job_metadata(circuit, **kwargs)
         metadata["meas_map"] = meas_map
-        
+
         return metadata
 
     def _translate_input(self, circuit, data_format, input_params, to_qir_kwargs={}):
         """ Translates the input values to the format expected by the AzureBackend. """
-        if "targetCapability" in input_params and input_params["targetCapability"] == "ionq":
-            del input_params["targetCapability"]
-
-        if "targetCapability" in input_params:
-            return super()._translate_input(circuit, "qir.v1", input_params, to_qir_kwargs)
-        else:
-            ionq_circ, _, _ = qiskit_circ_to_ionq_circ(circuit, gateset=self.gateset())
-            input_data = {
-                "gateset": self.gateset(),
-                "qubits": circuit.num_qubits,
-                "circuit": ionq_circ,
-            }
-            return (IonQ._encode_input_data(input_data), data_format, input_params)
+        ionq_circ, _, _ = qiskit_circ_to_ionq_circ(circuit, gateset=self.gateset())
+        input_data = {
+            "gateset": self.gateset(),
+            "qubits": circuit.num_qubits,
+            "circuit": ionq_circ,
+        }
+        return (IonQ._encode_input_data(input_data), data_format, input_params)
 
     def gateset(self):
         return self._gateset
@@ -85,12 +203,7 @@ class IonQBackend(AzureBackend):
 class IonQSimulatorBackend(IonQBackend):
     backend_names = ("ionq.simulator",)
 
-    def __init__(
-        self,
-        name: str,
-        provider: "AzureQuantumProvider",
-        **kwargs
-    ):
+    def __init__(self, name: str, provider: "AzureQuantumProvider", **kwargs):
         """Base class for interfacing with an IonQ Simulator backend"""
         self._gateset = kwargs.pop("gateset", "qis")
 
@@ -114,19 +227,16 @@ class IonQSimulatorBackend(IonQBackend):
             }
         )
         logger.info("Initializing IonQSimulatorBackend")
-        configuration: BackendConfiguration = kwargs.pop("configuration", default_config)
+        configuration: BackendConfiguration = kwargs.pop(
+            "configuration", default_config
+        )
         super().__init__(configuration=configuration, provider=provider, **kwargs)
 
 
 class IonQQPUBackend(IonQBackend):
     backend_names = ("ionq.qpu",)
 
-    def __init__(
-        self,
-        name: str,
-        provider: "AzureQuantumProvider",
-        **kwargs
-    ):
+    def __init__(self, name: str, provider: "AzureQuantumProvider", **kwargs):
         """Base class for interfacing with an IonQ QPU backend"""
         self._gateset = kwargs.pop("gateset", "qis")
 
@@ -150,19 +260,16 @@ class IonQQPUBackend(IonQBackend):
             }
         )
         logger.info("Initializing IonQQPUBackend")
-        configuration: BackendConfiguration = kwargs.pop("configuration", default_config)
+        configuration: BackendConfiguration = kwargs.pop(
+            "configuration", default_config
+        )
         super().__init__(configuration=configuration, provider=provider, **kwargs)
 
 
 class IonQAriaBackend(IonQBackend):
     backend_names = ("ionq.qpu.aria-1",)
 
-    def __init__(
-        self,
-        name: str,
-        provider: "AzureQuantumProvider",
-        **kwargs
-    ):
+    def __init__(self, name: str, provider: "AzureQuantumProvider", **kwargs):
         """Base class for interfacing with an IonQ Aria QPU backend"""
         self._gateset = kwargs.pop("gateset", "qis")
 
@@ -186,5 +293,7 @@ class IonQAriaBackend(IonQBackend):
             }
         )
         logger.info("Initializing IonQAriaQPUBackend")
-        configuration: BackendConfiguration = kwargs.pop("configuration", default_config)
+        configuration: BackendConfiguration = kwargs.pop(
+            "configuration", default_config
+        )
         super().__init__(configuration=configuration, provider=provider, **kwargs)

--- a/azure-quantum/azure/quantum/qiskit/backends/microsoft.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/microsoft.py
@@ -57,7 +57,7 @@ class MicrosoftBackend(AzureQirBackend):
     def _default_options(cls):
         return Options(targetCapability="AdaptiveExecution")
 
-    def _azure_config(self):
+    def _azure_config(self) -> Dict[str, str]:
         config = super()._azure_config()
         config.update(
             {

--- a/azure-quantum/azure/quantum/qiskit/backends/microsoft.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/microsoft.py
@@ -6,7 +6,7 @@
 from typing import TYPE_CHECKING
 from azure.quantum.version import __version__
 
-from .backend import AzureBackend
+from .backend import AzureQirBackend
 
 from qiskit.providers.models import BackendConfiguration
 from qiskit.providers import Options
@@ -43,23 +43,23 @@ __all__ = [
     "MicrosoftBackend", "MicrosoftResourceEstimationBackend"
 ]
 
-class MicrosoftBackend(AzureBackend):
+class MicrosoftBackend(AzureQirBackend):
     """Base class for interfacing with a Microsoft backend in Azure Quantum"""
 
     @classmethod
     def _default_options(cls):
         return Options(entryPoint="main", arguments=[], targetCapability="AdaptiveExecution")
 
-    @classmethod
-    def _azure_config(cls):
-        return {
-            "blob_name": "inputData",
-            "content_type": "qir.v1",
-            "provider_id": "microsoft-qc",
-            "input_data_format": "qir.v1",
-            "output_data_format": "microsoft.resource-estimates.v1",
-            "to_qir_kwargs": {"record_output": False}
-        }
+    def _azure_config(self):
+        config = super()._azure_config()
+        config.update(
+            {
+                "provider_id": "microsoft-qc",
+                "output_data_format": "microsoft.resource-estimates.v1",
+                "to_qir_kwargs": {"record_output": False}
+            }
+        )
+        return config
 
 class MicrosoftResourceEstimationBackend(MicrosoftBackend):
     """Backend class for interfacing with the resource estimator target"""

--- a/azure-quantum/azure/quantum/qiskit/backends/microsoft.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/microsoft.py
@@ -58,7 +58,7 @@ class MicrosoftBackend(AzureBackend):
             "provider_id": "microsoft-qc",
             "input_data_format": "qir.v1",
             "output_data_format": "microsoft.resource-estimates.v1",
-            "to_qir_kwargs": {"record_output": False, "use_static_qubit_alloc": False, "use_static_result_alloc": False}
+            "to_qir_kwargs": {"record_output": False}
         }
 
 class MicrosoftResourceEstimationBackend(MicrosoftBackend):

--- a/azure-quantum/azure/quantum/qiskit/backends/microsoft.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/microsoft.py
@@ -77,13 +77,10 @@ class MicrosoftResourceEstimationBackend(MicrosoftBackend):
     @classmethod
     def _default_options(cls):
         return Options(
-            entryPoint="main",
-            arguments=[],
             targetCapability="AdaptiveExecution",
             errorBudget=1e-3,
             qubitParams={"name": "qubit_gate_ns_e3"},
-            qecScheme={"name": "surface_code"},
-            items=None,
+            qecScheme={"name": "surface_code"}
         )
 
     def __init__(self, name: str, provider: "AzureQuantumProvider", **kwargs):
@@ -114,12 +111,3 @@ class MicrosoftResourceEstimationBackend(MicrosoftBackend):
             "configuration", default_config
         )
         super().__init__(configuration=configuration, provider=provider, **kwargs)
-
-    def _translate_input(
-        self, circuits: List[QuantumCircuit], input_params: Dict[str, Any]
-    ) -> bytes:
-        # Delete `items` key from input_data_format if it hasn't been set
-        if not input_params.get("items", None):
-            del input_params["items"]
-
-        return super()._translate_input(circuits, input_params)

--- a/azure-quantum/azure/quantum/qiskit/backends/microsoft.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/microsoft.py
@@ -6,11 +6,11 @@
 from typing import TYPE_CHECKING, Any, Dict, List
 from azure.quantum.version import __version__
 from qiskit import QuantumCircuit
-
+from abc import abstractmethod
 from .backend import AzureQirBackend
 
 from qiskit.providers.models import BackendConfiguration
-from qiskit.providers import Options
+from qiskit.providers import Options, Provider
 
 QIR_BASIS_GATES = [
     "measure",
@@ -46,6 +46,12 @@ __all__ = ["MicrosoftBackend", "MicrosoftResourceEstimationBackend"]
 
 class MicrosoftBackend(AzureQirBackend):
     """Base class for interfacing with a Microsoft backend in Azure Quantum"""
+
+    @abstractmethod
+    def __init__(
+        self, configuration: BackendConfiguration, provider: Provider = None, **fields
+    ):
+        super().__init__(configuration, provider, **fields)
 
     @classmethod
     def _default_options(cls):
@@ -116,4 +122,4 @@ class MicrosoftResourceEstimationBackend(MicrosoftBackend):
         if not input_params.get("items", None):
             del input_params["items"]
 
-        return super()._translate_input(self, circuits, input_params)
+        return super()._translate_input(circuits, input_params)

--- a/azure-quantum/azure/quantum/qiskit/backends/qci.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/qci.py
@@ -5,11 +5,11 @@
 
 from typing import TYPE_CHECKING
 from azure.quantum.version import __version__
-
+from abc import abstractmethod
 from .backend import AzureQirBackend
 
 from qiskit.providers.models import BackendConfiguration
-from qiskit.providers import Options
+from qiskit.providers import Options, Provider
 
 QIR_BASIS_GATES = [
     "measure",
@@ -44,6 +44,12 @@ __all__ = ["QCISimulatorBackend" "QCIQPUBackend"]
 
 
 class QCIBackend(AzureQirBackend):
+    @abstractmethod
+    def __init__(
+        self, configuration: BackendConfiguration, provider: Provider = None, **fields
+    ):
+        super().__init__(configuration, provider, **fields)
+
     @classmethod
     def _default_options(cls) -> Options:
         return Options(shots=500, targetCapability="AdaptiveExecution")

--- a/azure-quantum/azure/quantum/qiskit/backends/qci.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/qci.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 ##
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict
 from azure.quantum.version import __version__
 from abc import abstractmethod
 from .backend import AzureQirBackend
@@ -54,7 +54,7 @@ class QCIBackend(AzureQirBackend):
     def _default_options(cls) -> Options:
         return Options(shots=500, targetCapability="AdaptiveExecution")
 
-    def _azure_config(self) -> dict[str, str]:
+    def _azure_config(self) -> Dict[str, str]:
         config = super()._azure_config()
         config.update(
             {

--- a/azure-quantum/azure/quantum/qiskit/backends/qci.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/qci.py
@@ -48,7 +48,7 @@ class QCIBackend(AzureQirBackend):
     def _default_options(cls) -> Options:
         return Options(shots=500, targetCapability="AdaptiveExecution")
 
-    def _azure_config(cls) -> dict[str, str]:
+    def _azure_config(self) -> dict[str, str]:
         config = super()._azure_config()
         config.update(
             {

--- a/azure-quantum/azure/quantum/qiskit/backends/qci.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/qci.py
@@ -53,7 +53,6 @@ class QCIBackend(AzureQirBackend):
         config.update(
             {
                 "provider_id": "qci",
-                "output_data_format": "microsoft.quantum-results.v1",
             }
         )
         return config

--- a/azure-quantum/azure/quantum/qiskit/backends/qci.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/qci.py
@@ -2,13 +2,11 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 ##
-import warnings
 
-from typing import TYPE_CHECKING, Union, List
+from typing import TYPE_CHECKING
 from azure.quantum.version import __version__
-from azure.quantum.qiskit.job import AzureQuantumJob
 
-from .backend import AzureBackend
+from .backend import AzureQirBackend
 
 from qiskit.providers.models import BackendConfiguration
 from qiskit.providers import Options
@@ -32,47 +30,39 @@ QIR_BASIS_GATES = [
     "x",
     "y",
     "z",
-    "id"
+    "id",
 ]
 
 if TYPE_CHECKING:
     from azure.quantum.qiskit import AzureQuantumProvider
 
 import logging
+
 logger = logging.getLogger(__name__)
 
-__all__ = [
-    "QCISimulatorBackend"
-    "QCIQPUBackend"
-]
+__all__ = ["QCISimulatorBackend" "QCIQPUBackend"]
 
-class QCIBackend(AzureBackend):
-    """Base class for interfacing with a QCI backend in Azure Quantum"""
 
+class QCIBackend(AzureQirBackend):
     @classmethod
-    def _default_options(cls):
-        return Options(shots=500, entryPoint="main", arguments=[], targetCapability="AdaptiveExecution")
+    def _default_options(cls) -> Options:
+        return Options(shots=500, targetCapability="AdaptiveExecution")
 
-    @classmethod
-    def _azure_config(cls):
-        return {
-            "blob_name": "inputData",
-            "content_type": "qir.v1",
-            "provider_id": "qci",
-            "input_data_format": "qir.v1",
-            "output_data_format": "microsoft.quantum-results.v1",
-        }
+    def _azure_config(cls) -> dict[str, str]:
+        config = super()._azure_config()
+        config.update(
+            {
+                "provider_id": "qci",
+                "output_data_format": "microsoft.quantum-results.v1",
+            }
+        )
+        return config
 
 
 class QCISimulatorBackend(QCIBackend):
-    backend_names = ("qci.simulator","qci.simulator.noisy")
+    backend_names = ("qci.simulator", "qci.simulator.noisy")
 
-    def __init__(
-        self,
-        name: str,
-        provider: "AzureQuantumProvider",
-        **kwargs
-    ):
+    def __init__(self, name: str, provider: "AzureQuantumProvider", **kwargs):
         """Base class for interfacing with an QCI Simulator backend"""
         default_config = BackendConfiguration.from_dict(
             {
@@ -94,19 +84,16 @@ class QCISimulatorBackend(QCIBackend):
             }
         )
         logger.info("Initializing QCISimulatorBackend")
-        configuration: BackendConfiguration = kwargs.pop("configuration", default_config)
+        configuration: BackendConfiguration = kwargs.pop(
+            "configuration", default_config
+        )
         super().__init__(configuration=configuration, provider=provider, **kwargs)
 
 
 class QCIQPUBackend(QCIBackend):
     backend_names = ("qci.machine1",)
 
-    def __init__(
-        self,
-        name: str,
-        provider: "AzureQuantumProvider",
-        **kwargs
-    ):
+    def __init__(self, name: str, provider: "AzureQuantumProvider", **kwargs):
         """Base class for interfacing with an QCI QPU backend"""
         default_config = BackendConfiguration.from_dict(
             {
@@ -128,5 +115,7 @@ class QCIQPUBackend(QCIBackend):
             }
         )
         logger.info("Initializing QCIQPUBackend")
-        configuration: BackendConfiguration = kwargs.pop("configuration", default_config)
+        configuration: BackendConfiguration = kwargs.pop(
+            "configuration", default_config
+        )
         super().__init__(configuration=configuration, provider=provider, **kwargs)

--- a/azure-quantum/azure/quantum/qiskit/backends/quantinuum.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/quantinuum.py
@@ -68,7 +68,6 @@ class QuantinuumQirBackendBase(AzureQirBackend):
         config.update(
             {
                 "provider_id": QUANTINUUM_PROVIDER_ID,
-                "output_data_format": "microsoft.quantum-results.v1",
             }
         )
         return config
@@ -82,7 +81,7 @@ class QuantinuumSyntaxCheckerQirBackend(QuantinuumQirBackendBase):
     backend_names = (
         # Note: Target names on the same line are equivalent.
         "quantinuum.hqs-lt-s1-apival", "quantinuum.sim.h1-1sc",
-        "quantinuum.hqs-lt-s2-apival", "quantinuum.sim.h1-2sc"
+        "quantinuum.hqs-lt-s2-apival", "quantinuum.sim.h1-2sc",
     )
 
     def __init__(self, name: str, provider: "AzureQuantumProvider", **kwargs):
@@ -119,7 +118,7 @@ class QuantinuumEmulatorQirBackend(QuantinuumQirBackendBase):
     backend_names = (
         # Note: Target names on the same line are equivalent.
         "quantinuum.hqs-lt-s1-sim", "quantinuum.sim.h1-1e",
-        "quantinuum.hqs-lt-s2-sim", "quantinuum.sim.h1-2e"
+        "quantinuum.hqs-lt-s2-sim", "quantinuum.sim.h1-2e",
     )
 
     def __init__(self, name: str, provider: "AzureQuantumProvider", **kwargs):
@@ -156,7 +155,7 @@ class QuantinuumQPUQirBackend(QuantinuumQirBackendBase):
     backend_names = (
         # Note: Target names on the same line are equivalent.
         "quantinuum.hqs-lt-s1", "quantinuum.qpu.h1-1",
-        "quantinuum.hqs-lt-s2", "quantinuum.qpu.h1-2"
+        "quantinuum.hqs-lt-s2", "quantinuum.qpu.h1-2",
     )
 
     def __init__(self, name: str, provider: "AzureQuantumProvider", **kwargs):
@@ -211,9 +210,9 @@ class QuantinuumBackend(AzureBackend):
             "is_default": True,
         }
 
-    def _translate_input(self, circuit, data_format, input_params, to_qir_kwargs={}):
+    def _translate_input(self, circuit):
         """Translates the input values to the format expected by the AzureBackend."""
-        return (circuit.qasm(), data_format, input_params)
+        return circuit.qasm()
 
     def estimate_cost(
         self, circuit: QuantumCircuit, shots: int = None, count: int = None
@@ -242,11 +241,12 @@ class QuantinuumBackend(AzureBackend):
         name = name.lower()
         return 20 if "h1-1" in name or "s1" in name else 12
 
+
 class QuantinuumSyntaxCheckerBackend(QuantinuumBackend):
     backend_names = (
         # Note: Target names on the same line are equivalent.
         "quantinuum.hqs-lt-s1-apival", "quantinuum.sim.h1-1sc",
-        "quantinuum.hqs-lt-s2-apival", "quantinuum.sim.h1-2sc"
+        "quantinuum.hqs-lt-s2-apival", "quantinuum.sim.h1-2sc",
     )
 
     def __init__(self, name: str, provider: "AzureQuantumProvider", **kwargs):
@@ -283,7 +283,7 @@ class QuantinuumEmulatorBackend(QuantinuumBackend):
     backend_names = (
         # Note: Target names on the same line are equivalent.
         "quantinuum.hqs-lt-s1-sim", "quantinuum.sim.h1-1e",
-        "quantinuum.hqs-lt-s2-sim", "quantinuum.sim.h1-2e"
+        "quantinuum.hqs-lt-s2-sim", "quantinuum.sim.h1-2e",
     )
 
     def __init__(self, name: str, provider: "AzureQuantumProvider", **kwargs):
@@ -320,7 +320,7 @@ class QuantinuumQPUBackend(QuantinuumBackend):
     backend_names = (
         # Note: Target names on the same line are equivalent.
         "quantinuum.hqs-lt-s1", "quantinuum.qpu.h1-1",
-        "quantinuum.hqs-lt-s2", "quantinuum.qpu.h1-2"
+        "quantinuum.hqs-lt-s2", "quantinuum.qpu.h1-2",
     )
 
     def __init__(self, name: str, provider: "AzureQuantumProvider", **kwargs):

--- a/azure-quantum/azure/quantum/qiskit/backends/quantinuum.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/quantinuum.py
@@ -63,7 +63,7 @@ class QuantinuumQirBackendBase(AzureQirBackend):
     def _default_options(cls) -> Options:
         return Options(shots=500, targetCapability="BasicExecution")
 
-    def _azure_config(cls) -> dict[str, str]:
+    def _azure_config(self) -> dict[str, str]:
         config = super()._azure_config()
         config.update(
             {

--- a/azure-quantum/azure/quantum/qiskit/backends/quantinuum.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/quantinuum.py
@@ -6,7 +6,7 @@
 from azure.quantum.version import __version__
 
 from .backend import AzureBackend, AzureQirBackend
-
+from abc import abstractmethod
 from qiskit import QuantumCircuit
 from qiskit.providers.models import BackendConfiguration
 from qiskit.providers import Options
@@ -52,11 +52,10 @@ QUANTINUUM_PROVIDER_NAME = "Quantinuum"
 
 
 class QuantinuumQirBackendBase(AzureQirBackend):
+    @abstractmethod
     def __init__(
         self, configuration: BackendConfiguration, provider: Provider = None, **fields
     ):
-        self._provider_id = QUANTINUUM_PROVIDER_ID
-        self._provider_name = QUANTINUUM_PROVIDER_NAME
         super().__init__(configuration, provider, **fields)
 
     @classmethod
@@ -191,10 +190,11 @@ class QuantinuumQPUQirBackend(QuantinuumQirBackendBase):
 class QuantinuumBackend(AzureBackend):
     """Base class for interfacing with a Quantinuum (formerly Honeywell) backend in Azure Quantum"""
 
-    def __init__(self, **kwargs):
-        self._provider_id = QUANTINUUM_PROVIDER_ID
-        self._provider_name = QUANTINUUM_PROVIDER_NAME
-        super().__init__(**kwargs)
+    @abstractmethod
+    def __init__(
+        self, configuration: BackendConfiguration, provider: Provider = None, **fields
+    ):
+        super().__init__(configuration, provider, **fields)
 
     @classmethod
     def _default_options(cls):

--- a/azure-quantum/azure/quantum/qiskit/backends/quantinuum.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/quantinuum.py
@@ -73,10 +73,9 @@ class QuantinuumQirBackendBase(AzureQirBackend):
         )
         return config
 
-    def _initialize_n_qubits(self, name):
+    def _get_n_qubits(self, name):
         name = name.lower()
-        self.n_qubits = 20 if "h1-1" in name or "s1" in name else 12
-        return self.n_qubits
+        return 20 if "h1-1" in name or "s1" in name else 12
 
 
 class QuantinuumSyntaxCheckerQirBackend(QuantinuumQirBackendBase):
@@ -90,7 +89,6 @@ class QuantinuumSyntaxCheckerQirBackend(QuantinuumQirBackendBase):
         self._provider_id = QUANTINUUM_PROVIDER_ID
         self._provider_name = QUANTINUUM_PROVIDER_NAME
 
-        self._initialize_n_qubits(name)
         default_config = BackendConfiguration.from_dict(
             {
                 "backend_name": name,
@@ -101,7 +99,7 @@ class QuantinuumSyntaxCheckerQirBackend(QuantinuumQirBackendBase):
                 "description": f"Quantinuum Syntax Checker on Azure Quantum",
                 "basis_gates": QUANTINUUM_BASIS_GATES,
                 "memory": False,
-                "n_qubits": self.n_qubits,
+                "n_qubits": self._get_n_qubits(name),
                 "conditional": False,
                 "max_shots": None,
                 "max_experiments": 1,
@@ -128,8 +126,6 @@ class QuantinuumEmulatorQirBackend(QuantinuumQirBackendBase):
         self._provider_id = QUANTINUUM_PROVIDER_ID
         self._provider_name = QUANTINUUM_PROVIDER_NAME
 
-        self._initialize_n_qubits(name)
-        configuration: BackendConfiguration = kwargs.pop("configuration", None)
         default_config = BackendConfiguration.from_dict(
             {
                 "backend_name": name,
@@ -140,7 +136,7 @@ class QuantinuumEmulatorQirBackend(QuantinuumQirBackendBase):
                 "description": f"Quantinuum emulator on Azure Quantum",
                 "basis_gates": QUANTINUUM_BASIS_GATES,
                 "memory": False,
-                "n_qubits": self.n_qubits,
+                "n_qubits": self._get_n_qubits(name),
                 "conditional": False,
                 "max_shots": None,
                 "max_experiments": 1,
@@ -167,7 +163,6 @@ class QuantinuumQPUQirBackend(QuantinuumQirBackendBase):
         self._provider_id = QUANTINUUM_PROVIDER_ID
         self._provider_name = QUANTINUUM_PROVIDER_NAME
 
-        self._initialize_n_qubits(name)
         default_config = BackendConfiguration.from_dict(
             {
                 "backend_name": name,
@@ -178,7 +173,7 @@ class QuantinuumQPUQirBackend(QuantinuumQirBackendBase):
                 "description": f"Quantinuum QPU on Azure Quantum",
                 "basis_gates": QUANTINUUM_BASIS_GATES,
                 "memory": False,
-                "n_qubits": self.n_qubits,
+                "n_qubits": self._get_n_qubits(name),
                 "conditional": False,
                 "max_shots": 10000,
                 "max_experiments": 1,
@@ -243,10 +238,9 @@ class QuantinuumBackend(AzureBackend):
         target = workspace.get_targets(self.name())
         return target.estimate_cost(input_data, num_shots=shots)
 
-    def _initialize_n_qubits(self, name):
+    def _get_n_qubits(self, name):
         name = name.lower()
-        self.n_qubits = 20 if "h1-1" in name or "s1" in name else 12
-        return self.n_qubits
+        return 20 if "h1-1" in name or "s1" in name else 12
 
 class QuantinuumSyntaxCheckerBackend(QuantinuumBackend):
     backend_names = (
@@ -259,7 +253,6 @@ class QuantinuumSyntaxCheckerBackend(QuantinuumBackend):
         self._provider_id = QUANTINUUM_PROVIDER_ID
         self._provider_name = QUANTINUUM_PROVIDER_NAME
 
-        self._initialize_n_qubits(name)
         default_config = BackendConfiguration.from_dict(
             {
                 "backend_name": name,
@@ -270,7 +263,7 @@ class QuantinuumSyntaxCheckerBackend(QuantinuumBackend):
                 "description": f"Quantinuum Syntax Checker on Azure Quantum",
                 "basis_gates": QUANTINUUM_BASIS_GATES,
                 "memory": False,
-                "n_qubits": self.n_qubits,
+                "n_qubits": self._get_n_qubits(name),
                 "conditional": False,
                 "max_shots": None,
                 "max_experiments": 1,
@@ -297,8 +290,6 @@ class QuantinuumEmulatorBackend(QuantinuumBackend):
         self._provider_id = QUANTINUUM_PROVIDER_ID
         self._provider_name = QUANTINUUM_PROVIDER_NAME
 
-        self._initialize_n_qubits(name)
-        configuration: BackendConfiguration = kwargs.pop("configuration", None)
         default_config = BackendConfiguration.from_dict(
             {
                 "backend_name": name,
@@ -309,7 +300,7 @@ class QuantinuumEmulatorBackend(QuantinuumBackend):
                 "description": f"Quantinuum emulator on Azure Quantum",
                 "basis_gates": QUANTINUUM_BASIS_GATES,
                 "memory": False,
-                "n_qubits": self.n_qubits,
+                "n_qubits": self._get_n_qubits(name),
                 "conditional": False,
                 "max_shots": None,
                 "max_experiments": 1,
@@ -336,7 +327,6 @@ class QuantinuumQPUBackend(QuantinuumBackend):
         self._provider_id = QUANTINUUM_PROVIDER_ID
         self._provider_name = QUANTINUUM_PROVIDER_NAME
 
-        self._initialize_n_qubits(name)
         default_config = BackendConfiguration.from_dict(
             {
                 "backend_name": name,
@@ -347,7 +337,7 @@ class QuantinuumQPUBackend(QuantinuumBackend):
                 "description": f"Quantinuum QPU on Azure Quantum",
                 "basis_gates": QUANTINUUM_BASIS_GATES,
                 "memory": False,
-                "n_qubits": self.n_qubits,
+                "n_qubits": self._get_n_qubits(name),
                 "conditional": False,
                 "max_shots": 10000,
                 "max_experiments": 1,

--- a/azure-quantum/azure/quantum/qiskit/backends/quantinuum.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/quantinuum.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 ##
 
+from typing import Dict
 from azure.quantum.version import __version__
 
 from .backend import AzureBackend, AzureQirBackend
@@ -62,7 +63,7 @@ class QuantinuumQirBackendBase(AzureQirBackend):
     def _default_options(cls) -> Options:
         return Options(shots=500, targetCapability="BasicExecution")
 
-    def _azure_config(self) -> dict[str, str]:
+    def _azure_config(self) -> Dict[str, str]:
         config = super()._azure_config()
         config.update(
             {
@@ -200,7 +201,7 @@ class QuantinuumBackend(AzureBackend):
     def _default_options(cls):
         return Options(count=500)
 
-    def _azure_config(self):
+    def _azure_config(self) -> Dict[str, str]:
         return {
             "blob_name": "inputData",
             "content_type": "application/qasm",

--- a/azure-quantum/azure/quantum/qiskit/backends/rigetti.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/rigetti.py
@@ -54,7 +54,6 @@ class RigettiBackend(AzureQirBackend):
         config.update(
             {
                 "provider_id": "rigetti",
-                "output_data_format": "microsoft.quantum-results.v1",
             }
         )
         return config

--- a/azure-quantum/azure/quantum/qiskit/backends/rigetti.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/rigetti.py
@@ -2,17 +2,16 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 ##
-import warnings
 
-from typing import TYPE_CHECKING, Union, List
+from typing import TYPE_CHECKING
 from azure.quantum.version import __version__
-from azure.quantum.qiskit.job import AzureQuantumJob
 from azure.quantum.target.rigetti import RigettiTarget
 
-from .backend import AzureBackend
+from .backend import AzureQirBackend
 
 from qiskit.providers.models import BackendConfiguration
 from qiskit.providers import Options
+
 QIR_BASIS_GATES = [
     "measure",
     "m",
@@ -30,47 +29,41 @@ QIR_BASIS_GATES = [
     "x",
     "y",
     "z",
-    "id"
+    "id",
 ]
 
 if TYPE_CHECKING:
     from azure.quantum.qiskit import AzureQuantumProvider
 
 import logging
+
 logger = logging.getLogger(__name__)
 
-__all__ = [
-    "RigettiSimulatorBackend"
-    "RigettiQPUBackend"
-]
+__all__ = ["RigettiSimulatorBackend" "RigettiQPUBackend"]
 
-class RigettiBackend(AzureBackend):
+
+class RigettiBackend(AzureQirBackend):
     """Base class for interfacing with a Rigetti backend in Azure Quantum"""
 
     @classmethod
     def _default_options(cls):
-        return Options(count=500, entryPoint="main", arguments=[], targetCapability="BasicExecution")
+        return Options(count=500, targetCapability="BasicExecution")
 
-    @classmethod
-    def _azure_config(cls):
-        return {
-            "blob_name": "inputData",
-            "content_type": "qir.v1",
-            "provider_id": "rigetti",
-            "input_data_format": "qir.v1",
-            "output_data_format": "microsoft.quantum-results.v1",
-        }
+    def _azure_config(cls) -> dict[str, str]:
+        config = super()._azure_config()
+        config.update(
+            {
+                "provider_id": "rigetti",
+                "output_data_format": "microsoft.quantum-results.v1",
+            }
+        )
+        return config
 
 
 class RigettiSimulatorBackend(RigettiBackend):
     backend_names = RigettiTarget.simulators()
 
-    def __init__(
-        self,
-        name: str,
-        provider: "AzureQuantumProvider",
-        **kwargs
-    ):
+    def __init__(self, name: str, provider: "AzureQuantumProvider", **kwargs):
         """Base class for interfacing with an Rigetti Simulator backend"""
         default_config = BackendConfiguration.from_dict(
             {
@@ -92,19 +85,16 @@ class RigettiSimulatorBackend(RigettiBackend):
             }
         )
         logger.info("Initializing RigettiSimulatorBackend")
-        configuration: BackendConfiguration = kwargs.pop("configuration", default_config)
+        configuration: BackendConfiguration = kwargs.pop(
+            "configuration", default_config
+        )
         super().__init__(configuration=configuration, provider=provider, **kwargs)
 
 
 class RigettiQPUBackend(RigettiBackend):
     backend_names = RigettiTarget.qpus()
 
-    def __init__(
-        self,
-        name: str,
-        provider: "AzureQuantumProvider",
-        **kwargs
-    ):
+    def __init__(self, name: str, provider: "AzureQuantumProvider", **kwargs):
         """Base class for interfacing with a Rigetti QPU backend"""
         default_config = BackendConfiguration.from_dict(
             {
@@ -126,5 +116,7 @@ class RigettiQPUBackend(RigettiBackend):
             }
         )
         logger.info("Initializing RigettiQPUBackend")
-        configuration: BackendConfiguration = kwargs.pop("configuration", default_config)
+        configuration: BackendConfiguration = kwargs.pop(
+            "configuration", default_config
+        )
         super().__init__(configuration=configuration, provider=provider, **kwargs)

--- a/azure-quantum/azure/quantum/qiskit/backends/rigetti.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/rigetti.py
@@ -49,7 +49,7 @@ class RigettiBackend(AzureQirBackend):
     def _default_options(cls):
         return Options(count=500, targetCapability="BasicExecution")
 
-    def _azure_config(cls) -> dict[str, str]:
+    def _azure_config(self) -> dict[str, str]:
         config = super()._azure_config()
         config.update(
             {

--- a/azure-quantum/azure/quantum/qiskit/backends/rigetti.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/rigetti.py
@@ -6,11 +6,11 @@
 from typing import TYPE_CHECKING
 from azure.quantum.version import __version__
 from azure.quantum.target.rigetti import RigettiTarget
-
+from abc import abstractmethod
 from .backend import AzureQirBackend
 
 from qiskit.providers.models import BackendConfiguration
-from qiskit.providers import Options
+from qiskit.providers import Options, Provider
 
 QIR_BASIS_GATES = [
     "measure",
@@ -44,6 +44,12 @@ __all__ = ["RigettiSimulatorBackend" "RigettiQPUBackend"]
 
 class RigettiBackend(AzureQirBackend):
     """Base class for interfacing with a Rigetti backend in Azure Quantum"""
+
+    @abstractmethod
+    def __init__(
+        self, configuration: BackendConfiguration, provider: Provider = None, **fields
+    ):
+        super().__init__(configuration, provider, **fields)
 
     @classmethod
     def _default_options(cls):

--- a/azure-quantum/azure/quantum/qiskit/backends/rigetti.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/rigetti.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 ##
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict
 from azure.quantum.version import __version__
 from azure.quantum.target.rigetti import RigettiTarget
 from abc import abstractmethod
@@ -55,7 +55,7 @@ class RigettiBackend(AzureQirBackend):
     def _default_options(cls):
         return Options(count=500, targetCapability="BasicExecution")
 
-    def _azure_config(self) -> dict[str, str]:
+    def _azure_config(self) -> Dict[str, str]:
         config = super()._azure_config()
         config.update(
             {

--- a/azure-quantum/azure/quantum/qiskit/job.py
+++ b/azure-quantum/azure/quantum/qiskit/job.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 ##
 from collections import defaultdict
+from typing import Any, Dict, List, Union
 import numpy as np
 
 try:
@@ -85,7 +86,7 @@ class AzureQuantumJob(JobV1):
         results = self._format_results(sampler_seed=sampler_seed)
 
         result_dict = {
-            "results" : results,
+            "results" : results if isinstance(results, list) else [results],
             "job_id" : self._azure_job.details.id,
             "backend_name" : self._backend.name(),
             "backend_version" : self._backend.version,
@@ -127,7 +128,7 @@ class AzureQuantumJob(JobV1):
 
         return shots
 
-    def _format_results(self, sampler_seed=None):
+    def _format_results(self, sampler_seed=None) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
         """ Populates the results datastructures in a format that is compatible with qiskit libraries. """
 
         if (self._azure_job.details.output_data_format == MICROSOFT_OUTPUT_DATA_FORMAT_V2):
@@ -159,7 +160,7 @@ class AzureQuantumJob(JobV1):
             job_result["header"]["metadata"] = json.loads(job_result["header"]["metadata"])
 
         job_result["shots"] = self._shots_count()
-        return [job_result]
+        return job_result
 
     def _draw_random_sample(self, sampler_seed, probabilities, shots):
         _norm = sum(probabilities.values())
@@ -338,7 +339,7 @@ class AzureQuantumJob(JobV1):
         else:
             return ["main"]
 
-    def _format_microsoft_v2_results(self):
+    def _format_microsoft_v2_results(self) -> List[Dict[str, Any]]:
         success = self.details.status == "Succeeded"
 
         if not success:

--- a/azure-quantum/azure/quantum/qiskit/provider.py
+++ b/azure-quantum/azure/quantum/qiskit/provider.py
@@ -213,7 +213,10 @@ see https://aka.ms/AQ/Docs/AddProvider"
         configuration_filters = {}
         unknown_filters = {}
         for key, value in kwargs.items():
-            if all(
+            # If `any` of the backends has the key in its configuration, filter by it.
+            # qiskit API for this requires `all` backends to have the key in
+            # their configuration to be considered for filtering
+            if any(
                 _has_config_value(backend.configuration(), key) for backend in backends
             ):
                 configuration_filters[key] = value

--- a/azure-quantum/azure/quantum/qiskit/provider.py
+++ b/azure-quantum/azure/quantum/qiskit/provider.py
@@ -2,59 +2,73 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 ##
+
 try:
     from qiskit.providers import ProviderV1 as Provider
     from qiskit.providers.exceptions import QiskitBackendNotFoundError
+    from qiskit.providers import BackendV1 as Backend
+    from qiskit.exceptions import QiskitError
 except ImportError:
     raise ImportError(
-    "Missing optional 'qiskit' dependencies. \
+        "Missing optional 'qiskit' dependencies. \
 To install run: pip install azure-quantum[qiskit]"
     )
 
-from typing import Dict, Iterable
-from azure.quantum import Workspace
 
+from typing import Dict, List, Tuple, Type
+from azure.quantum import Workspace
+from azure.quantum.qiskit.backends.backend import AzureBackendBase
 from azure.quantum.qiskit.job import AzureQuantumJob
 from azure.quantum.qiskit.backends import *
+from itertools import groupby
+import warnings
+
+# Target ID keyword for parameter-free solvers
+PARAMETER_FREE = "parameterfree"
 
 QISKIT_USER_AGENT = "azure-quantum-qiskit"
 
 
 class AzureQuantumProvider(Provider):
     def __init__(self, workspace=None, **kwargs):
-        self._backends = None
         if workspace is None:
             workspace = Workspace(**kwargs)
 
         workspace.append_user_agent(QISKIT_USER_AGENT)
 
         self._workspace = workspace
+        self._backends = None
 
     def get_workspace(self) -> Workspace:
         return self._workspace
 
-    def _get_all_subclasses(self, cls):
-        all_subclasses = []
-        for subclass in cls.__subclasses__():
-            all_subclasses.append(subclass)
-            all_subclasses.extend(self._get_all_subclasses(subclass))
-        return all_subclasses
-
     def get_backend(self, name=None, **kwargs):
+        """Return a single backend matching the specified filtering.
+        Args:
+            name (str): name of the backend.
+            **kwargs: dict used for filtering.
+        Returns:
+            Backend: a backend matching the filtering.
+        Raises:
+            QiskitBackendNotFoundError: if no backend could be found or
+                more than one backend matches the filtering criteria.
         """
-        Return a single backend matching the specified filtering.
-        """
-        backends = self.backends(name, **kwargs)
+
+        backends = self.backends(name=name, **kwargs)
         if len(backends) > 1:
-            raise QiskitBackendNotFoundError("More than one backend matches the criteria")
+            raise QiskitBackendNotFoundError(
+                "More than one backend matches the criteria"
+            )
         if not backends:
-            raise QiskitBackendNotFoundError(f"Could not find target '{name}'. \
+            raise QiskitBackendNotFoundError(
+                f"Could not find target '{name}'. \
 Please make sure the target name is valid and that the associated provider is added to your Workspace. \
 To add a provider to your quantum workspace on the Azure Portal, \
-see https://aka.ms/AQ/Docs/AddProvider")
+see https://aka.ms/AQ/Docs/AddProvider"
+            )
         return backends[0]
 
-    def backends(self, name=None, provider_id=None, **kwargs):
+    def backends(self, name=None, **kwargs):
         """Return a list of backends matching the specified filtering.
         Args:
             name (str): name of the backend.
@@ -63,38 +77,179 @@ see https://aka.ms/AQ/Docs/AddProvider")
             list[Backend]: a list of Backends that match the filtering
                 criteria.
         """
-        from azure.quantum.target.target_factory import TargetFactory
-        from qiskit.providers import BackendV1 as Backend
-        from azure.quantum.qiskit.backends import DEFAULT_TARGETS
 
-        all_targets = {
-            name: _t for t in self._get_all_subclasses(Backend)
-            for _t in [t]
-            if hasattr(_t, "backend_names")
-            for name in _t.backend_names
-        }
+        # Lazy load backends
+        if self._backends is None:
+            self._backends = self._init_backends()
 
-        target_factory = TargetFactory(
-            base_cls=Backend,
-            workspace=self._workspace,
-            default_targets=DEFAULT_TARGETS,
-            all_targets=all_targets
+        if name:
+            if name not in self._backends:
+                raise QiskitBackendNotFoundError(
+                    f"The '{name}' backend is not installed in your system."
+                )
+
+        provider_id = kwargs.get("provider_id", None)
+
+        allowed_targets = self._get_allowed_targets_from_workspace(name, provider_id)
+
+        workspace_allowed = lambda backend: self._is_available_in_ws(
+            allowed_targets, backend
         )
 
-        targets = target_factory.get_targets(
-            name=name,
-            provider_id=provider_id,
-            provider=self,
-            **kwargs
+        # flatten the available backends
+        backend_list = [x for v in self._backends.values() for x in v]
+
+        # filter by properties specified in the kwargs and filter function
+        backends: List[Backend] = self._filter_backends(
+            backend_list, filters=workspace_allowed, **kwargs
         )
 
-        # Always return an iterable
-        if isinstance(targets, Iterable):
-            return targets
-        return [targets]
+        return backends
 
     def get_job(self, job_id) -> AzureQuantumJob:
-        """ Returns the Job instance associated with the given id."""
+        """Returns the Job instance associated with the given id."""
         azure_job = self._workspace.get_job(job_id)
         backend = self.get_backend(azure_job.details.target)
         return AzureQuantumJob(backend, azure_job)
+
+    def _is_available_in_ws(
+        self, allowed_targets: List[Tuple[str, str]], backend: Backend
+    ):
+        for name, provider in allowed_targets:
+            if backend.name() == name:
+                config = backend.configuration().to_dict()
+                if "azure" in config and "provider_id" in config["azure"]:
+                    if config["azure"]["provider_id"] == provider:
+                        return True
+        return False
+
+    def _get_allowed_targets_from_workspace(
+        self, name: str, provider_id: str
+    ) -> List[Tuple[str, str]]:
+        target_statuses = self._workspace._get_target_status(name, provider_id)
+        candidates: List[Tuple[str, str]] = []
+        for provider_id, status in target_statuses:
+            candidates.append((status.id, provider_id))
+        return candidates
+
+    def _get_leaf_subclasses(self, subtype: Type[Backend]):
+        subclasses = subtype.__subclasses__()
+        if subclasses:
+            for subclass in subclasses:
+                for leaf in self._get_leaf_subclasses(subclass):
+                    yield leaf
+        else:
+            yield subtype
+
+    def _init_backends(self) -> Dict[str, List[Backend]]:
+        instances: Dict[str, List[Backend]] = {}
+        subclasses = list(self._get_leaf_subclasses(subtype=AzureBackendBase))
+
+        for backend_cls in subclasses:
+            backend_names = self._backend_names(backend_cls)
+            if backend_names is None:
+                continue
+
+            for name in backend_names:
+                backend_instance: Backend = self._get_backend_instance(
+                    backend_cls, name
+                )
+                backend_name: str = backend_instance.name()
+                instances.setdefault(backend_name, []).append(backend_instance)
+
+        return instances
+
+    def _backend_names(self, backend_cls: Type[Backend]) -> List[str]:
+        if hasattr(backend_cls, "backend_names"):
+            return list(backend_cls.backend_names)
+        return None
+
+    def _get_backend_instance(self, backend_cls: Type[Backend], name: str) -> Backend:
+        try:
+            return backend_cls(name=name, provider=self)
+        except Exception as err:
+            raise QiskitError(
+                f"Backend {backend_cls} could not be instantiated: {err}"
+            ) from err
+
+    def _filter_backends(
+        self, backends: List[Backend], filters=None, **kwargs
+    ) -> List[Backend]:
+        """Return the backends matching the specified filtering.
+        Filter the `backends` list by their `configuration` attributes,
+        or from a boolean callable. The criteria for filtering can
+        be specified via `**kwargs` or as a callable via `filters`, and the
+        backends must fulfill all specified conditions.
+        Args:
+            backends (list[Backend]): list of backends.
+            filters (callable): filtering conditions as a callable.
+            **kwargs: dict of criteria.
+        Returns:
+            list[Backend]: a list of backend instances matching the
+                conditions.
+        """
+
+        def _match_all(obj, criteria):
+            """Return True if all items in criteria matches items in obj."""
+            return all(
+                _match_config(obj, key_, value_) for key_, value_ in criteria.items()
+            )
+
+        def _match_config(obj, key, value):
+            """Return True if the criteria matches the base config or azure config."""
+            return getattr(obj, key, None) == value or _match_azure_config(
+                obj, key, value
+            )
+
+        def _match_azure_config(obj, key, value):
+            """Return True if the criteria matches the azure config."""
+            azure_config = obj.to_dict().get("azure", {})
+            return azure_config.get(key, None) == value
+
+        def _has_config_value(obj, key):
+            """Return True if the key is found in the root config or azure config."""
+            return key in obj or key in obj.to_dict().get("azure", {})
+
+        configuration_filters = {}
+        unknown_filters = {}
+        for key, value in kwargs.items():
+            if all(
+                _has_config_value(backend.configuration(), key) for backend in backends
+            ):
+                configuration_filters[key] = value
+            else:
+                unknown_filters[key] = value
+
+        if configuration_filters:
+            backends = list(
+                filter(
+                    lambda backend: _match_all(
+                        backend.configuration(), configuration_filters
+                    ),
+                    backends,
+                )
+            )
+
+        if unknown_filters:
+            warnings.warn(
+                f"Specified filters {unknown_filters} are not supported by the available backends."
+            )
+
+        backends = list(filter(filters, backends))
+        
+        if len(backends) > 1:
+            def all_same(iterable):
+                group_iter = groupby(iterable)
+                return next(group_iter, True) and not next(group_iter, False)
+
+            # If all backends have the same name, filter for default backend
+            if all_same(backend.name() for backend in backends):
+                backends = list(
+                    filter(
+                        lambda backend: _match_all(
+                            backend.configuration(), {"is_default": True}
+                        ),
+                        backends,
+                    )
+                )
+        return backends

--- a/azure-quantum/environment-cirq-beta.yml
+++ b/azure-quantum/environment-cirq-beta.yml
@@ -13,7 +13,7 @@ dependencies:
     - cirq-ionq>=1.0.0
     - qiskit-ionq>=0.3.3
     - qiskit-terra>=0.19.1
-    - qiskit-qir>=0.3.0a1,<0.4
+    - qiskit-qir>=0.3.1,<0.4
     - azure-devtools>=1.2.0
     - asyncmock>=0.4.0
     - Markdown>=3.4.1

--- a/azure-quantum/environment-cirq-beta.yml
+++ b/azure-quantum/environment-cirq-beta.yml
@@ -13,7 +13,7 @@ dependencies:
     - cirq-ionq>=1.0.0
     - qiskit-ionq>=0.3.3
     - qiskit-terra>=0.19.1
-    - qiskit-qir>=0.2,<0.3
+    - qiskit-qir>=0.3.0a1,<0.4
     - azure-devtools>=1.2.0
     - asyncmock>=0.4.0
     - Markdown>=3.4.1

--- a/azure-quantum/environment.yml
+++ b/azure-quantum/environment.yml
@@ -13,7 +13,7 @@ dependencies:
     - cirq-ionq>=1.0.0
     - qiskit-ionq>=0.3.3
     - qiskit-terra>=0.19.1
-    - qiskit-qir>=0.3.0a1,<0.4
+    - qiskit-qir>=0.3.1,<0.4
     - azure-devtools>=1.2.0
     - asyncmock>=0.4.0
     - Markdown>=3.4.1

--- a/azure-quantum/environment.yml
+++ b/azure-quantum/environment.yml
@@ -13,7 +13,7 @@ dependencies:
     - cirq-ionq>=1.0.0
     - qiskit-ionq>=0.3.3
     - qiskit-terra>=0.19.1
-    - qiskit-qir>=0.2,<0.3
+    - qiskit-qir>=0.3.0a1,<0.4
     - azure-devtools>=1.2.0
     - asyncmock>=0.4.0
     - Markdown>=3.4.1

--- a/azure-quantum/setup.py
+++ b/azure-quantum/setup.py
@@ -83,7 +83,7 @@ setuptools.setup(
         "qiskit": [
             "qiskit-ionq>=0.3.3",
             "qiskit-terra>=0.19.1",
-            "qiskit-qir>=0.3.0a1,<0.4",
+            "qiskit-qir>=0.3.1,<0.4",
             "Markdown>=3.4.1",
             "python-markdown-math>=0.8"
         ],

--- a/azure-quantum/setup.py
+++ b/azure-quantum/setup.py
@@ -83,7 +83,7 @@ setuptools.setup(
         "qiskit": [
             "qiskit-ionq>=0.3.3",
             "qiskit-terra>=0.19.1",
-            "qiskit-qir>=0.2,<0.3",
+            "qiskit-qir>=0.3.0a1,<0.4",
             "Markdown>=3.4.1",
             "python-markdown-math>=0.8"
         ],

--- a/azure-quantum/tests/unit/recordings/test_qiskit_controlled_s_to_resource_estimator.yaml
+++ b/azure-quantum/tests/unit/recordings/test_qiskit_controlled_s_to_resource_estimator.yaml
@@ -13,7 +13,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - azsdk-python-identity/1.10.0 Python/3.7.13 (Darwin-21.6.0-x86_64-i386-64bit)
+      - azsdk-python-identity/1.10.0 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
       x-client-cpu:
       - x64
       x-client-current-telemetry:
@@ -23,7 +23,7 @@ interactions:
       x-client-sku:
       - MSAL.Python
       x-client-ver:
-      - 1.18.0
+      - 1.20.0
     method: POST
     uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
   response:
@@ -48,28 +48,17 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-21.6.0-x86_64-i386-64bit)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/providerStatus
   response:
     body:
-      string: '{"value": [{"id": "Microsoft.Simulator", "currentAvailability": "Available",
-        "targets": [{"id": "microsoft.simulator.resources-estimator", "currentAvailability":
-        "Available", "averageQueueTime": 0, "statusPage": null}]}, {"id": "microsoft-qc",
-        "currentAvailability": "Available", "targets": [{"id": "microsoft.estimator",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
-        {"id": "ionq", "currentAvailability": "Available", "targets": [{"id": "ionq.qpu",
-        "currentAvailability": "Available", "averageQueueTime": 8219, "statusPage":
-        "https://status.ionq.co"}, {"id": "ionq.qpu.aria-1", "currentAvailability":
-        "Available", "averageQueueTime": 614981, "statusPage": "https://status.ionq.co"},
-        {"id": "ionq.simulator", "currentAvailability": "Available", "averageQueueTime":
-        2, "statusPage": "https://status.ionq.co"}]}], "nextLink": null, "access_token":
-        "fake_token"}'
+      string: '{"value":[{"id":"microsoft-qc","currentAvailability":"Available","targets":[{"id":"microsoft.estimator","currentAvailability":"Available","averageQueueTime":0,"statusPage":null}]}],"nextLink":null,"access_token":"fake_token"}'
     headers:
       connection:
       - keep-alive
       content-length:
-      - '895'
+      - '226'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -91,7 +80,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-21.6.0-x86_64-i386-64bit)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
     method: POST
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
   response:
@@ -120,9 +109,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.13.1 Python/3.7.13 (Darwin-21.6.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.14.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Thu, 27 Oct 2022 13:16:35 GMT
+      - Tue, 14 Mar 2023 15:04:25 GMT
       x-ms-version:
       - '2021-08-06'
     method: GET
@@ -130,7 +119,7 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
-        specified container does not exist.\nRequestId:e877654a-101e-000f-0f06-eaeced000000\nTime:2022-10-27T13:16:36.1744939Z</Message></Error>"
+        specified container does not exist.\nRequestId:af9b606c-801e-00a4-3686-569327000000\nTime:2023-03-14T15:04:26.1783707Z</Message></Error>"
     headers:
       content-length:
       - '223'
@@ -153,9 +142,9 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.13.1 Python/3.7.13 (Darwin-21.6.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.14.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Thu, 27 Oct 2022 13:16:36 GMT
+      - Tue, 14 Mar 2023 15:04:26 GMT
       x-ms-version:
       - '2021-08-06'
     method: PUT
@@ -181,9 +170,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.13.1 Python/3.7.13 (Darwin-21.6.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.14.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Thu, 27 Oct 2022 13:16:36 GMT
+      - Tue, 14 Mar 2023 15:04:26 GMT
       x-ms-version:
       - '2021-08-06'
     method: GET
@@ -204,23 +193,23 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: b'BC\xc0\xde5\x14\x00\x00\x05\x00\x00\x00b\x0c0$JY\xbef]\xfb\xb5O\x0bQ\x80L\x01\x00\x00\x00!\x0c\x00\x009\x01\x00\x00\x0b\x02!\x00\x02\x00\x00\x00\x16\x00\x00\x00\x07\x81#\x91A\xc8\x04I\x06\x1029\x92\x01\x84\x0c%\x05\x08\x19\x1e\x04\x8bb\x80\x10E\x02B\x92\x0bB\x84\x102\x148\x08\x18K\n2B\x88Hp\xc4!#D\x12\x87\x8c\x10A\x92\x02d\xc8\x08\xb1\x14
-      CF\x88 \xc9\x012B\x84\x18*(*\x901|\xb0\\\x91 \xc4\xc8\x00\x00\x00\x89 \x00\x00\x0f\x00\x00\x002"\x08\t
-      d\x85\x04\x13"\xa4\x84\x04\x13"\xe3\x84\xa1\x90\x14\x12L\x88\x8c\x0b\x84\x84L\x100#\x00%\x00\x8a+T*@\xa61\x02\x80\xa6\x04DU\x04
-      \xba2\x00\x11\xe5@\x00\x00\x00\x00\x00Q\x18\x00\x00\x07\x00\x00\x00\x1b\x9c\xe0\xff\xff\xff\xff\x87\xa1\x14\xdc\x81\x1e\xe4!\x1f`\xe1\x1d\xd2\xc1\x1d\xe8\x01\x00\x00\x00\x00I\x18\x00\x00\x01\x00\x00\x00\x13\x82\x00\x00\x1a!L\x0e\x93qZ>\xae\xa7\xe9-\xd8\x90\n
-      \x02\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x18R\x11]\x01\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00@\x00C\xaa0\xb8\x0e
-      \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x18R\xe1\x81\x96\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x10\xc0\x90J\x16\xac\x03\x08\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80\x00\x86T\xe8\xc0\x1d@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04
-      \xb1A\xa0hO\x00\x00@,\x06\x93\x00\x00\x003\x08\x80\x1c\xc4\xe1\x1cf\x14\x01=\x88C8\x84\xc3\x8cB\x80\x07yx\x07s\x98q\x0c\xe6\x00\x0f\xed\x10\x0e\xf4\x80\x0e3\x0cB\x1e\xc2\xc1\x1d\xce\xa1\x1cf0\x05=\x88C8\x84\x83\x1b\xcc\x03=\xc8C=\x8c\x03=\xccx\x8ctp\x07{\x08\x07yH\x87pp\x07zp\x03vx\x87p
+    body: 'b''BC\xc0\xde5\x14\x00\x00\x05\x00\x00\x00b\x0c0$JY\xbef\x8d\xfb\xb4\xaf\x0bQ\x80L\x01\x00\x00\x00!\x0c\x00\x00\x8a\x01\x00\x00\x0b\x02!\x00\x02\x00\x00\x00\x16\x00\x00\x00\x07\x81#\x91A\xc8\x04I\x06\x1029\x92\x01\x84\x0c%\x05\x08\x19\x1e\x04\x8bb\x80\x10E\x02B\x92\x0bB\x84\x102\x148\x08\x18K\n2B\x88Hp\xc4!#D\x12\x87\x8c\x10A\x92\x02d\xc8\x08\xb1\x14
+      CF\x88 \xc9\x012B\x84\x18*(*\x901|\xb0\\\x91 \xc4\xc8\x00\x00\x00\x89 \x00\x00\x11\x00\x00\x002"\x08\t
+      bF\x00!+$\x98\x10!%$\x98\x10\x19\''\x0c\x85\xa4\x90`Bd\\ $d\x82\xa0\x19\x010\x01P`\xa1R\x012\x8d\x11\x004F\x00\xa22\x03\x10\xd1\r\x04\xcc\x11\x80\xc1\x1cA0G\x00\n\x00\x00Q\x18\x00\x00(\x00\x00\x00\x1b\xd6!\xf8\xff\xff\xff\xffa(\x07w\xa0\x07y\xc8\x87_\x80\x87wH\x07w\xa0\x07\x80p\x87zh\x87_\x90\x87r\x88\x87zH\x07y(\x07r\xf8\x85x\xa8\x07qH\x07z\x98\x07`\x0e\x00\xc2\x1d\xea\xa1\x1d~A\x1e\xca!\x1e\xea!\x1d\xe4\xa1\x1c\xc8\xe1\x17\xe4\xa1\x1c\xe6\xa1\x1e\xd8\x81\x1e\xe6\x01\x80\x03`x\x87z\xa0\x07x\xa8\x07z\xf8\x05v\x08\x07q(\x07vH\x07w8\x87_\x98\x87q@\x87rh\x87p\x00\x88xH\x07y\xf8\x05x\x90\x87w0\x87t`\x87r\x98\x07`\x1c\xeaa\x1e\xe8\xe1\x1d\xda\x01\x00\x00\x00\x00I\x18\x00\x00\x01\x00\x00\x00\x13\x82\x00\x00\x1a!\x0cY\x04\xc0$\x1cC*
+      \t\x00\x00\x08\x00\x00\x00\x00\x00\x00\x00\x00\x00\x12`H\x95\\\x05\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00@\x02\x0c\xa9\xc0@;\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x12`H\xa5\x07V\x01\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x90\x00\x12\x1b\x04\x8a:\x06\x00\x00d\x81\x00\x00\x07\x00\x00\x002\x1e\x98\x10\x19\x11L\x90\x8c\t&G\xc6\x04C\xd2\x12(\x87\x11\x00\xda\x11\x00\x00\x00\x00\x00\xb1\x18\x00\x00\x97\x00\x00\x003\x08\x80\x1c\xc4\xe1\x1cf\x14\x01=\x88C8\x84\xc3\x8cB\x80\x07yx\x07s\x98q\x0c\xe6\x00\x0f\xed\x10\x0e\xf4\x80\x0e3\x0cB\x1e\xc2\xc1\x1d\xce\xa1\x1cf0\x05=\x88C8\x84\x83\x1b\xcc\x03=\xc8C=\x8c\x03=\xccx\x8ctp\x07{\x08\x07yH\x87pp\x07zp\x03vx\x87p
       \x87\x19\xcc\x11\x0e\xec\x90\x0e\xe10\x0fn0\x0f\xe3\xf0\x0e\xf0P\x0e3\x10\xc4\x1d\xde!\x1c\xd8!\x1d\xc2a\x1ef0\x89;\xbc\x83;\xd0C9\xb4\x03<\xbc\x83<\x84\x03;\xcc\xf0\x14v`\x07{h\x077h\x87rh\x077\x80\x87p\x90\x87p`\x07v(\x07v\xf8\x05vx\x87w\x80\x87_\x08\x87q\x18\x87r\x98\x87y\x98\x81,\xee\xf0\x0e\xee\xe0\x0e\xf5\xc0\x0e\xec0\x03b\xc8\xa1\x1c\xe4\xa1\x1c\xcc\xa1\x1c\xe4\xa1\x1c\xdca\x1c\xca!\x1c\xc4\x81\x1d\xcaa\x06\xd6\x90C9\xc8C9\x98C9\xc8C9\xb8\xc38\x94C8\x88\x03;\x94\xc3/\xbc\x83<\xfc\x82;\xd4\x03;\xb0\xc3\x0c\xc7i\x87pX\x87rp\x83th\x07x`\x87t\x18\x87t\xa0\x87\x19\xceS\x0f\xee\x00\x0f\xf2P\x0e\xe4\x90\x0e\xe3@\x0f\xe1
       \x0e\xecP\x0e3 (\x1d\xdc\xc1\x1e\xc2A\x1e\xd2!\x1c\xdc\x81\x1e\xdc\xe0\x1c\xe4\xe1\x1d\xea\x01\x1ef\x18Q8\xb0C:\x9c\x83;\xccP$v`\x07{h\x077`\x87wx\x07x\x98QL\xf4\x90\x0f\xf0P\x0e3\x1ej\x1e\xcaa\x1c\xe8!\x1d\xde\xc1\x1d~\x01\x1e\xe4\xa1\x1c\xcc!\x1d\xf0a\x06T\x85\x838\xcc\xc3;\xb0C=\xd0C9\xfc\xc2<\xe4C;\x88\xc3;\xb0\xc3\x8c\xc5\n\x87y\x98\x87w\x18\x87t\x08\x07z(\x07r\x98\x81\\\xe3\x10\x0e\xec\xc0\x0e\xe5P\x0e\xf30#\xc1\xd2A\x1e\xe4\xe1\x17\xd8\xe1\x1d\xde\x01\x1efH\x19;\xb0\x83=\xb4\x83\x1b\x84\xc38\x8cC9\xcc\xc3<\xb8\xc19\xc8\xc3;\xd4\x03<\xccH\xb4q\x08\x07v`\x07q\x08\x87qX\x87\x19\xdb\xc6\x0e\xec`\x0f\xed\xe0\x06\xf0
-      \x0f\xe50\x0f\xe5 \x0f\xf6P\x0en\x10\x0e\xe30\x0e\xe50\x0f\xf3\xe0\x06\xe9\xe0\x0e\xe4P\x0e\xf80C\xe1\xda!\x1d\xe6\xa1\x1c\xf0\x01\x1e\xcaa\x1c\xe8aF\xd4\xd9\xc38\x84\x03;\xb0\xc3/\xd8C:\xccC:\x88C:\xb0C:\xd0C>\x00\xa9\x18\x00\x00\x19\x00\x00\x00\x0b\nr(\x87w\x80\x07zXp\x98C=\xb8\xc38\xb0C9\xd0\xc3\x82\xe6\x1c\xc6\xa1\r\xe8A\x1e\xc2\xc1\x1d\xe6!\x1d\xe8!\x1d\xde\xc1\x1d\x164\xe3`\x0e\xe7P\x0f\xe1
-      \x0f\xe4@\x0f\xe1 \x0f\xe7P\x0e\xf4\xb0\x80\x81\x07y(\x87p`\x07vx\x87q\x08\x07z(\x07rXp\x9c\xc38\xb4\x01;\xa4\x83=\x94\x03\x00\x00\x00\xd1\x10\x00\x00\x06\x00\x00\x00\x07\xcc<\xa4\x83;\x9c\x03;\x94\x03=\xa0\x83<\x94C8\x90\xc3\x01\x00\x00\x00a
-      \x00\x00#\x00\x00\x00\x13\x04\xc1\x88\x01\x01\x80 \x18\x14\xc5\x88\x01\x01\x80
-      \x18\x14\xc6\x88\x01\x01\x80 \x18\x14\xc7\x88A\x01\x80 \x18\x1c\xc70bP\x00 \x08\x06\xc7!\x8c\x18\x18\x00\x08\x82Ab\x0c\xc2\x88A\x01\x80
-      \x18\x1c\x850b`\x00 \x08\x06\x891\x08#\x06\x05\x00\x82`p\x10\xc2\x88A\x01\x80
-      \x18\x1c\xc40bP\x00 \x08\x06\x07\x11h8\x10\x00\x00\x00\x07\x00\x00\x00\x07P\x10\xcd\x14af`@T\x80L\xb4\x1d\x18\x10\x15
-      Sm\x08\x06D\x05\xc8d\x03\x00\x00\x00\x00\x00q \x00\x00\x03\x00\x00\x002\x0e\x10"\x84\x00\x98\x02\x00\x00\x00\x00\x00\x00\x00\x00]\x0c\x00\x002\x00\x00\x00\x12\x03\x94|\x01\x00\x00\x00main__quantum__rt__qubit_allocate__quantum__qis__t__body__quantum__qis__cnot__body__quantum__qis__t__adj__quantum__rt__qubit_release11.1.0
-      1fdec59bffc11ae37eb51a1b9869f0696bfd5312circuit-0\x00\x00\x00\x00'
+      \x0f\xe50\x0f\xe5 \x0f\xf6P\x0en\x10\x0e\xe30\x0e\xe50\x0f\xf3\xe0\x06\xe9\xe0\x0e\xe4P\x0e\xf80#\xe2\xeca\x1c\xc2\x81\x1d\xd8\xe1\x17\xec!\x1d\xe6!\x1d\xc4!\x1d\xd8!\x1d\xe8!\x1ff
+      \x9d;\xbcC=\xb8\x039\x94\x839\xccX\xbcpp\x07wx\x07z\x08\x07zH\x87wp\x07\x00\x00y
+      \x00\x00.\x00\x00\x00r\x1eH C\x88\x0c\x19\tr2H #\x81\x8c\x91\x91\xd1D\xa0\x10(d<12B\x8e\x90!\xa3H\x10\xb7\x00Q\x84e\x00qir_major_versionqir_minor_versiondynamic_qubit_managementdynamic_result_management\x00#\x08\n1\x82\xa0\x14#\x08\x8a1\x82\xb0\x1c3\x0cEP\xcc0\x18\xc21\xc3P\x0c\xc8\x0cCA
+      2\x12\x98\xa0\x8c\xd8\xd8\xec\xda\\\xda\xde\xc8\xea\xd8\xca\\\xcc\xd8\xc2\xce\xe6F!\x90DY\x00\x00\xa9\x18\x00\x00!\x00\x00\x00\x0b\nr(\x87w\x80\x07zXp\x98C=\xb8\xc38\xb0C9\xd0\xc3\x82\xe6\x1c\xc6\xa1\r\xe8A\x1e\xc2\xc1\x1d\xe6!\x1d\xe8!\x1d\xde\xc1\x1d\x164\xe3`\x0e\xe7P\x0f\xe1
+      \x0f\xe4@\x0f\xe1 \x0f\xe7P\x0e\xf4\xb0\x80\x81\x07y(\x87p`\x07vx\x87q\x08\x07z(\x07rXp\x9c\xc38\xb4\x01;\xa4\x83=\x94\xc3\x02k\x1c\xd8!\x1c\xdc\xe1\x1c\xdc
+      \x1c\xe4a\x1c\xdc \x1c\xe8\x81\x1e\xc2a\x1c\xd0\xa1\x1c\xc8a\x1c\xc2\x81\x1d\xd8\x01\xd1\x10\x00\x00\x06\x00\x00\x00\x07\xcc<\xa4\x83;\x9c\x03;\x94\x03=\xa0\x83<\x94C8\x90\xc3\x01\x00\x00\x00a
+      \x00\x00\x16\x00\x00\x00\x13\x04A,\x10\x00\x00\x00\x03\x00\x00\x00\xc4%@d\xca\x08#\x00\x00\x00\x00\x00#\x06\x05\x00\x82`P(\xc1\x88A\x01\x80
+      \x18\x14\x8a0b`\x00 \x08\x06G\x12\x08#\x06\x05\x00\x82`P \xc2\x88\x81\x01\x80
+      \x18\x1cI h8\x10\x02\x00\x00\x00\x07P\x10\xcd\x14a\x00\x00\x00\x00\x00\x00q
+      \x00\x00\x03\x00\x00\x002\x0e\x10"\x84\x00\xf6\x02\x00\x00\x00\x00\x00\x00\x00\x00]\x0c\x00\x00$\x00\x00\x00\x12\x03\x94$\x01\x00\x00\x00circuit-0__quantum__qis__t__body__quantum__qis__cnot__body__quantum__qis__t__adj14.0.6
+      f28c006a5895fc0e329fe15fead81e37457cb1d1batch\x00\x00\x00\x00'''
     headers:
       Accept:
       - application/xml
@@ -229,15 +218,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '4208'
+      - '4882'
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.13.1 Python/3.7.13 (Darwin-21.6.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.14.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Thu, 27 Oct 2022 13:16:37 GMT
+      - Tue, 14 Mar 2023 15:04:26 GMT
       x-ms-version:
       - '2021-08-06'
     method: PUT
@@ -257,12 +246,11 @@ interactions:
     body: 'b''{"id": "00000000-0000-0000-0000-000000000000", "name": "circuit-0",
       "containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
       "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData",
-      "inputDataFormat": "qir.v1", "inputParams": {"entryPoint": "main", "arguments":
-      [], "targetCapability": "AdaptiveExecution", "errorBudget": 0.001, "qubitParams":
+      "inputDataFormat": "qir.v1", "inputParams": {"errorBudget": 0.001, "qubitParams":
       {"name": "qubit_gate_ns_e3"}, "qecScheme": {"name": "surface_code"}, "count":
-      null, "shots": null}, "providerId": "microsoft-qc", "target": "microsoft.estimator",
-      "metadata": {"qiskit": "True", "name": "circuit-0", "num_qubits": "3", "metadata":
-      "null"}, "outputDataFormat": "microsoft.resource-estimates.v1"}'''
+      null, "shots": null, "items": [{"entryPoint": "circuit-0", "arguments": []}]},
+      "providerId": "microsoft-qc", "target": "microsoft.estimator", "metadata": {},
+      "outputDataFormat": "microsoft.resource-estimates.v1"}'''
     headers:
       Accept:
       - application/json
@@ -271,76 +259,33 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '818'
+      - '719'
       Content-Type:
       - application/json
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-21.6.0-x86_64-i386-64bit)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
     method: PUT
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
         "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=rcw",
-        "inputDataFormat": "qir.v1", "inputParams": {"entryPoint": "main", "arguments":
-        [], "targetCapability": "AdaptiveExecution", "errorBudget": 0.001, "qubitParams":
+        "inputDataFormat": "qir.v1", "inputParams": {"errorBudget": 0.001, "qubitParams":
         {"name": "qubit_gate_ns_e3"}, "qecScheme": {"name": "surface_code"}, "count":
-        null, "shots": null}, "providerId": "microsoft-qc", "target": "microsoft.estimator",
-        "metadata": {"qiskit": "True", "name": "circuit-0", "num_qubits": "3", "metadata":
-        "null"}, "name": "circuit-0", "id": "00000000-0000-0000-0000-000000000000",
-        "status": "Waiting", "jobType": "Unknown", "outputDataFormat": "microsoft.resource-estimates.v1",
-        "outputDataUri": "https://mystorage.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "creationTime": "2022-10-27T13:16:37.4852681+00:00", "beginExecutionTime":
-        null, "endExecutionTime": null, "cancellationTime": null, "costEstimate":
-        null, "quantumComputingData": null, "errorData": null, "isCancelling": false,
-        "tags": [], "access_token": "fake_token"}'
-    headers:
-      connection:
-      - keep-alive
-      content-length:
-      - '1367'
-      content-type:
-      - application/json; charset=utf-8
-      transfer-encoding:
-      - chunked
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-21.6.0-x86_64-i386-64bit)
-    method: GET
-    uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
-  response:
-    body:
-      string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-0-942fdc3a-55f9-11ed-9713-acde48001122.input.json",
-        "inputDataFormat": "qir.v1", "inputParams": {"entryPoint": "main", "arguments":
-        [], "targetCapability": "AdaptiveExecution", "errorBudget": 0.001, "qubitParams":
-        {"name": "qubit_gate_ns_e3"}, "qecScheme": {"name": "surface_code"}, "count":
-        null, "shots": null}, "providerId": "microsoft-qc", "target": "microsoft.estimator",
-        "metadata": {"qiskit": "True", "name": "circuit-0", "num_qubits": "3", "metadata":
-        "null"}, "name": "circuit-0", "id": "00000000-0000-0000-0000-000000000000",
-        "status": "Succeeded", "jobType": "QuantumComputing", "outputDataFormat":
-        "microsoft.resource-estimates.v1", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-0-942fdc3a-55f9-11ed-9713-acde48001122.output.json",
-        "creationTime": "2022-10-27T13:16:37.4852681+00:00", "beginExecutionTime":
-        "2022-10-27T13:16:33.2111476Z", "endExecutionTime": "2022-10-27T13:16:37.9231295Z",
-        "cancellationTime": null, "costEstimate": null, "quantumComputingData": {"count":
-        1}, "errorData": null, "isCancelling": false, "tags": [], "access_token":
+        null, "shots": null, "items": [{"entryPoint": "circuit-0", "arguments": []}]},
+        "metadata": {}, "sessionId": null, "status": "Waiting", "jobType": "QuantumComputing",
+        "outputDataFormat": "microsoft.resource-estimates.v1", "outputDataUri": "https://mystorage.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "beginExecutionTime": null, "cancellationTime": null, "quantumComputingData":
+        null, "errorData": null, "isCancelling": false, "tags": [], "name": "circuit-0",
+        "id": "00000000-0000-0000-0000-000000000000", "providerId": "microsoft-qc",
+        "target": "microsoft.estimator", "creationTime": "2023-03-14T15:04:27.4543972+00:00",
+        "endExecutionTime": null, "costEstimate": null, "itemType": "Job", "access_token":
         "fake_token"}'
     headers:
       connection:
       - keep-alive
       content-length:
-      - '1606'
+      - '1315'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -358,31 +303,29 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-21.6.0-x86_64-i386-64bit)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-0-942fdc3a-55f9-11ed-9713-acde48001122.input.json",
-        "inputDataFormat": "qir.v1", "inputParams": {"entryPoint": "main", "arguments":
-        [], "targetCapability": "AdaptiveExecution", "errorBudget": 0.001, "qubitParams":
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-0-81cb094c-c279-11ed-8d97-acde48001122.input.json",
+        "inputDataFormat": "qir.v1", "inputParams": {"errorBudget": 0.001, "qubitParams":
         {"name": "qubit_gate_ns_e3"}, "qecScheme": {"name": "surface_code"}, "count":
-        null, "shots": null}, "providerId": "microsoft-qc", "target": "microsoft.estimator",
-        "metadata": {"qiskit": "True", "name": "circuit-0", "num_qubits": "3", "metadata":
-        "null"}, "name": "circuit-0", "id": "00000000-0000-0000-0000-000000000000",
-        "status": "Succeeded", "jobType": "QuantumComputing", "outputDataFormat":
-        "microsoft.resource-estimates.v1", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-0-942fdc3a-55f9-11ed-9713-acde48001122.output.json",
-        "creationTime": "2022-10-27T13:16:37.4852681+00:00", "beginExecutionTime":
-        "2022-10-27T13:16:33.2111476Z", "endExecutionTime": "2022-10-27T13:16:37.9231295Z",
-        "cancellationTime": null, "costEstimate": null, "quantumComputingData": {"count":
-        1}, "errorData": null, "isCancelling": false, "tags": [], "access_token":
-        "fake_token"}'
+        null, "shots": null, "items": [{"entryPoint": "circuit-0", "arguments": []}]},
+        "metadata": {}, "sessionId": null, "status": "Succeeded", "jobType": "QuantumComputing",
+        "outputDataFormat": "microsoft.resource-estimates.v1", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-0-81cb094c-c279-11ed-8d97-acde48001122.output.json",
+        "beginExecutionTime": "2023-03-14T15:04:52.7065237Z", "cancellationTime":
+        null, "quantumComputingData": {"count": 1}, "errorData": null, "isCancelling":
+        false, "tags": [], "name": "circuit-0", "id": "00000000-0000-0000-0000-000000000000",
+        "providerId": "microsoft-qc", "target": "microsoft.estimator", "creationTime":
+        "2023-03-14T15:04:27.4543972+00:00", "endExecutionTime": "2023-03-14T15:04:57.9135222Z",
+        "costEstimate": null, "itemType": "Job", "access_token": "fake_token"}'
     headers:
       connection:
       - keep-alive
       content-length:
-      - '1606'
+      - '1545'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -400,31 +343,29 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-21.6.0-x86_64-i386-64bit)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-0-942fdc3a-55f9-11ed-9713-acde48001122.input.json",
-        "inputDataFormat": "qir.v1", "inputParams": {"entryPoint": "main", "arguments":
-        [], "targetCapability": "AdaptiveExecution", "errorBudget": 0.001, "qubitParams":
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-0-81cb094c-c279-11ed-8d97-acde48001122.input.json",
+        "inputDataFormat": "qir.v1", "inputParams": {"errorBudget": 0.001, "qubitParams":
         {"name": "qubit_gate_ns_e3"}, "qecScheme": {"name": "surface_code"}, "count":
-        null, "shots": null}, "providerId": "microsoft-qc", "target": "microsoft.estimator",
-        "metadata": {"qiskit": "True", "name": "circuit-0", "num_qubits": "3", "metadata":
-        "null"}, "name": "circuit-0", "id": "00000000-0000-0000-0000-000000000000",
-        "status": "Succeeded", "jobType": "QuantumComputing", "outputDataFormat":
-        "microsoft.resource-estimates.v1", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-0-942fdc3a-55f9-11ed-9713-acde48001122.output.json",
-        "creationTime": "2022-10-27T13:16:37.4852681+00:00", "beginExecutionTime":
-        "2022-10-27T13:16:33.2111476Z", "endExecutionTime": "2022-10-27T13:16:37.9231295Z",
-        "cancellationTime": null, "costEstimate": null, "quantumComputingData": {"count":
-        1}, "errorData": null, "isCancelling": false, "tags": [], "access_token":
-        "fake_token"}'
+        null, "shots": null, "items": [{"entryPoint": "circuit-0", "arguments": []}]},
+        "metadata": {}, "sessionId": null, "status": "Succeeded", "jobType": "QuantumComputing",
+        "outputDataFormat": "microsoft.resource-estimates.v1", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-0-81cb094c-c279-11ed-8d97-acde48001122.output.json",
+        "beginExecutionTime": "2023-03-14T15:04:52.7065237Z", "cancellationTime":
+        null, "quantumComputingData": {"count": 1}, "errorData": null, "isCancelling":
+        false, "tags": [], "name": "circuit-0", "id": "00000000-0000-0000-0000-000000000000",
+        "providerId": "microsoft-qc", "target": "microsoft.estimator", "creationTime":
+        "2023-03-14T15:04:27.4543972+00:00", "endExecutionTime": "2023-03-14T15:04:57.9135222Z",
+        "costEstimate": null, "itemType": "Job", "access_token": "fake_token"}'
     headers:
       connection:
       - keep-alive
       content-length:
-      - '1606'
+      - '1545'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -442,28 +383,57 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-21.6.0-x86_64-i386-64bit)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
+  response:
+    body:
+      string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-0-81cb094c-c279-11ed-8d97-acde48001122.input.json",
+        "inputDataFormat": "qir.v1", "inputParams": {"errorBudget": 0.001, "qubitParams":
+        {"name": "qubit_gate_ns_e3"}, "qecScheme": {"name": "surface_code"}, "count":
+        null, "shots": null, "items": [{"entryPoint": "circuit-0", "arguments": []}]},
+        "metadata": {}, "sessionId": null, "status": "Succeeded", "jobType": "QuantumComputing",
+        "outputDataFormat": "microsoft.resource-estimates.v1", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-0-81cb094c-c279-11ed-8d97-acde48001122.output.json",
+        "beginExecutionTime": "2023-03-14T15:04:52.7065237Z", "cancellationTime":
+        null, "quantumComputingData": {"count": 1}, "errorData": null, "isCancelling":
+        false, "tags": [], "name": "circuit-0", "id": "00000000-0000-0000-0000-000000000000",
+        "providerId": "microsoft-qc", "target": "microsoft.estimator", "creationTime":
+        "2023-03-14T15:04:27.4543972+00:00", "endExecutionTime": "2023-03-14T15:04:57.9135222Z",
+        "costEstimate": null, "itemType": "Job", "access_token": "fake_token"}'
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '1545'
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/providerStatus
   response:
     body:
-      string: '{"value": [{"id": "Microsoft.Simulator", "currentAvailability": "Available",
-        "targets": [{"id": "microsoft.simulator.resources-estimator", "currentAvailability":
-        "Available", "averageQueueTime": 0, "statusPage": null}]}, {"id": "microsoft-qc",
-        "currentAvailability": "Available", "targets": [{"id": "microsoft.estimator",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
-        {"id": "ionq", "currentAvailability": "Available", "targets": [{"id": "ionq.qpu",
-        "currentAvailability": "Available", "averageQueueTime": 8219, "statusPage":
-        "https://status.ionq.co"}, {"id": "ionq.qpu.aria-1", "currentAvailability":
-        "Available", "averageQueueTime": 614981, "statusPage": "https://status.ionq.co"},
-        {"id": "ionq.simulator", "currentAvailability": "Available", "averageQueueTime":
-        2, "statusPage": "https://status.ionq.co"}]}], "nextLink": null, "access_token":
-        "fake_token"}'
+      string: '{"value":[{"id":"microsoft-qc","currentAvailability":"Available","targets":[{"id":"microsoft.estimator","currentAvailability":"Available","averageQueueTime":0,"statusPage":null}]}],"nextLink":null,"access_token":"fake_token"}'
     headers:
       connection:
       - keep-alive
       content-length:
-      - '895'
+      - '226'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -481,31 +451,29 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-21.6.0-x86_64-i386-64bit)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-0-942fdc3a-55f9-11ed-9713-acde48001122.input.json",
-        "inputDataFormat": "qir.v1", "inputParams": {"entryPoint": "main", "arguments":
-        [], "targetCapability": "AdaptiveExecution", "errorBudget": 0.001, "qubitParams":
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-0-81cb094c-c279-11ed-8d97-acde48001122.input.json",
+        "inputDataFormat": "qir.v1", "inputParams": {"errorBudget": 0.001, "qubitParams":
         {"name": "qubit_gate_ns_e3"}, "qecScheme": {"name": "surface_code"}, "count":
-        null, "shots": null}, "providerId": "microsoft-qc", "target": "microsoft.estimator",
-        "metadata": {"qiskit": "True", "name": "circuit-0", "num_qubits": "3", "metadata":
-        "null"}, "name": "circuit-0", "id": "00000000-0000-0000-0000-000000000000",
-        "status": "Succeeded", "jobType": "QuantumComputing", "outputDataFormat":
-        "microsoft.resource-estimates.v1", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-0-942fdc3a-55f9-11ed-9713-acde48001122.output.json",
-        "creationTime": "2022-10-27T13:16:37.4852681+00:00", "beginExecutionTime":
-        "2022-10-27T13:16:33.2111476Z", "endExecutionTime": "2022-10-27T13:16:37.9231295Z",
-        "cancellationTime": null, "costEstimate": null, "quantumComputingData": {"count":
-        1}, "errorData": null, "isCancelling": false, "tags": [], "access_token":
-        "fake_token"}'
+        null, "shots": null, "items": [{"entryPoint": "circuit-0", "arguments": []}]},
+        "metadata": {}, "sessionId": null, "status": "Succeeded", "jobType": "QuantumComputing",
+        "outputDataFormat": "microsoft.resource-estimates.v1", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-0-81cb094c-c279-11ed-8d97-acde48001122.output.json",
+        "beginExecutionTime": "2023-03-14T15:04:52.7065237Z", "cancellationTime":
+        null, "quantumComputingData": {"count": 1}, "errorData": null, "isCancelling":
+        false, "tags": [], "name": "circuit-0", "id": "00000000-0000-0000-0000-000000000000",
+        "providerId": "microsoft-qc", "target": "microsoft.estimator", "creationTime":
+        "2023-03-14T15:04:27.4543972+00:00", "endExecutionTime": "2023-03-14T15:04:57.9135222Z",
+        "costEstimate": null, "itemType": "Job", "access_token": "fake_token"}'
     headers:
       connection:
       - keep-alive
       content-length:
-      - '1606'
+      - '1545'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -523,31 +491,29 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-21.6.0-x86_64-i386-64bit)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-0-942fdc3a-55f9-11ed-9713-acde48001122.input.json",
-        "inputDataFormat": "qir.v1", "inputParams": {"entryPoint": "main", "arguments":
-        [], "targetCapability": "AdaptiveExecution", "errorBudget": 0.001, "qubitParams":
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-0-81cb094c-c279-11ed-8d97-acde48001122.input.json",
+        "inputDataFormat": "qir.v1", "inputParams": {"errorBudget": 0.001, "qubitParams":
         {"name": "qubit_gate_ns_e3"}, "qecScheme": {"name": "surface_code"}, "count":
-        null, "shots": null}, "providerId": "microsoft-qc", "target": "microsoft.estimator",
-        "metadata": {"qiskit": "True", "name": "circuit-0", "num_qubits": "3", "metadata":
-        "null"}, "name": "circuit-0", "id": "00000000-0000-0000-0000-000000000000",
-        "status": "Succeeded", "jobType": "QuantumComputing", "outputDataFormat":
-        "microsoft.resource-estimates.v1", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-0-942fdc3a-55f9-11ed-9713-acde48001122.output.json",
-        "creationTime": "2022-10-27T13:16:37.4852681+00:00", "beginExecutionTime":
-        "2022-10-27T13:16:33.2111476Z", "endExecutionTime": "2022-10-27T13:16:37.9231295Z",
-        "cancellationTime": null, "costEstimate": null, "quantumComputingData": {"count":
-        1}, "errorData": null, "isCancelling": false, "tags": [], "access_token":
-        "fake_token"}'
+        null, "shots": null, "items": [{"entryPoint": "circuit-0", "arguments": []}]},
+        "metadata": {}, "sessionId": null, "status": "Succeeded", "jobType": "QuantumComputing",
+        "outputDataFormat": "microsoft.resource-estimates.v1", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-0-81cb094c-c279-11ed-8d97-acde48001122.output.json",
+        "beginExecutionTime": "2023-03-14T15:04:52.7065237Z", "cancellationTime":
+        null, "quantumComputingData": {"count": 1}, "errorData": null, "isCancelling":
+        false, "tags": [], "name": "circuit-0", "id": "00000000-0000-0000-0000-000000000000",
+        "providerId": "microsoft-qc", "target": "microsoft.estimator", "creationTime":
+        "2023-03-14T15:04:27.4543972+00:00", "endExecutionTime": "2023-03-14T15:04:57.9135222Z",
+        "costEstimate": null, "itemType": "Job", "access_token": "fake_token"}'
     headers:
       connection:
       - keep-alive
       content-length:
-      - '1606'
+      - '1545'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -565,31 +531,69 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-21.6.0-x86_64-i386-64bit)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-0-942fdc3a-55f9-11ed-9713-acde48001122.input.json",
-        "inputDataFormat": "qir.v1", "inputParams": {"entryPoint": "main", "arguments":
-        [], "targetCapability": "AdaptiveExecution", "errorBudget": 0.001, "qubitParams":
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-0-81cb094c-c279-11ed-8d97-acde48001122.input.json",
+        "inputDataFormat": "qir.v1", "inputParams": {"errorBudget": 0.001, "qubitParams":
         {"name": "qubit_gate_ns_e3"}, "qecScheme": {"name": "surface_code"}, "count":
-        null, "shots": null}, "providerId": "microsoft-qc", "target": "microsoft.estimator",
-        "metadata": {"qiskit": "True", "name": "circuit-0", "num_qubits": "3", "metadata":
-        "null"}, "name": "circuit-0", "id": "00000000-0000-0000-0000-000000000000",
-        "status": "Succeeded", "jobType": "QuantumComputing", "outputDataFormat":
-        "microsoft.resource-estimates.v1", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-0-942fdc3a-55f9-11ed-9713-acde48001122.output.json",
-        "creationTime": "2022-10-27T13:16:37.4852681+00:00", "beginExecutionTime":
-        "2022-10-27T13:16:33.2111476Z", "endExecutionTime": "2022-10-27T13:16:37.9231295Z",
-        "cancellationTime": null, "costEstimate": null, "quantumComputingData": {"count":
-        1}, "errorData": null, "isCancelling": false, "tags": [], "access_token":
-        "fake_token"}'
+        null, "shots": null, "items": [{"entryPoint": "circuit-0", "arguments": []}]},
+        "metadata": {}, "sessionId": null, "status": "Succeeded", "jobType": "QuantumComputing",
+        "outputDataFormat": "microsoft.resource-estimates.v1", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-0-81cb094c-c279-11ed-8d97-acde48001122.output.json",
+        "beginExecutionTime": "2023-03-14T15:04:52.7065237Z", "cancellationTime":
+        null, "quantumComputingData": {"count": 1}, "errorData": null, "isCancelling":
+        false, "tags": [], "name": "circuit-0", "id": "00000000-0000-0000-0000-000000000000",
+        "providerId": "microsoft-qc", "target": "microsoft.estimator", "creationTime":
+        "2023-03-14T15:04:27.4543972+00:00", "endExecutionTime": "2023-03-14T15:04:57.9135222Z",
+        "costEstimate": null, "itemType": "Job", "access_token": "fake_token"}'
     headers:
       connection:
       - keep-alive
       content-length:
-      - '1606'
+      - '1545'
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
+  response:
+    body:
+      string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-0-81cb094c-c279-11ed-8d97-acde48001122.input.json",
+        "inputDataFormat": "qir.v1", "inputParams": {"errorBudget": 0.001, "qubitParams":
+        {"name": "qubit_gate_ns_e3"}, "qecScheme": {"name": "surface_code"}, "count":
+        null, "shots": null, "items": [{"entryPoint": "circuit-0", "arguments": []}]},
+        "metadata": {}, "sessionId": null, "status": "Succeeded", "jobType": "QuantumComputing",
+        "outputDataFormat": "microsoft.resource-estimates.v1", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-0-81cb094c-c279-11ed-8d97-acde48001122.output.json",
+        "beginExecutionTime": "2023-03-14T15:04:52.7065237Z", "cancellationTime":
+        null, "quantumComputingData": {"count": 1}, "errorData": null, "isCancelling":
+        false, "tags": [], "name": "circuit-0", "id": "00000000-0000-0000-0000-000000000000",
+        "providerId": "microsoft-qc", "target": "microsoft.estimator", "creationTime":
+        "2023-03-14T15:04:27.4543972+00:00", "endExecutionTime": "2023-03-14T15:04:57.9135222Z",
+        "costEstimate": null, "itemType": "Job", "access_token": "fake_token"}'
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '1545'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -607,15 +611,15 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.13.1 Python/3.7.13 (Darwin-21.6.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.14.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Thu, 27 Oct 2022 13:16:47 GMT
+      - Tue, 14 Mar 2023 15:05:05 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
       - '2021-08-06'
     method: GET
-    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-0-942fdc3a-55f9-11ed-9713-acde48001122.output.json
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-0-81cb094c-c279-11ed-8d97-acde48001122.output.json
   response:
     body:
       string: '{"errorBudget": {"logical": 0.0005, "rotations": 0.0, "tstates": 0.0005},
@@ -627,72 +631,78 @@ interactions:
         "50 ns", "oneQubitMeasurementErrorRate": 0.001, "oneQubitMeasurementTime":
         "100 ns", "tGateErrorRate": 0.001, "tGateTime": "50 ns", "twoQubitGateErrorRate":
         0.001, "twoQubitGateTime": "50 ns"}}, "logicalCounts": {"ccixCount": 0, "cczCount":
-        0, "measurementCount": 0, "numQubits": 3, "rotationCount": 0, "rotationDepth":
+        0, "measurementCount": 0, "numQubits": 2, "rotationCount": 0, "rotationDepth":
         0, "tCount": 3}, "logicalQubit": {"codeDistance": 7, "logicalCycleTime": 2800.0,
         "logicalErrorRate": 3.0000000000000013e-06, "physicalQubits": 98}, "physicalCounts":
-        {"breakdown": {"algorithmicLogicalDepth": 3, "algorithmicLogicalQubits": 12,
+        {"breakdown": {"algorithmicLogicalDepth": 3, "algorithmicLogicalQubits": 9,
         "cliffordErrorRate": 0.001, "logicalDepth": 13, "numTfactories": 3, "numTfactoryRuns":
         1, "numTsPerRotation": null, "numTstates": 3, "physicalQubitsForAlgorithm":
-        1176, "physicalQubitsForTfactories": 11760, "requiredLogicalQubitErrorRate":
-        3.2051282051282054e-06, "requiredLogicalTstateErrorRate": 0.00016666666666666666},
-        "physicalQubits": 12936, "runtime": 36400}, "physicalCountsFormatted": {"codeDistancePerRound":
+        882, "physicalQubitsForTfactories": 11760, "requiredLogicalQubitErrorRate":
+        4.273504273504274e-06, "requiredLogicalTstateErrorRate": 0.00016666666666666666},
+        "physicalQubits": 12642, "runtime": 36400}, "physicalCountsFormatted": {"codeDistancePerRound":
         "7", "errorBudget": "1.00e-3", "errorBudgetLogical": "5.00e-4", "errorBudgetRotations":
         "0.00e0", "errorBudgetTstates": "5.00e-4", "logicalCycleTime": "2us 800ns",
         "logicalErrorRate": "3.00e-6", "numTsPerRotation": "No rotations in algorithm",
-        "numUnitsPerRound": "2", "physicalQubitsForTfactoriesPercentage": "90.91 %",
-        "physicalQubitsPerRound": "3920", "requiredLogicalQubitErrorRate": "3.21e-6",
+        "numUnitsPerRound": "2", "physicalQubitsForTfactoriesPercentage": "93.02 %",
+        "physicalQubitsPerRound": "3920", "requiredLogicalQubitErrorRate": "4.27e-6",
         "requiredLogicalTstateErrorRate": "1.67e-4", "runtime": "36us 400ns", "tfactoryRuntime":
         "36us 400ns", "tfactoryRuntimePerRound": "36us 400ns", "tstateLogicalErrorRate":
         "2.13e-5", "unitNamePerRound": "15-to-1 space efficient logical"}, "reportData":
-        {"assumptions": ["**Uniform independent physical noise.** We assume that the
-        noise on physical qubits and physical qubit operations is the standard circuit
-        noise model. In particular we assume error events at different space-time
-        locations are independent and that error rates are uniform across the system
-        in time and space.", "**Efficient classical computation.** We assume that
-        classical overhead (compilation, control, feedback, readout, decoding, etc.)
-        does not dominate the overall cost of implementing the full quantum algorithm.",
-        "**Extraction circuits for planar quantum ISA.** We assume that stabilizer
-        extraction circuits with similar depth and error correction performance to
-        those for standard surface and Hastings-Haah code patches can be constructed
-        to implement all operations of the planar quantum ISA.", "**Uniform independent
-        logical noise.** We assume that the error rate of a logical operation is approximately
-        equal to its space-time volume (the number of tiles multiplied by the number
-        of logical time steps) multiplied by the error rate of a logical qubit in
-        a standard one-tile patch in one logical time step.", "**Negligible Clifford
-        costs for synthesis.** We assume that the space overhead for synthesis and
-        space and time overhead for transport of magic states within magic state factories
-        and to synthesis qubits are all negligible.", "**Smooth magic state consumption
+        {"assumptions": ["_More details on the following lists of assumptions can
+        be found in the paper [Accessing requirements for scaling quantum computers
+        and their applications](https://aka.ms/AQ/RE/Paper)._", "**Uniform independent
+        physical noise.** We assume that the noise on physical qubits and physical
+        qubit operations is the standard circuit noise model. In particular we assume
+        error events at different space-time locations are independent and that error
+        rates are uniform across the system in time and space.", "**Efficient classical
+        computation.** We assume that classical overhead (compilation, control, feedback,
+        readout, decoding, etc.) does not dominate the overall cost of implementing
+        the full quantum algorithm.", "**Extraction circuits for planar quantum ISA.**
+        We assume that stabilizer extraction circuits with similar depth and error
+        correction performance to those for standard surface and Hastings-Haah code
+        patches can be constructed to implement all operations of the planar quantum
+        ISA (instruction set architecture).", "**Uniform independent logical noise.**
+        We assume that the error rate of a logical operation is approximately equal
+        to its space-time volume (the number of tiles multiplied by the number of
+        logical time steps) multiplied by the error rate of a logical qubit in a standard
+        one-tile patch in one logical time step.", "**Negligible Clifford costs for
+        synthesis.** We assume that the space overhead for synthesis and space and
+        time overhead for transport of magic states within magic state factories and
+        to synthesis qubits are all negligible.", "**Smooth magic state consumption
         rate.** We assume that the rate of T state consumption throughout the compiled
         algorithm is almost constant, or can be made almost constant without significantly
         increasing the number of logical time steps for the algorithm."], "groups":
         [{"alwaysVisible": true, "entries": [{"description": "Number of physical qubits",
         "explanation": "This value represents the total number of physical qubits,
-        which is the sum of 1176 physical qubits required to implement the algorithm
-        logic, and 11760 physical qubits required by the T factories that are responsible
-        to produce the required T states that are consumed by the algorithm.", "label":
-        "Physical qubits", "path": "physicalCounts/physicalQubits"}, {"description":
-        "Total runtime in nanoseconds", "explanation": "This is a runtime estimate
-        in nanoseconds for the execution time of the algorithm.  In general, the execution
-        time corresponds to the duration of one logical cycle (2us 800ns) multiplied
-        by the 3 logical cycles required to run the algorithm.  If however the duration
-        of a single T factory (here: 36us 400ns) is larger than the algorithm runtime,
-        we extend the number of logical cycles artificially in order to exceed the
-        runtime of a single T factory.", "label": "Runtime", "path": "physicalCountsFormatted/runtime"}],
+        which is the sum of 882 physical qubits to implement the algorithm logic,
+        and 11760 physical qubits to execute the T factories that are responsible
+        to produce the T states that are consumed by the algorithm.", "label": "Physical
+        qubits", "path": "physicalCounts/physicalQubits"}, {"description": "Total
+        runtime", "explanation": "This is a runtime estimate (in nanosecond precision)
+        for the execution time of the algorithm.  In general, the execution time corresponds
+        to the duration of one logical cycle (2us 800ns) multiplied by the 3 logical
+        cycles to run the algorithm.  If however the duration of a single T factory
+        (here: 36us 400ns) is larger than the algorithm runtime, we extend the number
+        of logical cycles artificially in order to exceed the runtime of a single
+        T factory.", "label": "Runtime", "path": "physicalCountsFormatted/runtime"}],
         "title": "Physical resource estimates"}, {"alwaysVisible": false, "entries":
-        [{"description": "Number of logical qubits required for the algorithm after
-        layout", "explanation": "Laying out the logical qubits in the presence of
-        nearest-neighbor constraints requires additional logical qubits.  In particular,
-        to layout the 3 logical qubits in the input algorithm, we require in total
-        $2 \\cdot 3 + \\cdot \\lceil \\sqrt{8 \\cdot 3}\\rceil + 1$ logical qubits.",
-        "label": "Logical algorithmic qubits", "path": "physicalCounts/breakdown/algorithmicLogicalQubits"},
-        {"description": "Number of logical cycles required for the algorithm", "explanation":
-        "To execute the algorithm using multi-qubit measurements, we require one multi-qubit
-        measurement for the 0 single-qubit measurements, the 0 arbitrary single-qubit
-        rotations, and the 3 T gates, three multi-qubit measurements for each of the
-        0 CCZ and 0 CCiX gates in the input program, as well as No rotations in algorithm
-        multi-qubit measurements for each of the 0 non-Clifford layers in which there
-        is at least one single-qubit rotation with an arbitrary angle rotation.",
-        "label": "Algorithmic depth", "path": "physicalCounts/breakdown/algorithmicLogicalDepth"},
+        [{"description": "Number of logical qubits for the algorithm after layout",
+        "explanation": "Laying out the logical qubits in the presence of nearest-neighbor
+        constraints requires additional logical qubits.  In particular, to layout
+        the $Q_{\\rm alg} = 2$ logical qubits in the input algorithm, we require in
+        total $2 \\cdot Q_{\\rm alg} + \\lceil \\sqrt{8 \\cdot Q_{\\rm alg}}\\rceil
+        + 1 = 9$ logical qubits.", "label": "Logical algorithmic qubits", "path":
+        "physicalCounts/breakdown/algorithmicLogicalQubits"}, {"description": "Number
+        of logical cycles for the algorithm", "explanation": "To execute the algorithm
+        using _Parallel Synthesis Sequential Pauli Computation_ (PSSPC), operations
+        are scheduled in terms of multi-qubit Pauli measurements, for which assume
+        an execution time of one logical cycle.  Based on the input algorithm, we
+        require one multi-qubit measurement for the 0 single-qubit measurements, the
+        0 arbitrary single-qubit rotations, and the 3 T gates, three multi-qubit measurements
+        for each of the 0 CCZ and 0 CCiX gates in the input program, as well as No
+        rotations in algorithm multi-qubit measurements for each of the 0 non-Clifford
+        layers in which there is at least one single-qubit rotation with an arbitrary
+        angle rotation.", "label": "Algorithmic depth", "path": "physicalCounts/breakdown/algorithmicLogicalDepth"},
         {"description": "Number of logical cycles performed", "explanation": "This
         number is usually equal to the logical depth of the algorithm, which is 3.  However,
         in the case in which a single T factory is slower than the execution time
@@ -710,40 +720,38 @@ interactions:
         per T factory} \\cdot 36us 400ns\\;\\text{algorithm runtime}}\\right\\rceil$",
         "label": "Number of T factories", "path": "physicalCounts/breakdown/numTfactories"},
         {"description": "Number of times all T factories are invoked", "explanation":
-        "In order to prepare the required 3 T states, the 3 copies of the T factory
-        are repeatedly invoked 1 times.", "label": "Number of T factory invocations",
-        "path": "physicalCounts/breakdown/numTfactoryRuns"}, {"description": "Number
-        of physical qubits required for the algorithm after layout", "explanation":
-        "The 1176 are the product of the 12 required logical qubits after layout and
-        the 98 physical qubits that encode a single logical qubit.", "label": "Physical
-        algorithmic qubits", "path": "physicalCounts/breakdown/physicalQubitsForAlgorithm"},
-        {"description": "Number of physical qubits required for the T factories",
-        "explanation": "Each T factory requires 3920 physical qubits and we run 3
-        in parallel, therefore we need $11760 = 3920 \\cdot 3$ qubits.", "label":
-        "Physical T factory qubits", "path": "physicalCounts/breakdown/physicalQubitsForTfactories"},
-        {"description": "The minimum logical qubit error rate required to run the
-        algorithm within the error budget", "explanation": "The required logical qubit
-        error rate is obtained by dividing the logical error probability 5.00e-4 by
-        the product of 12 logical qubits and the total cycle count 13.", "label":
-        "Required logical qubit error rate", "path": "physicalCountsFormatted/requiredLogicalQubitErrorRate"},
+        "In order to prepare the 3 T states, the 3 copies of the T factory are repeatedly
+        invoked 1 times.", "label": "Number of T factory invocations", "path": "physicalCounts/breakdown/numTfactoryRuns"},
+        {"description": "Number of physical qubits for the algorithm after layout",
+        "explanation": "The 882 are the product of the 9 logical qubits after layout
+        and the 98 physical qubits that encode a single logical qubit.", "label":
+        "Physical algorithmic qubits", "path": "physicalCounts/breakdown/physicalQubitsForAlgorithm"},
+        {"description": "Number of physical qubits for the T factories", "explanation":
+        "Each T factory requires 3920 physical qubits and we run 3 in parallel, therefore
+        we need $11760 = 3920 \\cdot 3$ qubits.", "label": "Physical T factory qubits",
+        "path": "physicalCounts/breakdown/physicalQubitsForTfactories"}, {"description":
+        "The minimum logical qubit error rate required to run the algorithm within
+        the error budget", "explanation": "The minimum logical qubit error rate is
+        obtained by dividing the logical error probability 5.00e-4 by the product
+        of 9 logical qubits and the total cycle count 13.", "label": "Required logical
+        qubit error rate", "path": "physicalCountsFormatted/requiredLogicalQubitErrorRate"},
         {"description": "The minimum T state error rate required for distilled T states",
-        "explanation": "The required T state error rate is obtained by dividing the
+        "explanation": "The minimum T state error rate is obtained by dividing the
         T distillation error probability 5.00e-4 by the total number of T states 3.",
         "label": "Required logical T state error rate", "path": "physicalCountsFormatted/requiredLogicalTstateErrorRate"},
-        {"description": "Required number of T states to implement a rotation with
-        an arbitrary angle", "explanation": "The number of T states required to implement
-        a rotation with an arbitrary angle is $\\lceil 0.53 \\log_2(0 / 0) + 5.3\\rceil$
-        [[arXiv:2203.10064](https://arxiv.org/abs/2203.10064)].  For simplicity, we
-        use this formula for all single-qubit arbitrary angle rotations, and do not
-        distinguish between best, worst, and average cases.", "label": "Number of
-        T states per rotation", "path": "physicalCountsFormatted/numTsPerRotation"}],
-        "title": "Resource breakdown"}, {"alwaysVisible": false, "entries": [{"description":
-        "Name of QEC scheme", "explanation": "You can load pre-defined QEC schemes
-        by using the name `surface_code` or `floquet_code`. The latter only works
-        with Majorana qubits.", "label": "QEC scheme", "path": "jobParams/qecScheme/name"},
+        {"description": "Number of T states to implement a rotation with an arbitrary
+        angle", "explanation": "The number of T states to implement a rotation with
+        an arbitrary angle is $\\lceil 0.53 \\log_2(0 / 0) + 5.3\\rceil$ [[arXiv:2203.10064](https://arxiv.org/abs/2203.10064)].  For
+        simplicity, we use this formula for all single-qubit arbitrary angle rotations,
+        and do not distinguish between best, worst, and average cases.", "label":
+        "Number of T states per rotation", "path": "physicalCountsFormatted/numTsPerRotation"}],
+        "title": "Resource estimates breakdown"}, {"alwaysVisible": false, "entries":
+        [{"description": "Name of QEC scheme", "explanation": "You can load pre-defined
+        QEC schemes by using the name `surface_code` or `floquet_code`. The latter
+        only works with Majorana qubits.", "label": "QEC scheme", "path": "jobParams/qecScheme/name"},
         {"description": "Required code distance for error correction", "explanation":
         "The code distance is the smallest odd integer greater or equal to $\\dfrac{2\\log(0.03
-        / 0.0000032051282051282054)}{\\log(0.01/0.001)} - 1$", "label": "Code distance",
+        / 0.000004273504273504274)}{\\log(0.01/0.001)} - 1$", "label": "Code distance",
         "path": "logicalQubit/codeDistance"}, {"description": "Number of physical
         qubits per logical qubit", "explanation": "The number of physical qubits per
         logical qubit are evaluated using the formula 2 * codeDistance * codeDistance
@@ -754,7 +762,7 @@ interactions:
         be user-specified.", "label": "Logical cycle time", "path": "physicalCountsFormatted/logicalCycleTime"},
         {"description": "Logical qubit error rate", "explanation": "The logical qubit
         error rate is computed as $0.03 \\cdot \\left(\\dfrac{0.001}{0.01}\\right)^\\frac{7
-        + 1}{1}$", "label": "Logical qubit error rate", "path": "physicalCountsFormatted/logicalErrorRate"},
+        + 1}{2}$", "label": "Logical qubit error rate", "path": "physicalCountsFormatted/logicalErrorRate"},
         {"description": "Crossing prefactor used in QEC scheme", "explanation": "The
         crossing prefactor is usually extracted numerically from simulations when
         fitting an exponential curve to model the relationship between logical and
@@ -773,26 +781,26 @@ interactions:
         the number of physical qubits per logical qubits 98.", "label": "Physical
         qubits formula", "path": "jobParams/qecScheme/physicalQubitsPerLogicalQubit"}],
         "title": "Logical qubit parameters"}, {"alwaysVisible": false, "entries":
-        [{"description": "Number of physical qubits required for a single T factory",
-        "explanation": "This corresponds to the maximum number of physical qubits
-        over all rounds of T distillation units in a T factory.  A round of distillation
-        contains of multiple copies of distillation units to achieve the required
-        success probability of producing a T state with the expected logical T state
-        error rate.", "label": "Physical qubits", "path": "tfactory/physicalQubits"},
-        {"description": "Runtime of a single T factory", "explanation": "The runtime
-        of a single T factory is the accumulated runtime of executing each round in
-        a T factory.", "label": "Runtime", "path": "physicalCountsFormatted/tfactoryRuntime"},
-        {"description": "Number of output T states produced in a single run of T factory",
-        "explanation": "The T factory takes as input 30 noisy physical T states with
-        an error rate of 0.001 and produces 1 T states with an error rate of 2.13e-5.",
-        "label": "Number of output T states per run", "path": "tfactory/numTstates"},
-        {"description": "Number of physical input T states consumed in a single run
-        of a T factory", "explanation": "This value includes the physical input T
-        states of all copies of the distillation unit in the first round.", "label":
-        "Number of input T states per run", "path": "tfactory/numInputTstates"}, {"description":
-        "The number of distillation rounds", "explanation": "This is the number of
-        distillation rounds.  In each round one or multiple copies of some distillation
-        unit is executed.", "label": "Distillation rounds", "path": "tfactory/numRounds"},
+        [{"description": "Number of physical qubits for a single T factory", "explanation":
+        "This corresponds to the maximum number of physical qubits over all rounds
+        of T distillation units in a T factory.  A round of distillation contains
+        of multiple copies of distillation units to achieve the required success probability
+        of producing a T state with the expected logical T state error rate.", "label":
+        "Physical qubits", "path": "tfactory/physicalQubits"}, {"description": "Runtime
+        of a single T factory", "explanation": "The runtime of a single T factory
+        is the accumulated runtime of executing each round in a T factory.", "label":
+        "Runtime", "path": "physicalCountsFormatted/tfactoryRuntime"}, {"description":
+        "Number of output T states produced in a single run of T factory", "explanation":
+        "The T factory takes as input 30 noisy physical T states with an error rate
+        of 0.001 and produces 1 T states with an error rate of 2.13e-5.", "label":
+        "Number of output T states per run", "path": "tfactory/numTstates"}, {"description":
+        "Number of physical input T states consumed in a single run of a T factory",
+        "explanation": "This value includes the physical input T states of all copies
+        of the distillation unit in the first round.", "label": "Number of input T
+        states per run", "path": "tfactory/numInputTstates"}, {"description": "The
+        number of distillation rounds", "explanation": "This is the number of distillation
+        rounds.  In each round one or multiple copies of some distillation unit is
+        executed.", "label": "Distillation rounds", "path": "tfactory/numRounds"},
         {"description": "The number of units in each round of distillation", "explanation":
         "This is the number of copies for the distillation units per round.", "label":
         "Distillation units per round", "path": "physicalCountsFormatted/numUnitsPerRound"},
@@ -808,91 +816,93 @@ interactions:
         logical qubits.", "label": "Distillation code distances", "path": "physicalCountsFormatted/codeDistancePerRound"},
         {"description": "The number of physical qubits used in each round of distillation",
         "explanation": "The maximum number of physical qubits over all rounds is the
-        number of physical qubits required for the T factory, since qubits are reused
-        by different rounds.", "label": "Number of physical qubits per round", "path":
-        "physicalCountsFormatted/physicalQubitsPerRound"}, {"description": "The runtime
-        of each distillation round", "explanation": "The runtime of the T factory
-        is the sum of the runtimes in all rounds.", "label": "Runtime per round",
-        "path": "physicalCountsFormatted/tfactoryRuntimePerRound"}, {"description":
-        "Logical T state error rate", "explanation": "This is the logical T state
-        error rate achieved by the T factory which is equal or smaller than the required
-        error rate 1.67e-4.", "label": "Logical T state error rate", "path": "physicalCountsFormatted/tstateLogicalErrorRate"}],
-        "title": "T factory parameters"}, {"alwaysVisible": false, "entries": [{"description":
-        "Number of logical qubits in the input quantum program", "explanation": "We
-        determine 12 from this number by assuming to align them in a 2D grid.  Auxiliary
-        qubits are added to allow for sufficient space to execute multi-qubit Pauli
-        measurements on all or a subset of the logical qubits.", "label": "Logical
-        qubits (pre-layout)", "path": "logicalCounts/numQubits"}, {"description":
-        "Number of T gates in the input quantum program", "explanation": "This includes
-        all T gates and adjoint T gates, but not T gates required to implement rotation
-        gates with arbitrary angle, CCZ gates, or CCiX gates.", "label": "T gates",
-        "path": "logicalCounts/tCount"}, {"description": "Number of rotation gates
-        in the input quantum program", "explanation": "This is the number of all rotation
-        gates. If an angle corresponds to a Pauli, Clifford, or T gate, it is not
-        accounted for in this number.", "label": "Rotation gates", "path": "logicalCounts/rotationCount"},
-        {"description": "Depth of rotation gates in the input quantum program", "explanation":
-        "This is the number of all non-Clifford layers that include at least one single-qubit
-        rotation gate with an arbitrary angle.", "label": "Rotation depth", "path":
-        "logicalCounts/rotationDepth"}, {"description": "Number of CCZ-gates in the
-        input quantum program", "explanation": "This is the number of CCZ gates.",
-        "label": "CCZ gates", "path": "logicalCounts/cczCount"}, {"description": "Number
-        of CCiX-gates in the input quantum program", "explanation": "This is the number
-        of CCiX gates, which applies $-iX$ controlled on two control qubits [[1212.5069](https://arxiv.org/abs/1212.5069)].",
-        "label": "CCiX gates", "path": "logicalCounts/ccixCount"}, {"description":
-        "Number of single qubit measurements in the input quantum program", "explanation":
-        "This is the number of single qubit measurements in Pauli basis that are used
-        in the input program.  Note that all measurements are counted, however, the
-        measurement result is is determined randomly (with a fixed seed) to be 0 or
-        1 with a probability of 50%.", "label": "Measurement operations", "path":
-        "logicalCounts/measurementCount"}], "title": "Pre-layout logical resources"},
-        {"alwaysVisible": false, "entries": [{"description": "Total error budget for
-        the algorithm", "explanation": "The total error budget sets the overall allowed
-        error for the algorithm, i.e., the number of times it is allowed to fail.  Its
-        value must be between 0 and 1 and the default value is 0.001, which corresponds
-        to 0.1%, and means that the algorithm is allowed to fail once in 1000 executions.  This
-        parameter is highly application specific. For example, if one is running Shor''s
-        algorithm for factoring integers, a large value for the error budget may be
-        tolerated as one can check that the output are indeed the prime factors of
-        the input.  On the other hand, a much smaller error budget may be needed for
-        an algorithm solving a problem with a solution which cannot be efficiently
-        verified.  This budget $\\epsilon = \\epsilon_{\\log} + \\epsilon_{\\rm dis}
-        + \\epsilon_{\\rm syn}$ is uniformly distributed and applies to errors $\\epsilon_{\\log}$
-        to implement logical qubits, an error budget $\\epsilon_{\\rm dis}$ to produce
-        T states through distillation, and an error budget $\\epsilon_{\\rm syn}$
-        to synthesize rotation gates with arbitrary angles.  Note that for distillation
-        and rotation synthesis, the respective error budgets $\\epsilon_{\\rm dis}$
-        and $\\epsilon_{\\rm syn}$ are uniformly distributed among all required T
-        states and all required rotation gates, respectively. If there are no rotation
-        gates in the input algorithm, the error budget is uniformly distributed to
-        logical errors and T state errors.", "label": "Total error budget", "path":
-        "physicalCountsFormatted/errorBudget"}, {"description": "Probability of at
-        least one logical error", "explanation": "This is one third of the total error
-        budget 1.00e-3 if the input algorithm contains rotation with gates with arbitrary
-        angles, or one half of it, otherwise.", "label": "Logical error probability",
-        "path": "physicalCountsFormatted/errorBudgetLogical"}, {"description": "Probability
-        of at least one faulty T distillation", "explanation": "This is one third
+        number of physical qubits for the T factory, since qubits are reused by different
+        rounds.", "label": "Number of physical qubits per round", "path": "physicalCountsFormatted/physicalQubitsPerRound"},
+        {"description": "The runtime of each distillation round", "explanation": "The
+        runtime of the T factory is the sum of the runtimes in all rounds.", "label":
+        "Runtime per round", "path": "physicalCountsFormatted/tfactoryRuntimePerRound"},
+        {"description": "Logical T state error rate", "explanation": "This is the
+        logical T state error rate achieved by the T factory which is equal or smaller
+        than the required error rate 1.67e-4.", "label": "Logical T state error rate",
+        "path": "physicalCountsFormatted/tstateLogicalErrorRate"}], "title": "T factory
+        parameters"}, {"alwaysVisible": false, "entries": [{"description": "Number
+        of logical qubits in the input quantum program", "explanation": "We determine
+        9 from this number by assuming to align them in a 2D grid.  Auxiliary qubits
+        are added to allow for sufficient space to execute multi-qubit Pauli measurements
+        on all or a subset of the logical qubits.", "label": "Logical qubits (pre-layout)",
+        "path": "logicalCounts/numQubits"}, {"description": "Number of T gates in
+        the input quantum program", "explanation": "This includes all T gates and
+        adjoint T gates, but not T gates used to implement rotation gates with arbitrary
+        angle, CCZ gates, or CCiX gates.", "label": "T gates", "path": "logicalCounts/tCount"},
+        {"description": "Number of rotation gates in the input quantum program", "explanation":
+        "This is the number of all rotation gates. If an angle corresponds to a Pauli,
+        Clifford, or T gate, it is not accounted for in this number.", "label": "Rotation
+        gates", "path": "logicalCounts/rotationCount"}, {"description": "Depth of
+        rotation gates in the input quantum program", "explanation": "This is the
+        number of all non-Clifford layers that include at least one single-qubit rotation
+        gate with an arbitrary angle.", "label": "Rotation depth", "path": "logicalCounts/rotationDepth"},
+        {"description": "Number of CCZ-gates in the input quantum program", "explanation":
+        "This is the number of CCZ gates.", "label": "CCZ gates", "path": "logicalCounts/cczCount"},
+        {"description": "Number of CCiX-gates in the input quantum program", "explanation":
+        "This is the number of CCiX gates, which applies $-iX$ controlled on two control
+        qubits [[1212.5069](https://arxiv.org/abs/1212.5069)].", "label": "CCiX gates",
+        "path": "logicalCounts/ccixCount"}, {"description": "Number of single qubit
+        measurements in the input quantum program", "explanation": "This is the number
+        of single qubit measurements in Pauli basis that are used in the input program.  Note
+        that all measurements are counted, however, the measurement result is is determined
+        randomly (with a fixed seed) to be 0 or 1 with a probability of 50%.", "label":
+        "Measurement operations", "path": "logicalCounts/measurementCount"}], "title":
+        "Pre-layout logical resources"}, {"alwaysVisible": false, "entries": [{"description":
+        "Total error budget for the algorithm", "explanation": "The total error budget
+        sets the overall allowed error for the algorithm, i.e., the number of times
+        it is allowed to fail.  Its value must be between 0 and 1 and the default
+        value is 0.001, which corresponds to 0.1%, and means that the algorithm is
+        allowed to fail once in 1000 executions.  This parameter is highly application
+        specific. For example, if one is running Shor''s algorithm for factoring integers,
+        a large value for the error budget may be tolerated as one can check that
+        the output are indeed the prime factors of the input.  On the other hand,
+        a much smaller error budget may be needed for an algorithm solving a problem
+        with a solution which cannot be efficiently verified.  This budget $\\epsilon
+        = \\epsilon_{\\log} + \\epsilon_{\\rm dis} + \\epsilon_{\\rm syn}$ is uniformly
+        distributed and applies to errors $\\epsilon_{\\log}$ to implement logical
+        qubits, an error budget $\\epsilon_{\\rm dis}$ to produce T states through
+        distillation, and an error budget $\\epsilon_{\\rm syn}$ to synthesize rotation
+        gates with arbitrary angles.  Note that for distillation and rotation synthesis,
+        the respective error budgets $\\epsilon_{\\rm dis}$ and $\\epsilon_{\\rm syn}$
+        are uniformly distributed among all T states and all rotation gates, respectively.
+        If there are no rotation gates in the input algorithm, the error budget is
+        uniformly distributed to logical errors and T state errors.", "label": "Total
+        error budget", "path": "physicalCountsFormatted/errorBudget"}, {"description":
+        "Probability of at least one logical error", "explanation": "This is one third
         of the total error budget 1.00e-3 if the input algorithm contains rotation
         with gates with arbitrary angles, or one half of it, otherwise.", "label":
-        "T distillation error probability", "path": "physicalCountsFormatted/errorBudgetTstates"},
+        "Logical error probability", "path": "physicalCountsFormatted/errorBudgetLogical"},
+        {"description": "Probability of at least one faulty T distillation", "explanation":
+        "This is one third of the total error budget 1.00e-3 if the input algorithm
+        contains rotation with gates with arbitrary angles, or one half of it, otherwise.",
+        "label": "T distillation error probability", "path": "physicalCountsFormatted/errorBudgetTstates"},
         {"description": "Probability of at least one failed rotation synthesis", "explanation":
         "This is one third of the total error budget 1.00e-3.", "label": "Rotation
         synthesis error probability", "path": "physicalCountsFormatted/errorBudgetRotations"}],
         "title": "Assumed error budget"}, {"alwaysVisible": false, "entries": [{"description":
         "Some descriptive name for the qubit model", "explanation": "You can load
         pre-defined qubit parameters by using the names `qubit_gate_ns_e3`, `qubit_gate_ns_e4`,
-        `qubit_gate_us_e3`, `qubit_gate_us_e4`, `qubit_maj_ns_e4`, or `qubit_maj_ns_e6`.",
-        "label": "Qubit name", "path": "jobParams/qubitParams/name"}, {"description":
-        "Underlying qubit technology (gate-based or Majorana)", "explanation": "When
-        modeling the physical qubit abstractions, we distinguish between two different
-        physical instruction sets that are used to operate the qubits.  The physical
-        instruction set can be either *gate-based* or *Majorana*.  A gate-based instruction
-        set provides single-qubit measurement, single-qubit gates (incl. T gates),
-        and two-qubit gates.  A Majorana instruction set provides a physical T gate,
-        single-qubit measurement and two-qubit joint measurement operations.", "label":
-        "Instruction set", "path": "jobParams/qubitParams/instructionSet"}, {"description":
-        "Operation time for single-qubit measurement (t_meas) in ns", "explanation":
-        "This is the operation time in nanoseconds to perform a single-qubit measurement
-        in the Pauli basis.", "label": "Single-qubit measurement time", "path": "jobParams/qubitParams/oneQubitMeasurementTime"},
+        `qubit_gate_us_e3`, `qubit_gate_us_e4`, `qubit_maj_ns_e4`, or `qubit_maj_ns_e6`.  The
+        names of these pre-defined qubit parameters indicate the instruction set (gate-based
+        or Majorana), the operation speed (ns or \u00ac\u00b5s regime), as well as
+        the fidelity (e.g., e3 for $10^{-3}$ gate error rates).", "label": "Qubit
+        name", "path": "jobParams/qubitParams/name"}, {"description": "Underlying
+        qubit technology (gate-based or Majorana)", "explanation": "When modeling
+        the physical qubit abstractions, we distinguish between two different physical
+        instruction sets that are used to operate the qubits.  The physical instruction
+        set can be either *gate-based* or *Majorana*.  A gate-based instruction set
+        provides single-qubit measurement, single-qubit gates (incl. T gates), and
+        two-qubit gates.  A Majorana instruction set provides a physical T gate, single-qubit
+        measurement and two-qubit joint measurement operations.", "label": "Instruction
+        set", "path": "jobParams/qubitParams/instructionSet"}, {"description": "Operation
+        time for single-qubit measurement (t_meas) in ns", "explanation": "This is
+        the operation time in nanoseconds to perform a single-qubit measurement in
+        the Pauli basis.", "label": "Single-qubit measurement time", "path": "jobParams/qubitParams/oneQubitMeasurementTime"},
         {"description": "Operation time for single-qubit gate (t_gate) in ns", "explanation":
         "This is the operation time in nanoseconds to perform a single-qubit Clifford
         operation, e.g., Hadamard or Phase gates.", "label": "Single-qubit gate time",
@@ -926,17 +936,17 @@ interactions:
       accept-ranges:
       - bytes
       content-length:
-      - '24370'
+      - '24892'
       content-range:
-      - bytes 0-23706/23707
+      - bytes 0-24219/24220
       content-type:
       - application/json
       x-ms-blob-content-md5:
-      - eFbQihrsdEENwzXwc1mvyg==
+      - UpzQizhyzH+vKU2/mu3baw==
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Thu, 27 Oct 2022 13:16:38 GMT
+      - Tue, 14 Mar 2023 15:04:52 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:

--- a/azure-quantum/tests/unit/recordings/test_qiskit_controlled_s_to_resource_estimator_with_high_error_rate.yaml
+++ b/azure-quantum/tests/unit/recordings/test_qiskit_controlled_s_to_resource_estimator_with_high_error_rate.yaml
@@ -13,7 +13,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - azsdk-python-identity/1.10.0 Python/3.7.13 (Darwin-22.2.0-x86_64-i386-64bit)
+      - azsdk-python-identity/1.10.0 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
       x-client-cpu:
       - x64
       x-client-current-telemetry:
@@ -23,7 +23,7 @@ interactions:
       x-client-sku:
       - MSAL.Python
       x-client-ver:
-      - 1.18.0
+      - 1.20.0
     method: POST
     uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
   response:
@@ -48,43 +48,17 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.2.0-x86_64-i386-64bit)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/providerStatus
   response:
     body:
-      string: '{"value": [{"id": "microsoft-qc", "currentAvailability": "Available",
-        "targets": [{"id": "microsoft.estimator", "currentAvailability": "Available",
-        "averageQueueTime": 0, "statusPage": null}]}, {"id": "ionq", "currentAvailability":
-        "Available", "targets": [{"id": "ionq.qpu", "currentAvailability": "Available",
-        "averageQueueTime": 58319, "statusPage": "https://status.ionq.co"}, {"id":
-        "ionq.qpu.aria-1", "currentAvailability": "Available", "averageQueueTime":
-        1946503, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
-        "currentAvailability": "Available", "averageQueueTime": 1, "statusPage": "https://status.ionq.co"},
-        {"id": "ionq.qpu-preview", "currentAvailability": "Available", "averageQueueTime":
-        58319, "statusPage": "https://status.ionq.co"}, {"id": "ionq.qpu.aria-1-preview",
-        "currentAvailability": "Available", "averageQueueTime": 1946503, "statusPage":
-        "https://status.ionq.co"}, {"id": "ionq.simulator-preview", "currentAvailability":
-        "Available", "averageQueueTime": 1, "statusPage": "https://status.ionq.co"}]},
-        {"id": "Microsoft.Test", "currentAvailability": "Available", "targets": [{"id":
-        "echo-rigetti", "currentAvailability": "Available", "averageQueueTime": 1,
-        "statusPage": ""}, {"id": "echo-quantinuum", "currentAvailability": "Available",
-        "averageQueueTime": 1, "statusPage": ""}, {"id": "echo-qci", "currentAvailability":
-        "Available", "averageQueueTime": 1, "statusPage": ""}, {"id": "echo-output",
-        "currentAvailability": "Available", "averageQueueTime": 1, "statusPage": ""}]},
-        {"id": "rigetti", "currentAvailability": "Degraded", "targets": [{"id": "rigetti.sim.qvm",
-        "currentAvailability": "Available", "averageQueueTime": 5, "statusPage": "https://rigetti.statuspage.io/"},
-        {"id": "rigetti.qpu.aspen-11", "currentAvailability": "Unavailable", "averageQueueTime":
-        0, "statusPage": null}, {"id": "rigetti.qpu.aspen-m-2", "currentAvailability":
-        "Available", "averageQueueTime": 5, "statusPage": "https://rigetti.statuspage.io/"},
-        {"id": "rigetti.qpu.aspen-m-3", "currentAvailability": "Available", "averageQueueTime":
-        5, "statusPage": "https://rigetti.statuspage.io/"}]}], "nextLink": null, "access_token":
-        "fake_token"}'
+      string: '{"value":[{"id":"microsoft-qc","currentAvailability":"Available","targets":[{"id":"microsoft.estimator","currentAvailability":"Available","averageQueueTime":0,"statusPage":null}]}],"nextLink":null,"access_token":"fake_token"}'
     headers:
       connection:
       - keep-alive
       content-length:
-      - '2162'
+      - '226'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -106,7 +80,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.2.0-x86_64-i386-64bit)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
     method: POST
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/storage/sasUri
   response:
@@ -135,9 +109,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.13.1 Python/3.7.13 (Darwin-22.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.14.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Wed, 11 Jan 2023 09:22:39 GMT
+      - Tue, 14 Mar 2023 15:05:07 GMT
       x-ms-version:
       - '2021-08-06'
     method: GET
@@ -145,7 +119,7 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
-        specified container does not exist.\nRequestId:ea4f0a0e-f01e-0007-0b9e-25f6e2000000\nTime:2023-01-11T09:22:40.6394936Z</Message></Error>"
+        specified container does not exist.\nRequestId:838569b0-201e-0076-2b86-5610c9000000\nTime:2023-03-14T15:05:08.3303354Z</Message></Error>"
     headers:
       content-length:
       - '223'
@@ -168,9 +142,9 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.13.1 Python/3.7.13 (Darwin-22.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.14.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Wed, 11 Jan 2023 09:22:40 GMT
+      - Tue, 14 Mar 2023 15:05:08 GMT
       x-ms-version:
       - '2021-08-06'
     method: PUT
@@ -196,9 +170,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.13.1 Python/3.7.13 (Darwin-22.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.14.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Wed, 11 Jan 2023 09:22:40 GMT
+      - Tue, 14 Mar 2023 15:05:08 GMT
       x-ms-version:
       - '2021-08-06'
     method: GET
@@ -219,22 +193,22 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: b'BC\xc0\xde5\x14\x00\x00\x05\x00\x00\x00b\x0c0$JY\xbef]\xfb\xb5O\x0bQ\x80L\x01\x00\x00\x00!\x0c\x00\x00:\x01\x00\x00\x0b\x02!\x00\x02\x00\x00\x00\x16\x00\x00\x00\x07\x81#\x91A\xc8\x04I\x06\x1029\x92\x01\x84\x0c%\x05\x08\x19\x1e\x04\x8bb\x80\x10E\x02B\x92\x0bB\x84\x102\x148\x08\x18K\n2B\x88Hp\xc4!#D\x12\x87\x8c\x10A\x92\x02d\xc8\x08\xb1\x14
-      CF\x88 \xc9\x012B\x84\x18*(*\x901|\xb0\\\x91 \xc4\xc8\x00\x00\x00\x89 \x00\x00\x0f\x00\x00\x002"\x08\t
-      d\x85\x04\x13"\xa4\x84\x04\x13"\xe3\x84\xa1\x90\x14\x12L\x88\x8c\x0b\x84\x84L\x100#\x00%\x00\x8a+T*@\xa61\x02\x80\xa6\x04DU\x04
-      \xba2\x00\x11\xe5@\x00\x00\x00\x00\x00Q\x18\x00\x00\x07\x00\x00\x00\x1b\x9c\xe0\xff\xff\xff\xff\x87\xa1\x14\xdc\x81\x1e\xe4!\x1f`\xe1\x1d\xd2\xc1\x1d\xe8\x01\x00\x00\x00\x00I\x18\x00\x00\x01\x00\x00\x00\x13\x82\x00\x00\x1a!L\x0e\x95qZ>\xae\xa7\xe9-\x1clH\x05\x10\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x0c\xa9\x88\xae\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00
-      \x80!U\x18\\\x07\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x0c\xa9\xf0@K\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08`H%\x0b\xd6\x01\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00@\x00C*t\xe0\x0e
-      \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x90\xd8 P\xd4\'\x00\x00 \x16\x03\x00\x00\x00\x93\x00\x00\x003\x08\x80\x1c\xc4\xe1\x1cf\x14\x01=\x88C8\x84\xc3\x8cB\x80\x07yx\x07s\x98q\x0c\xe6\x00\x0f\xed\x10\x0e\xf4\x80\x0e3\x0cB\x1e\xc2\xc1\x1d\xce\xa1\x1cf0\x05=\x88C8\x84\x83\x1b\xcc\x03=\xc8C=\x8c\x03=\xccx\x8ctp\x07{\x08\x07yH\x87pp\x07zp\x03vx\x87p
+    body: 'b''BC\xc0\xde5\x14\x00\x00\x05\x00\x00\x00b\x0c0$JY\xbef\x8d\xfb\xb4\xaf\x0bQ\x80L\x01\x00\x00\x00!\x0c\x00\x00\x8a\x01\x00\x00\x0b\x02!\x00\x02\x00\x00\x00\x16\x00\x00\x00\x07\x81#\x91A\xc8\x04I\x06\x1029\x92\x01\x84\x0c%\x05\x08\x19\x1e\x04\x8bb\x80\x10E\x02B\x92\x0bB\x84\x102\x148\x08\x18K\n2B\x88Hp\xc4!#D\x12\x87\x8c\x10A\x92\x02d\xc8\x08\xb1\x14
+      CF\x88 \xc9\x012B\x84\x18*(*\x901|\xb0\\\x91 \xc4\xc8\x00\x00\x00\x89 \x00\x00\x11\x00\x00\x002"\x08\t
+      bF\x00!+$\x98\x10!%$\x98\x10\x19\''\x0c\x85\xa4\x90`Bd\\ $d\x82\xa0\x19\x010\x01P`\xa1R\x012\x8d\x11\x004F\x00\xa22\x03\x10\xd1\r\x04\xcc\x11\x80\xc1\x1cA0G\x00\n\x00\x00Q\x18\x00\x00(\x00\x00\x00\x1b\xd6!\xf8\xff\xff\xff\xffa(\x07w\xa0\x07y\xc8\x87_\x80\x87wH\x07w\xa0\x07\x80p\x87zh\x87_\x90\x87r\x88\x87zH\x07y(\x07r\xf8\x85x\xa8\x07qH\x07z\x98\x07`\x0e\x00\xc2\x1d\xea\xa1\x1d~A\x1e\xca!\x1e\xea!\x1d\xe4\xa1\x1c\xc8\xe1\x17\xe4\xa1\x1c\xe6\xa1\x1e\xd8\x81\x1e\xe6\x01\x80\x03`x\x87z\xa0\x07x\xa8\x07z\xf8\x05v\x08\x07q(\x07vH\x07w8\x87_\x98\x87q@\x87rh\x87p\x00\x88xH\x07y\xf8\x05x\x90\x87w0\x87t`\x87r\x98\x07`\x1c\xeaa\x1e\xe8\xe1\x1d\xda\x01\x00\x00\x00\x00I\x18\x00\x00\x01\x00\x00\x00\x13\x82\x00\x00\x1a!\x0cY\x04\xc0$\x1cC*@\t\x00\x00\x08\x00\x00\x00\x00\x00\x00\x00\x00\x00\x14`H\xa5\\\x05\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80\x02\x0c\xa9\xc2@;\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x14`H\xb5\x07V\x01\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xa0\x00\x12\x1b\x04\x8a:\x06\x00\x00d\x81\x00\x00\x07\x00\x00\x002\x1e\x98\x10\x19\x11L\x90\x8c\t&G\xc6\x04C\xd2\x12(\x87\x11\x00\xda\x11\x00\x00\x00\x00\x00\xb1\x18\x00\x00\x97\x00\x00\x003\x08\x80\x1c\xc4\xe1\x1cf\x14\x01=\x88C8\x84\xc3\x8cB\x80\x07yx\x07s\x98q\x0c\xe6\x00\x0f\xed\x10\x0e\xf4\x80\x0e3\x0cB\x1e\xc2\xc1\x1d\xce\xa1\x1cf0\x05=\x88C8\x84\x83\x1b\xcc\x03=\xc8C=\x8c\x03=\xccx\x8ctp\x07{\x08\x07yH\x87pp\x07zp\x03vx\x87p
       \x87\x19\xcc\x11\x0e\xec\x90\x0e\xe10\x0fn0\x0f\xe3\xf0\x0e\xf0P\x0e3\x10\xc4\x1d\xde!\x1c\xd8!\x1d\xc2a\x1ef0\x89;\xbc\x83;\xd0C9\xb4\x03<\xbc\x83<\x84\x03;\xcc\xf0\x14v`\x07{h\x077h\x87rh\x077\x80\x87p\x90\x87p`\x07v(\x07v\xf8\x05vx\x87w\x80\x87_\x08\x87q\x18\x87r\x98\x87y\x98\x81,\xee\xf0\x0e\xee\xe0\x0e\xf5\xc0\x0e\xec0\x03b\xc8\xa1\x1c\xe4\xa1\x1c\xcc\xa1\x1c\xe4\xa1\x1c\xdca\x1c\xca!\x1c\xc4\x81\x1d\xcaa\x06\xd6\x90C9\xc8C9\x98C9\xc8C9\xb8\xc38\x94C8\x88\x03;\x94\xc3/\xbc\x83<\xfc\x82;\xd4\x03;\xb0\xc3\x0c\xc7i\x87pX\x87rp\x83th\x07x`\x87t\x18\x87t\xa0\x87\x19\xceS\x0f\xee\x00\x0f\xf2P\x0e\xe4\x90\x0e\xe3@\x0f\xe1
       \x0e\xecP\x0e3 (\x1d\xdc\xc1\x1e\xc2A\x1e\xd2!\x1c\xdc\x81\x1e\xdc\xe0\x1c\xe4\xe1\x1d\xea\x01\x1ef\x18Q8\xb0C:\x9c\x83;\xccP$v`\x07{h\x077`\x87wx\x07x\x98QL\xf4\x90\x0f\xf0P\x0e3\x1ej\x1e\xcaa\x1c\xe8!\x1d\xde\xc1\x1d~\x01\x1e\xe4\xa1\x1c\xcc!\x1d\xf0a\x06T\x85\x838\xcc\xc3;\xb0C=\xd0C9\xfc\xc2<\xe4C;\x88\xc3;\xb0\xc3\x8c\xc5\n\x87y\x98\x87w\x18\x87t\x08\x07z(\x07r\x98\x81\\\xe3\x10\x0e\xec\xc0\x0e\xe5P\x0e\xf30#\xc1\xd2A\x1e\xe4\xe1\x17\xd8\xe1\x1d\xde\x01\x1efH\x19;\xb0\x83=\xb4\x83\x1b\x84\xc38\x8cC9\xcc\xc3<\xb8\xc19\xc8\xc3;\xd4\x03<\xccH\xb4q\x08\x07v`\x07q\x08\x87qX\x87\x19\xdb\xc6\x0e\xec`\x0f\xed\xe0\x06\xf0
-      \x0f\xe50\x0f\xe5 \x0f\xf6P\x0en\x10\x0e\xe30\x0e\xe50\x0f\xf3\xe0\x06\xe9\xe0\x0e\xe4P\x0e\xf80C\xe1\xda!\x1d\xe6\xa1\x1c\xf0\x01\x1e\xcaa\x1c\xe8aF\xd4\xd9\xc38\x84\x03;\xb0\xc3/\xd8C:\xccC:\x88C:\xb0C:\xd0C>\x00\xa9\x18\x00\x00\x19\x00\x00\x00\x0b\nr(\x87w\x80\x07zXp\x98C=\xb8\xc38\xb0C9\xd0\xc3\x82\xe6\x1c\xc6\xa1\r\xe8A\x1e\xc2\xc1\x1d\xe6!\x1d\xe8!\x1d\xde\xc1\x1d\x164\xe3`\x0e\xe7P\x0f\xe1
-      \x0f\xe4@\x0f\xe1 \x0f\xe7P\x0e\xf4\xb0\x80\x81\x07y(\x87p`\x07vx\x87q\x08\x07z(\x07rXp\x9c\xc38\xb4\x01;\xa4\x83=\x94\x03\x00\x00\x00\xd1\x10\x00\x00\x06\x00\x00\x00\x07\xcc<\xa4\x83;\x9c\x03;\x94\x03=\xa0\x83<\x94C8\x90\xc3\x01\x00\x00\x00a
-      \x00\x00#\x00\x00\x00\x13\x04\xc1\x88\x01\x01\x80 \x18\x14\xc5\x88\x01\x01\x80
-      \x18\x14\xc6\x88\x01\x01\x80 \x18\x14\xc7\x88A\x01\x80 \x18\x1c\xc70bP\x00 \x08\x06\xc7!\x8c\x18\x18\x00\x08\x82Ab\x0c\xc2\x88A\x01\x80
-      \x18\x1c\x850b`\x00 \x08\x06\x891\x08#\x06\x05\x00\x82`p\x10\xc2\x88A\x01\x80
-      \x18\x1c\xc40bP\x00 \x08\x06\x07\x11h8\x10\x00\x00\x00\x07\x00\x00\x00\x07P\x10\xcd\x14af`@T\x80L\xb4\x1d\x18\x10\x15
-      Sm\x08\x06D\x05\xc8d\x03\x00\x00\x00\x00\x00q \x00\x00\x03\x00\x00\x002\x0e\x10"\x84\x00\x99\x02\x00\x00\x00\x00\x00\x00\x00\x00]\x0c\x00\x003\x00\x00\x00\x12\x03\x94}\x01\x00\x00\x00main__quantum__rt__qubit_allocate__quantum__qis__t__body__quantum__qis__cnot__body__quantum__qis__t__adj__quantum__rt__qubit_release11.1.0
-      1fdec59bffc11ae37eb51a1b9869f0696bfd5312circuit-80\x00\x00\x00\x00\x00\x00\x00'
+      \x0f\xe50\x0f\xe5 \x0f\xf6P\x0en\x10\x0e\xe30\x0e\xe50\x0f\xf3\xe0\x06\xe9\xe0\x0e\xe4P\x0e\xf80#\xe2\xeca\x1c\xc2\x81\x1d\xd8\xe1\x17\xec!\x1d\xe6!\x1d\xc4!\x1d\xd8!\x1d\xe8!\x1ff
+      \x9d;\xbcC=\xb8\x039\x94\x839\xccX\xbcpp\x07wx\x07z\x08\x07zH\x87wp\x07\x00\x00y
+      \x00\x00.\x00\x00\x00r\x1eH C\x88\x0c\x19\tr2H #\x81\x8c\x91\x91\xd1D\xa0\x10(d<12B\x8e\x90!\xa3H\x10\xb7\x00Q\x84e\x00qir_major_versionqir_minor_versiondynamic_qubit_managementdynamic_result_management\x00#\x08\n1\x82\xa0\x14#\x08\x8a1\x82\xb0\x1c3\x0cEP\xcc0\x18\xc21\xc3P\x0c\xc8\x0cCA
+      2\x12\x98\xa0\x8c\xd8\xd8\xec\xda\\\xda\xde\xc8\xea\xd8\xca\\\xcc\xd8\xc2\xce\xe6F!\x90DY\x00\x00\xa9\x18\x00\x00!\x00\x00\x00\x0b\nr(\x87w\x80\x07zXp\x98C=\xb8\xc38\xb0C9\xd0\xc3\x82\xe6\x1c\xc6\xa1\r\xe8A\x1e\xc2\xc1\x1d\xe6!\x1d\xe8!\x1d\xde\xc1\x1d\x164\xe3`\x0e\xe7P\x0f\xe1
+      \x0f\xe4@\x0f\xe1 \x0f\xe7P\x0e\xf4\xb0\x80\x81\x07y(\x87p`\x07vx\x87q\x08\x07z(\x07rXp\x9c\xc38\xb4\x01;\xa4\x83=\x94\xc3\x02k\x1c\xd8!\x1c\xdc\xe1\x1c\xdc
+      \x1c\xe4a\x1c\xdc \x1c\xe8\x81\x1e\xc2a\x1c\xd0\xa1\x1c\xc8a\x1c\xc2\x81\x1d\xd8\x01\xd1\x10\x00\x00\x06\x00\x00\x00\x07\xcc<\xa4\x83;\x9c\x03;\x94\x03=\xa0\x83<\x94C8\x90\xc3\x01\x00\x00\x00a
+      \x00\x00\x16\x00\x00\x00\x13\x04A,\x10\x00\x00\x00\x03\x00\x00\x00\xc4%@d\xca\x08#\x00\x00\x00\x00\x00#\x06\x05\x00\x82`P(\xc1\x88A\x01\x80
+      \x18\x14\x8a0b`\x00 \x08\x06G\x12\x08#\x06\x05\x00\x82`P \xc2\x88\x81\x01\x80
+      \x18\x1cI h8\x10\x02\x00\x00\x00\x07P\x10\xcd\x14a\x00\x00\x00\x00\x00\x00q
+      \x00\x00\x03\x00\x00\x002\x0e\x10"\x84\x00\xf6\x02\x00\x00\x00\x00\x00\x00\x00\x00]\x0c\x00\x00%\x00\x00\x00\x12\x03\x94%\x01\x00\x00\x00circuit-80__quantum__qis__t__body__quantum__qis__cnot__body__quantum__qis__t__adj14.0.6
+      f28c006a5895fc0e329fe15fead81e37457cb1d1batch\x00\x00\x00\x00\x00\x00\x00'''
     headers:
       Accept:
       - application/xml
@@ -243,15 +217,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '4232'
+      - '4898'
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.13.1 Python/3.7.13 (Darwin-22.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.14.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 11 Jan 2023 09:22:41 GMT
+      - Tue, 14 Mar 2023 15:05:09 GMT
       x-ms-version:
       - '2021-08-06'
     method: PUT
@@ -271,12 +245,11 @@ interactions:
     body: 'b''{"id": "00000000-0000-0000-0000-000000000000", "name": "circuit-80",
       "containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
       "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData",
-      "inputDataFormat": "qir.v1", "inputParams": {"entryPoint": "main", "arguments":
-      [], "targetCapability": "AdaptiveExecution", "errorBudget": 0.0001, "qubitParams":
+      "inputDataFormat": "qir.v1", "inputParams": {"errorBudget": 0.0001, "qubitParams":
       {"name": "qubit_gate_ns_e4"}, "qecScheme": {"name": "surface_code"}, "count":
-      null, "shots": null}, "providerId": "microsoft-qc", "target": "microsoft.estimator",
-      "metadata": {"qiskit": "True", "name": "circuit-80", "num_qubits": "3", "metadata":
-      "null"}, "outputDataFormat": "microsoft.resource-estimates.v1"}'''
+      null, "shots": null, "items": [{"entryPoint": "circuit-80", "arguments": []}]},
+      "providerId": "microsoft-qc", "target": "microsoft.estimator", "metadata": {},
+      "outputDataFormat": "microsoft.resource-estimates.v1"}'''
     headers:
       Accept:
       - application/json
@@ -285,35 +258,33 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '821'
+      - '722'
       Content-Type:
       - application/json
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.2.0-x86_64-i386-64bit)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
     method: PUT
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
         "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=rcw",
-        "inputDataFormat": "qir.v1", "inputParams": {"entryPoint": "main", "arguments":
-        [], "targetCapability": "AdaptiveExecution", "errorBudget": 0.0001, "qubitParams":
+        "inputDataFormat": "qir.v1", "inputParams": {"errorBudget": 0.0001, "qubitParams":
         {"name": "qubit_gate_ns_e4"}, "qecScheme": {"name": "surface_code"}, "count":
-        null, "shots": null}, "metadata": {"qiskit": "True", "name": "circuit-80",
-        "num_qubits": "3", "metadata": "null"}, "sessionId": null, "status": "Waiting",
-        "jobType": "Unknown", "outputDataFormat": "microsoft.resource-estimates.v1",
-        "outputDataUri": "https://mystorage.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        null, "shots": null, "items": [{"entryPoint": "circuit-80", "arguments": []}]},
+        "metadata": {}, "sessionId": null, "status": "Waiting", "jobType": "QuantumComputing",
+        "outputDataFormat": "microsoft.resource-estimates.v1", "outputDataUri": "https://mystorage.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
         "beginExecutionTime": null, "cancellationTime": null, "quantumComputingData":
         null, "errorData": null, "isCancelling": false, "tags": [], "name": "circuit-80",
         "id": "00000000-0000-0000-0000-000000000000", "providerId": "microsoft-qc",
-        "target": "microsoft.estimator", "creationTime": "2023-01-11T09:22:41.9828101+00:00",
+        "target": "microsoft.estimator", "creationTime": "2023-03-14T15:05:09.6473489+00:00",
         "endExecutionTime": null, "costEstimate": null, "itemType": "Job", "access_token":
         "fake_token"}'
     headers:
       connection:
       - keep-alive
       content-length:
-      - '1408'
+      - '1318'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -331,31 +302,29 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.2.0-x86_64-i386-64bit)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-80-7d27324e-9191-11ed-80d8-acde48001122.input.json",
-        "inputDataFormat": "qir.v1", "inputParams": {"entryPoint": "main", "arguments":
-        [], "targetCapability": "AdaptiveExecution", "errorBudget": 0.0001, "qubitParams":
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-80-9b074f92-c279-11ed-8d97-acde48001122.input.json",
+        "inputDataFormat": "qir.v1", "inputParams": {"errorBudget": 0.0001, "qubitParams":
         {"name": "qubit_gate_ns_e4"}, "qecScheme": {"name": "surface_code"}, "count":
-        null, "shots": null}, "metadata": {"qiskit": "True", "name": "circuit-80",
-        "num_qubits": "3", "metadata": "null"}, "sessionId": null, "status": "Succeeded",
-        "jobType": "QuantumComputing", "outputDataFormat": "microsoft.resource-estimates.v1",
-        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-80-7d27324e-9191-11ed-80d8-acde48001122.output.json",
-        "beginExecutionTime": "2023-01-11T09:22:11.7876751Z", "cancellationTime":
+        null, "shots": null, "items": [{"entryPoint": "circuit-80", "arguments": []}]},
+        "metadata": {}, "sessionId": null, "status": "Succeeded", "jobType": "QuantumComputing",
+        "outputDataFormat": "microsoft.resource-estimates.v1", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-80-9b074f92-c279-11ed-8d97-acde48001122.output.json",
+        "beginExecutionTime": "2023-03-14T15:05:10.1487015Z", "cancellationTime":
         null, "quantumComputingData": {"count": 1}, "errorData": null, "isCancelling":
         false, "tags": [], "name": "circuit-80", "id": "00000000-0000-0000-0000-000000000000",
         "providerId": "microsoft-qc", "target": "microsoft.estimator", "creationTime":
-        "2023-01-11T09:22:41.9828101+00:00", "endExecutionTime": "2023-01-11T09:22:16.2971799Z",
+        "2023-03-14T15:05:09.6473489+00:00", "endExecutionTime": "2023-03-14T15:05:14.9534229Z",
         "costEstimate": null, "itemType": "Job", "access_token": "fake_token"}'
     headers:
       connection:
       - keep-alive
       content-length:
-      - '1649'
+      - '1550'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -373,31 +342,29 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.2.0-x86_64-i386-64bit)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-80-7d27324e-9191-11ed-80d8-acde48001122.input.json",
-        "inputDataFormat": "qir.v1", "inputParams": {"entryPoint": "main", "arguments":
-        [], "targetCapability": "AdaptiveExecution", "errorBudget": 0.0001, "qubitParams":
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-80-9b074f92-c279-11ed-8d97-acde48001122.input.json",
+        "inputDataFormat": "qir.v1", "inputParams": {"errorBudget": 0.0001, "qubitParams":
         {"name": "qubit_gate_ns_e4"}, "qecScheme": {"name": "surface_code"}, "count":
-        null, "shots": null}, "metadata": {"qiskit": "True", "name": "circuit-80",
-        "num_qubits": "3", "metadata": "null"}, "sessionId": null, "status": "Succeeded",
-        "jobType": "QuantumComputing", "outputDataFormat": "microsoft.resource-estimates.v1",
-        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-80-7d27324e-9191-11ed-80d8-acde48001122.output.json",
-        "beginExecutionTime": "2023-01-11T09:22:11.7876751Z", "cancellationTime":
+        null, "shots": null, "items": [{"entryPoint": "circuit-80", "arguments": []}]},
+        "metadata": {}, "sessionId": null, "status": "Succeeded", "jobType": "QuantumComputing",
+        "outputDataFormat": "microsoft.resource-estimates.v1", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-80-9b074f92-c279-11ed-8d97-acde48001122.output.json",
+        "beginExecutionTime": "2023-03-14T15:05:10.1487015Z", "cancellationTime":
         null, "quantumComputingData": {"count": 1}, "errorData": null, "isCancelling":
         false, "tags": [], "name": "circuit-80", "id": "00000000-0000-0000-0000-000000000000",
         "providerId": "microsoft-qc", "target": "microsoft.estimator", "creationTime":
-        "2023-01-11T09:22:41.9828101+00:00", "endExecutionTime": "2023-01-11T09:22:16.2971799Z",
+        "2023-03-14T15:05:09.6473489+00:00", "endExecutionTime": "2023-03-14T15:05:14.9534229Z",
         "costEstimate": null, "itemType": "Job", "access_token": "fake_token"}'
     headers:
       connection:
       - keep-alive
       content-length:
-      - '1649'
+      - '1550'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -415,31 +382,29 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.2.0-x86_64-i386-64bit)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-80-7d27324e-9191-11ed-80d8-acde48001122.input.json",
-        "inputDataFormat": "qir.v1", "inputParams": {"entryPoint": "main", "arguments":
-        [], "targetCapability": "AdaptiveExecution", "errorBudget": 0.0001, "qubitParams":
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-80-9b074f92-c279-11ed-8d97-acde48001122.input.json",
+        "inputDataFormat": "qir.v1", "inputParams": {"errorBudget": 0.0001, "qubitParams":
         {"name": "qubit_gate_ns_e4"}, "qecScheme": {"name": "surface_code"}, "count":
-        null, "shots": null}, "metadata": {"qiskit": "True", "name": "circuit-80",
-        "num_qubits": "3", "metadata": "null"}, "sessionId": null, "status": "Succeeded",
-        "jobType": "QuantumComputing", "outputDataFormat": "microsoft.resource-estimates.v1",
-        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-80-7d27324e-9191-11ed-80d8-acde48001122.output.json",
-        "beginExecutionTime": "2023-01-11T09:22:11.7876751Z", "cancellationTime":
+        null, "shots": null, "items": [{"entryPoint": "circuit-80", "arguments": []}]},
+        "metadata": {}, "sessionId": null, "status": "Succeeded", "jobType": "QuantumComputing",
+        "outputDataFormat": "microsoft.resource-estimates.v1", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-80-9b074f92-c279-11ed-8d97-acde48001122.output.json",
+        "beginExecutionTime": "2023-03-14T15:05:10.1487015Z", "cancellationTime":
         null, "quantumComputingData": {"count": 1}, "errorData": null, "isCancelling":
         false, "tags": [], "name": "circuit-80", "id": "00000000-0000-0000-0000-000000000000",
         "providerId": "microsoft-qc", "target": "microsoft.estimator", "creationTime":
-        "2023-01-11T09:22:41.9828101+00:00", "endExecutionTime": "2023-01-11T09:22:16.2971799Z",
+        "2023-03-14T15:05:09.6473489+00:00", "endExecutionTime": "2023-03-14T15:05:14.9534229Z",
         "costEstimate": null, "itemType": "Job", "access_token": "fake_token"}'
     headers:
       connection:
       - keep-alive
       content-length:
-      - '1649'
+      - '1550'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -457,43 +422,17 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.2.0-x86_64-i386-64bit)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/providerStatus
   response:
     body:
-      string: '{"value": [{"id": "microsoft-qc", "currentAvailability": "Available",
-        "targets": [{"id": "microsoft.estimator", "currentAvailability": "Available",
-        "averageQueueTime": 0, "statusPage": null}]}, {"id": "ionq", "currentAvailability":
-        "Available", "targets": [{"id": "ionq.qpu", "currentAvailability": "Available",
-        "averageQueueTime": 58319, "statusPage": "https://status.ionq.co"}, {"id":
-        "ionq.qpu.aria-1", "currentAvailability": "Available", "averageQueueTime":
-        1946503, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator",
-        "currentAvailability": "Available", "averageQueueTime": 1, "statusPage": "https://status.ionq.co"},
-        {"id": "ionq.qpu-preview", "currentAvailability": "Available", "averageQueueTime":
-        58319, "statusPage": "https://status.ionq.co"}, {"id": "ionq.qpu.aria-1-preview",
-        "currentAvailability": "Available", "averageQueueTime": 1946503, "statusPage":
-        "https://status.ionq.co"}, {"id": "ionq.simulator-preview", "currentAvailability":
-        "Available", "averageQueueTime": 1, "statusPage": "https://status.ionq.co"}]},
-        {"id": "Microsoft.Test", "currentAvailability": "Available", "targets": [{"id":
-        "echo-rigetti", "currentAvailability": "Available", "averageQueueTime": 1,
-        "statusPage": ""}, {"id": "echo-quantinuum", "currentAvailability": "Available",
-        "averageQueueTime": 1, "statusPage": ""}, {"id": "echo-qci", "currentAvailability":
-        "Available", "averageQueueTime": 1, "statusPage": ""}, {"id": "echo-output",
-        "currentAvailability": "Available", "averageQueueTime": 1, "statusPage": ""}]},
-        {"id": "rigetti", "currentAvailability": "Degraded", "targets": [{"id": "rigetti.sim.qvm",
-        "currentAvailability": "Available", "averageQueueTime": 5, "statusPage": "https://rigetti.statuspage.io/"},
-        {"id": "rigetti.qpu.aspen-11", "currentAvailability": "Unavailable", "averageQueueTime":
-        0, "statusPage": null}, {"id": "rigetti.qpu.aspen-m-2", "currentAvailability":
-        "Available", "averageQueueTime": 5, "statusPage": "https://rigetti.statuspage.io/"},
-        {"id": "rigetti.qpu.aspen-m-3", "currentAvailability": "Available", "averageQueueTime":
-        5, "statusPage": "https://rigetti.statuspage.io/"}]}], "nextLink": null, "access_token":
-        "fake_token"}'
+      string: '{"value":[{"id":"microsoft-qc","currentAvailability":"Available","targets":[{"id":"microsoft.estimator","currentAvailability":"Available","averageQueueTime":0,"statusPage":null}]}],"nextLink":null,"access_token":"fake_token"}'
     headers:
       connection:
       - keep-alive
       content-length:
-      - '2162'
+      - '226'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -511,31 +450,29 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.2.0-x86_64-i386-64bit)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-80-7d27324e-9191-11ed-80d8-acde48001122.input.json",
-        "inputDataFormat": "qir.v1", "inputParams": {"entryPoint": "main", "arguments":
-        [], "targetCapability": "AdaptiveExecution", "errorBudget": 0.0001, "qubitParams":
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-80-9b074f92-c279-11ed-8d97-acde48001122.input.json",
+        "inputDataFormat": "qir.v1", "inputParams": {"errorBudget": 0.0001, "qubitParams":
         {"name": "qubit_gate_ns_e4"}, "qecScheme": {"name": "surface_code"}, "count":
-        null, "shots": null}, "metadata": {"qiskit": "True", "name": "circuit-80",
-        "num_qubits": "3", "metadata": "null"}, "sessionId": null, "status": "Succeeded",
-        "jobType": "QuantumComputing", "outputDataFormat": "microsoft.resource-estimates.v1",
-        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-80-7d27324e-9191-11ed-80d8-acde48001122.output.json",
-        "beginExecutionTime": "2023-01-11T09:22:11.7876751Z", "cancellationTime":
+        null, "shots": null, "items": [{"entryPoint": "circuit-80", "arguments": []}]},
+        "metadata": {}, "sessionId": null, "status": "Succeeded", "jobType": "QuantumComputing",
+        "outputDataFormat": "microsoft.resource-estimates.v1", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-80-9b074f92-c279-11ed-8d97-acde48001122.output.json",
+        "beginExecutionTime": "2023-03-14T15:05:10.1487015Z", "cancellationTime":
         null, "quantumComputingData": {"count": 1}, "errorData": null, "isCancelling":
         false, "tags": [], "name": "circuit-80", "id": "00000000-0000-0000-0000-000000000000",
         "providerId": "microsoft-qc", "target": "microsoft.estimator", "creationTime":
-        "2023-01-11T09:22:41.9828101+00:00", "endExecutionTime": "2023-01-11T09:22:16.2971799Z",
+        "2023-03-14T15:05:09.6473489+00:00", "endExecutionTime": "2023-03-14T15:05:14.9534229Z",
         "costEstimate": null, "itemType": "Job", "access_token": "fake_token"}'
     headers:
       connection:
       - keep-alive
       content-length:
-      - '1649'
+      - '1550'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -553,31 +490,29 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.2.0-x86_64-i386-64bit)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-80-7d27324e-9191-11ed-80d8-acde48001122.input.json",
-        "inputDataFormat": "qir.v1", "inputParams": {"entryPoint": "main", "arguments":
-        [], "targetCapability": "AdaptiveExecution", "errorBudget": 0.0001, "qubitParams":
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-80-9b074f92-c279-11ed-8d97-acde48001122.input.json",
+        "inputDataFormat": "qir.v1", "inputParams": {"errorBudget": 0.0001, "qubitParams":
         {"name": "qubit_gate_ns_e4"}, "qecScheme": {"name": "surface_code"}, "count":
-        null, "shots": null}, "metadata": {"qiskit": "True", "name": "circuit-80",
-        "num_qubits": "3", "metadata": "null"}, "sessionId": null, "status": "Succeeded",
-        "jobType": "QuantumComputing", "outputDataFormat": "microsoft.resource-estimates.v1",
-        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-80-7d27324e-9191-11ed-80d8-acde48001122.output.json",
-        "beginExecutionTime": "2023-01-11T09:22:11.7876751Z", "cancellationTime":
+        null, "shots": null, "items": [{"entryPoint": "circuit-80", "arguments": []}]},
+        "metadata": {}, "sessionId": null, "status": "Succeeded", "jobType": "QuantumComputing",
+        "outputDataFormat": "microsoft.resource-estimates.v1", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-80-9b074f92-c279-11ed-8d97-acde48001122.output.json",
+        "beginExecutionTime": "2023-03-14T15:05:10.1487015Z", "cancellationTime":
         null, "quantumComputingData": {"count": 1}, "errorData": null, "isCancelling":
         false, "tags": [], "name": "circuit-80", "id": "00000000-0000-0000-0000-000000000000",
         "providerId": "microsoft-qc", "target": "microsoft.estimator", "creationTime":
-        "2023-01-11T09:22:41.9828101+00:00", "endExecutionTime": "2023-01-11T09:22:16.2971799Z",
+        "2023-03-14T15:05:09.6473489+00:00", "endExecutionTime": "2023-03-14T15:05:14.9534229Z",
         "costEstimate": null, "itemType": "Job", "access_token": "fake_token"}'
     headers:
       connection:
       - keep-alive
       content-length:
-      - '1649'
+      - '1550'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -595,31 +530,69 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.2.0-x86_64-i386-64bit)
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
     method: GET
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-80-7d27324e-9191-11ed-80d8-acde48001122.input.json",
-        "inputDataFormat": "qir.v1", "inputParams": {"entryPoint": "main", "arguments":
-        [], "targetCapability": "AdaptiveExecution", "errorBudget": 0.0001, "qubitParams":
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-80-9b074f92-c279-11ed-8d97-acde48001122.input.json",
+        "inputDataFormat": "qir.v1", "inputParams": {"errorBudget": 0.0001, "qubitParams":
         {"name": "qubit_gate_ns_e4"}, "qecScheme": {"name": "surface_code"}, "count":
-        null, "shots": null}, "metadata": {"qiskit": "True", "name": "circuit-80",
-        "num_qubits": "3", "metadata": "null"}, "sessionId": null, "status": "Succeeded",
-        "jobType": "QuantumComputing", "outputDataFormat": "microsoft.resource-estimates.v1",
-        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-80-7d27324e-9191-11ed-80d8-acde48001122.output.json",
-        "beginExecutionTime": "2023-01-11T09:22:11.7876751Z", "cancellationTime":
+        null, "shots": null, "items": [{"entryPoint": "circuit-80", "arguments": []}]},
+        "metadata": {}, "sessionId": null, "status": "Succeeded", "jobType": "QuantumComputing",
+        "outputDataFormat": "microsoft.resource-estimates.v1", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-80-9b074f92-c279-11ed-8d97-acde48001122.output.json",
+        "beginExecutionTime": "2023-03-14T15:05:10.1487015Z", "cancellationTime":
         null, "quantumComputingData": {"count": 1}, "errorData": null, "isCancelling":
         false, "tags": [], "name": "circuit-80", "id": "00000000-0000-0000-0000-000000000000",
         "providerId": "microsoft-qc", "target": "microsoft.estimator", "creationTime":
-        "2023-01-11T09:22:41.9828101+00:00", "endExecutionTime": "2023-01-11T09:22:16.2971799Z",
+        "2023-03-14T15:05:09.6473489+00:00", "endExecutionTime": "2023-03-14T15:05:14.9534229Z",
         "costEstimate": null, "itemType": "Job", "access_token": "fake_token"}'
     headers:
       connection:
       - keep-alive
       content-length:
-      - '1649'
+      - '1550'
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
+  response:
+    body:
+      string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-80-9b074f92-c279-11ed-8d97-acde48001122.input.json",
+        "inputDataFormat": "qir.v1", "inputParams": {"errorBudget": 0.0001, "qubitParams":
+        {"name": "qubit_gate_ns_e4"}, "qecScheme": {"name": "surface_code"}, "count":
+        null, "shots": null, "items": [{"entryPoint": "circuit-80", "arguments": []}]},
+        "metadata": {}, "sessionId": null, "status": "Succeeded", "jobType": "QuantumComputing",
+        "outputDataFormat": "microsoft.resource-estimates.v1", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-80-9b074f92-c279-11ed-8d97-acde48001122.output.json",
+        "beginExecutionTime": "2023-03-14T15:05:10.1487015Z", "cancellationTime":
+        null, "quantumComputingData": {"count": 1}, "errorData": null, "isCancelling":
+        false, "tags": [], "name": "circuit-80", "id": "00000000-0000-0000-0000-000000000000",
+        "providerId": "microsoft-qc", "target": "microsoft.estimator", "creationTime":
+        "2023-03-14T15:05:09.6473489+00:00", "endExecutionTime": "2023-03-14T15:05:14.9534229Z",
+        "costEstimate": null, "itemType": "Job", "access_token": "fake_token"}'
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '1550'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -637,15 +610,15 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.13.1 Python/3.7.13 (Darwin-22.2.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.14.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Wed, 11 Jan 2023 09:22:55 GMT
+      - Tue, 14 Mar 2023 15:05:19 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
       - '2021-08-06'
     method: GET
-    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-80-7d27324e-9191-11ed-80d8-acde48001122.output.json
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-80-9b074f92-c279-11ed-8d97-acde48001122.output.json
   response:
     body:
       string: '{"errorBudget": {"logical": 5e-05, "rotations": 0.0, "tstates": 5e-05},
@@ -657,20 +630,20 @@ interactions:
         "50 ns", "oneQubitMeasurementErrorRate": 0.0001, "oneQubitMeasurementTime":
         "100 ns", "tGateErrorRate": 0.0001, "tGateTime": "50 ns", "twoQubitGateErrorRate":
         0.0001, "twoQubitGateTime": "50 ns"}}, "logicalCounts": {"ccixCount": 0, "cczCount":
-        0, "measurementCount": 0, "numQubits": 3, "rotationCount": 0, "rotationDepth":
+        0, "measurementCount": 0, "numQubits": 2, "rotationCount": 0, "rotationDepth":
         0, "tCount": 3}, "logicalQubit": {"codeDistance": 5, "logicalCycleTime": 2000.0,
         "logicalErrorRate": 3.0000000000000004e-08, "physicalQubits": 50}, "physicalCounts":
-        {"breakdown": {"algorithmicLogicalDepth": 3, "algorithmicLogicalQubits": 12,
+        {"breakdown": {"algorithmicLogicalDepth": 3, "algorithmicLogicalQubits": 9,
         "cliffordErrorRate": 0.0001, "logicalDepth": 13, "numTfactories": 3, "numTfactoryRuns":
         1, "numTsPerRotation": null, "numTstates": 3, "physicalQubitsForAlgorithm":
-        600, "physicalQubitsForTfactories": 3000, "requiredLogicalQubitErrorRate":
-        3.2051282051282055e-07, "requiredLogicalTstateErrorRate": 1.6666666666666667e-05},
-        "physicalQubits": 3600, "runtime": 26000}, "physicalCountsFormatted": {"codeDistancePerRound":
+        450, "physicalQubitsForTfactories": 3000, "requiredLogicalQubitErrorRate":
+        4.2735042735042736e-07, "requiredLogicalTstateErrorRate": 1.6666666666666667e-05},
+        "physicalQubits": 3450, "runtime": 26000}, "physicalCountsFormatted": {"codeDistancePerRound":
         "5", "errorBudget": "1.00e-4", "errorBudgetLogical": "5.00e-5", "errorBudgetRotations":
         "0.00e0", "errorBudgetTstates": "5.00e-5", "logicalCycleTime": "2us", "logicalErrorRate":
         "3.00e-8", "numTsPerRotation": "No rotations in algorithm", "numUnitsPerRound":
-        "1", "physicalQubitsForTfactoriesPercentage": "83.33 %", "physicalQubitsPerRound":
-        "1000", "requiredLogicalQubitErrorRate": "3.21e-7", "requiredLogicalTstateErrorRate":
+        "1", "physicalQubitsForTfactoriesPercentage": "86.96 %", "physicalQubitsPerRound":
+        "1000", "requiredLogicalQubitErrorRate": "4.27e-7", "requiredLogicalTstateErrorRate":
         "1.67e-5", "runtime": "26us", "tfactoryRuntime": "26us", "tfactoryRuntimePerRound":
         "26us", "tstateLogicalErrorRate": "2.13e-7", "unitNamePerRound": "15-to-1
         space efficient logical"}, "reportData": {"assumptions": ["_More details on
@@ -699,7 +672,7 @@ interactions:
         without significantly increasing the number of logical time steps for the
         algorithm."], "groups": [{"alwaysVisible": true, "entries": [{"description":
         "Number of physical qubits", "explanation": "This value represents the total
-        number of physical qubits, which is the sum of 600 physical qubits to implement
+        number of physical qubits, which is the sum of 450 physical qubits to implement
         the algorithm logic, and 3000 physical qubits to execute the T factories that
         are responsible to produce the T states that are consumed by the algorithm.",
         "label": "Physical qubits", "path": "physicalCounts/physicalQubits"}, {"description":
@@ -714,9 +687,9 @@ interactions:
         [{"description": "Number of logical qubits for the algorithm after layout",
         "explanation": "Laying out the logical qubits in the presence of nearest-neighbor
         constraints requires additional logical qubits.  In particular, to layout
-        the $Q_{\\rm alg} = 3$ logical qubits in the input algorithm, we require in
+        the $Q_{\\rm alg} = 2$ logical qubits in the input algorithm, we require in
         total $2 \\cdot Q_{\\rm alg} + \\lceil \\sqrt{8 \\cdot Q_{\\rm alg}}\\rceil
-        + 1 = 12$ logical qubits.", "label": "Logical algorithmic qubits", "path":
+        + 1 = 9$ logical qubits.", "label": "Logical algorithmic qubits", "path":
         "physicalCounts/breakdown/algorithmicLogicalQubits"}, {"description": "Number
         of logical cycles for the algorithm", "explanation": "To execute the algorithm
         using _Parallel Synthesis Sequential Pauli Computation_ (PSSPC), operations
@@ -748,7 +721,7 @@ interactions:
         "In order to prepare the 3 T states, the 3 copies of the T factory are repeatedly
         invoked 1 times.", "label": "Number of T factory invocations", "path": "physicalCounts/breakdown/numTfactoryRuns"},
         {"description": "Number of physical qubits for the algorithm after layout",
-        "explanation": "The 600 are the product of the 12 logical qubits after layout
+        "explanation": "The 450 are the product of the 9 logical qubits after layout
         and the 50 physical qubits that encode a single logical qubit.", "label":
         "Physical algorithmic qubits", "path": "physicalCounts/breakdown/physicalQubitsForAlgorithm"},
         {"description": "Number of physical qubits for the T factories", "explanation":
@@ -758,7 +731,7 @@ interactions:
         "The minimum logical qubit error rate required to run the algorithm within
         the error budget", "explanation": "The minimum logical qubit error rate is
         obtained by dividing the logical error probability 5.00e-5 by the product
-        of 12 logical qubits and the total cycle count 13.", "label": "Required logical
+        of 9 logical qubits and the total cycle count 13.", "label": "Required logical
         qubit error rate", "path": "physicalCountsFormatted/requiredLogicalQubitErrorRate"},
         {"description": "The minimum T state error rate required for distilled T states",
         "explanation": "The minimum T state error rate is obtained by dividing the
@@ -776,7 +749,7 @@ interactions:
         only works with Majorana qubits.", "label": "QEC scheme", "path": "jobParams/qecScheme/name"},
         {"description": "Required code distance for error correction", "explanation":
         "The code distance is the smallest odd integer greater or equal to $\\dfrac{2\\log(0.03
-        / 0.00000032051282051282055)}{\\log(0.01/0.0001)} - 1$", "label": "Code distance",
+        / 0.00000042735042735042736)}{\\log(0.01/0.0001)} - 1$", "label": "Code distance",
         "path": "logicalQubit/codeDistance"}, {"description": "Number of physical
         qubits per logical qubit", "explanation": "The number of physical qubits per
         logical qubit are evaluated using the formula 2 * codeDistance * codeDistance
@@ -852,7 +825,7 @@ interactions:
         "path": "physicalCountsFormatted/tstateLogicalErrorRate"}], "title": "T factory
         parameters"}, {"alwaysVisible": false, "entries": [{"description": "Number
         of logical qubits in the input quantum program", "explanation": "We determine
-        12 from this number by assuming to align them in a 2D grid.  Auxiliary qubits
+        9 from this number by assuming to align them in a 2D grid.  Auxiliary qubits
         are added to allow for sufficient space to execute multi-qubit Pauli measurements
         on all or a subset of the logical qubits.", "label": "Logical qubits (pre-layout)",
         "path": "logicalCounts/numQubits"}, {"description": "Number of T gates in
@@ -961,17 +934,17 @@ interactions:
       accept-ranges:
       - bytes
       content-length:
-      - '24850'
+      - '24845'
       content-range:
-      - bytes 0-24180/24181
+      - bytes 0-24175/24176
       content-type:
       - application/json
       x-ms-blob-content-md5:
-      - KHJPFl/d23T7hf9+0vpxxA==
+      - 1HvlY8BTmQk6XUprrTxKTA==
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 11 Jan 2023 09:22:42 GMT
+      - Tue, 14 Mar 2023 15:05:10 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:

--- a/azure-quantum/tests/unit/recordings/test_qiskit_controlled_s_to_resource_estimator_with_items.yaml
+++ b/azure-quantum/tests/unit/recordings/test_qiskit_controlled_s_to_resource_estimator_with_items.yaml
@@ -23,7 +23,7 @@ interactions:
       x-client-sku:
       - MSAL.Python
       x-client-ver:
-      - 1.18.0
+      - 1.20.0
     method: POST
     uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token
   response:
@@ -53,83 +53,12 @@ interactions:
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/providerStatus
   response:
     body:
-      string: '{"value": [{"id": "ionq", "currentAvailability": "Available", "targets":
-        [{"id": "ionq.qpu", "currentAvailability": "Available", "averageQueueTime":
-        1371, "statusPage": "https://status.ionq.co"}, {"id": "ionq.qpu.aria-1", "currentAvailability":
-        "Available", "averageQueueTime": 372300, "statusPage": "https://status.ionq.co"},
-        {"id": "ionq.simulator", "currentAvailability": "Available", "averageQueueTime":
-        39, "statusPage": "https://status.ionq.co"}, {"id": "ionq.qpu-preview", "currentAvailability":
-        "Available", "averageQueueTime": 1371, "statusPage": "https://status.ionq.co"},
-        {"id": "ionq.qpu.aria-1-preview", "currentAvailability": "Available", "averageQueueTime":
-        372300, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator-preview",
-        "currentAvailability": "Available", "averageQueueTime": 39, "statusPage":
-        "https://status.ionq.co"}]}, {"id": "Microsoft.Test", "currentAvailability":
-        "Available", "targets": [{"id": "echo-rigetti", "currentAvailability": "Available",
-        "averageQueueTime": 1, "statusPage": ""}, {"id": "echo-quantinuum", "currentAvailability":
-        "Available", "averageQueueTime": 1, "statusPage": ""}, {"id": "echo-qci",
-        "currentAvailability": "Available", "averageQueueTime": 1, "statusPage": ""},
-        {"id": "echo-ionq", "currentAvailability": "Available", "averageQueueTime":
-        1, "statusPage": ""}, {"id": "sparse-sim-rigetti", "currentAvailability":
-        "Available", "averageQueueTime": 1, "statusPage": ""}, {"id": "sparse-sim-quantinuum",
-        "currentAvailability": "Available", "averageQueueTime": 1, "statusPage": ""},
-        {"id": "sparse-sim-qci", "currentAvailability": "Available", "averageQueueTime":
-        1, "statusPage": ""}, {"id": "sparse-sim-ionq", "currentAvailability": "Available",
-        "averageQueueTime": 1, "statusPage": ""}, {"id": "echo-output", "currentAvailability":
-        "Available", "averageQueueTime": 1, "statusPage": ""}]}, {"id": "rigetti",
-        "currentAvailability": "Degraded", "targets": [{"id": "rigetti.sim.qvm", "currentAvailability":
-        "Available", "averageQueueTime": 5, "statusPage": "https://rigetti.statuspage.io/"},
-        {"id": "rigetti.qpu.aspen-11", "currentAvailability": "Unavailable", "averageQueueTime":
-        0, "statusPage": null}, {"id": "rigetti.qpu.aspen-m-2", "currentAvailability":
-        "Available", "averageQueueTime": 5, "statusPage": "https://rigetti.statuspage.io/"},
-        {"id": "rigetti.qpu.aspen-m-3", "currentAvailability": "Available", "averageQueueTime":
-        5, "statusPage": "https://rigetti.statuspage.io/"}]}, {"id": "microsoft-qc",
-        "currentAvailability": "Available", "targets": [{"id": "microsoft.estimator",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
-        {"id": "quantinuum", "currentAvailability": "Degraded", "targets": [{"id":
-        "quantinuum.hqs-lt-s1", "currentAvailability": "Unavailable", "averageQueueTime":
-        0, "statusPage": "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.hqs-lt-s1-apival",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"},
-        {"id": "quantinuum.hqs-lt-s2", "currentAvailability": "Unavailable", "averageQueueTime":
-        0, "statusPage": "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.hqs-lt-s2-apival",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"},
-        {"id": "quantinuum.hqs-lt-s1-sim", "currentAvailability": "Available", "averageQueueTime":
-        8, "statusPage": "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.hqs-lt-s2-sim",
-        "currentAvailability": "Available", "averageQueueTime": 25, "statusPage":
-        "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.hqs-lt", "currentAvailability":
-        "Unavailable", "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"},
-        {"id": "quantinuum.qpu.h1-1", "currentAvailability": "Unavailable", "averageQueueTime":
-        0, "statusPage": "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.sim.h1-1sc",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"},
-        {"id": "quantinuum.qpu.h1-2", "currentAvailability": "Unavailable", "averageQueueTime":
-        0, "statusPage": "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.sim.h1-2sc",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"},
-        {"id": "quantinuum.sim.h1-1e", "currentAvailability": "Available", "averageQueueTime":
-        8, "statusPage": "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.sim.h1-2e",
-        "currentAvailability": "Available", "averageQueueTime": 25, "statusPage":
-        "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.qpu.h1", "currentAvailability":
-        "Unavailable", "averageQueueTime": 0, "statusPage": null}, {"id": "quantinuum.qpu.h2-1",
-        "currentAvailability": "Unavailable", "averageQueueTime": 38305, "statusPage":
-        "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.sim.h2-1sc",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"},
-        {"id": "quantinuum.sim.h2-1e", "currentAvailability": "Available", "averageQueueTime":
-        217, "statusPage": "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.sim.h1-1sc-preview",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"},
-        {"id": "quantinuum.sim.h1-2sc-preview", "currentAvailability": "Available",
-        "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"},
-        {"id": "quantinuum.sim.h1-1e-preview", "currentAvailability": "Available",
-        "averageQueueTime": 8, "statusPage": "https://www.quantinuum.com/products/h1"},
-        {"id": "quantinuum.sim.h1-2e-preview", "currentAvailability": "Available",
-        "averageQueueTime": 25, "statusPage": "https://www.quantinuum.com/products/h1"},
-        {"id": "quantinuum.qpu.h1-1-preview", "currentAvailability": "Unavailable",
-        "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"},
-        {"id": "quantinuum.qpu.h1-2-preview", "currentAvailability": "Unavailable",
-        "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"}]}],
-        "nextLink": null, "access_token": "fake_token"}'
+      string: '{"value":[{"id":"microsoft-qc","currentAvailability":"Available","targets":[{"id":"microsoft.estimator","currentAvailability":"Available","averageQueueTime":0,"statusPage":null}]}],"nextLink":null,"access_token":"fake_token"}'
     headers:
       connection:
       - keep-alive
       content-length:
-      - '6188'
+      - '226'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -180,9 +109,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.13.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.14.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Wed, 15 Feb 2023 09:40:46 GMT
+      - Tue, 14 Mar 2023 15:05:21 GMT
       x-ms-version:
       - '2021-08-06'
     method: GET
@@ -190,7 +119,7 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
-        specified container does not exist.\nRequestId:aa87b971-b01e-0064-2721-416b19000000\nTime:2023-02-15T09:40:47.6418683Z</Message></Error>"
+        specified container does not exist.\nRequestId:b2d7c2f5-e01e-00ef-5786-566f74000000\nTime:2023-03-14T15:05:21.8621770Z</Message></Error>"
     headers:
       content-length:
       - '223'
@@ -213,9 +142,9 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.13.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.14.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Wed, 15 Feb 2023 09:40:47 GMT
+      - Tue, 14 Mar 2023 15:05:21 GMT
       x-ms-version:
       - '2021-08-06'
     method: PUT
@@ -241,9 +170,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.13.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.14.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Wed, 15 Feb 2023 09:40:47 GMT
+      - Tue, 14 Mar 2023 15:05:22 GMT
       x-ms-version:
       - '2021-08-06'
     method: GET
@@ -264,22 +193,22 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: b'BC\xc0\xde5\x14\x00\x00\x05\x00\x00\x00b\x0c0$JY\xbef]\xfb\xb5O\x0bQ\x80L\x01\x00\x00\x00!\x0c\x00\x00:\x01\x00\x00\x0b\x02!\x00\x02\x00\x00\x00\x16\x00\x00\x00\x07\x81#\x91A\xc8\x04I\x06\x1029\x92\x01\x84\x0c%\x05\x08\x19\x1e\x04\x8bb\x80\x10E\x02B\x92\x0bB\x84\x102\x148\x08\x18K\n2B\x88Hp\xc4!#D\x12\x87\x8c\x10A\x92\x02d\xc8\x08\xb1\x14
-      CF\x88 \xc9\x012B\x84\x18*(*\x901|\xb0\\\x91 \xc4\xc8\x00\x00\x00\x89 \x00\x00\x0f\x00\x00\x002"\x08\t
-      d\x85\x04\x13"\xa4\x84\x04\x13"\xe3\x84\xa1\x90\x14\x12L\x88\x8c\x0b\x84\x84L\x100#\x00%\x00\x8a+T*@\xa61\x02\x80\xa6\x04DU\x04
-      \xba2\x00\x11\xe5@\x00\x00\x00\x00\x00Q\x18\x00\x00\x07\x00\x00\x00\x1b\x9c\xe0\xff\xff\xff\xff\x87\xa1\x14\xdc\x81\x1e\xe4!\x1f`\xe1\x1d\xd2\xc1\x1d\xe8\x01\x00\x00\x00\x00I\x18\x00\x00\x01\x00\x00\x00\x13\x82\x00\x00\x1a!L\x0e\x95qZ>\xae\xa7\xe9\xad\\lH\x05\x10\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x0c\xa9\x88\xae\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00
-      \x80!U\x18\\\x07\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x0c\xa9\xf0@K\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08`H%\x0b\xd6\x01\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00@\x00C*t\xe0\x0e
-      \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x90\xd8 P\xd4\'\x00\x00 \x16\x03\x00\x00\x00\x93\x00\x00\x003\x08\x80\x1c\xc4\xe1\x1cf\x14\x01=\x88C8\x84\xc3\x8cB\x80\x07yx\x07s\x98q\x0c\xe6\x00\x0f\xed\x10\x0e\xf4\x80\x0e3\x0cB\x1e\xc2\xc1\x1d\xce\xa1\x1cf0\x05=\x88C8\x84\x83\x1b\xcc\x03=\xc8C=\x8c\x03=\xccx\x8ctp\x07{\x08\x07yH\x87pp\x07zp\x03vx\x87p
+    body: 'b''BC\xc0\xde5\x14\x00\x00\x05\x00\x00\x00b\x0c0$JY\xbef\x8d\xfb\xb4\xaf\x0bQ\x80L\x01\x00\x00\x00!\x0c\x00\x00\x8a\x01\x00\x00\x0b\x02!\x00\x02\x00\x00\x00\x16\x00\x00\x00\x07\x81#\x91A\xc8\x04I\x06\x1029\x92\x01\x84\x0c%\x05\x08\x19\x1e\x04\x8bb\x80\x10E\x02B\x92\x0bB\x84\x102\x148\x08\x18K\n2B\x88Hp\xc4!#D\x12\x87\x8c\x10A\x92\x02d\xc8\x08\xb1\x14
+      CF\x88 \xc9\x012B\x84\x18*(*\x901|\xb0\\\x91 \xc4\xc8\x00\x00\x00\x89 \x00\x00\x11\x00\x00\x002"\x08\t
+      bF\x00!+$\x98\x10!%$\x98\x10\x19\''\x0c\x85\xa4\x90`Bd\\ $d\x82\xa0\x19\x010\x01P`\xa1R\x012\x8d\x11\x004F\x00\xa22\x03\x10\xd1\r\x04\xcc\x11\x80\xc1\x1cA0G\x00\n\x00\x00Q\x18\x00\x00(\x00\x00\x00\x1b\xd6!\xf8\xff\xff\xff\xffa(\x07w\xa0\x07y\xc8\x87_\x80\x87wH\x07w\xa0\x07\x80p\x87zh\x87_\x90\x87r\x88\x87zH\x07y(\x07r\xf8\x85x\xa8\x07qH\x07z\x98\x07`\x0e\x00\xc2\x1d\xea\xa1\x1d~A\x1e\xca!\x1e\xea!\x1d\xe4\xa1\x1c\xc8\xe1\x17\xe4\xa1\x1c\xe6\xa1\x1e\xd8\x81\x1e\xe6\x01\x80\x03`x\x87z\xa0\x07x\xa8\x07z\xf8\x05v\x08\x07q(\x07vH\x07w8\x87_\x98\x87q@\x87rh\x87p\x00\x88xH\x07y\xf8\x05x\x90\x87w0\x87t`\x87r\x98\x07`\x1c\xeaa\x1e\xe8\xe1\x1d\xda\x01\x00\x00\x00\x00I\x18\x00\x00\x01\x00\x00\x00\x13\x82\x00\x00\x1a!\x0cY\x04\xc0$\x1cC*@\t\x00\x00\x08\x00\x00\x00\x00\x00\x00\x00\x00\x00\x14`H\xa5\\\x05\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80\x02\x0c\xa9\xc2@;\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x14`H\xb5\x07V\x01\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xa0\x00\x12\x1b\x04\x8a:\x06\x00\x00d\x81\x00\x00\x07\x00\x00\x002\x1e\x98\x10\x19\x11L\x90\x8c\t&G\xc6\x04C\xd2\x12(\x87\x11\x00\xda\x11\x00\x00\x00\x00\x00\xb1\x18\x00\x00\x97\x00\x00\x003\x08\x80\x1c\xc4\xe1\x1cf\x14\x01=\x88C8\x84\xc3\x8cB\x80\x07yx\x07s\x98q\x0c\xe6\x00\x0f\xed\x10\x0e\xf4\x80\x0e3\x0cB\x1e\xc2\xc1\x1d\xce\xa1\x1cf0\x05=\x88C8\x84\x83\x1b\xcc\x03=\xc8C=\x8c\x03=\xccx\x8ctp\x07{\x08\x07yH\x87pp\x07zp\x03vx\x87p
       \x87\x19\xcc\x11\x0e\xec\x90\x0e\xe10\x0fn0\x0f\xe3\xf0\x0e\xf0P\x0e3\x10\xc4\x1d\xde!\x1c\xd8!\x1d\xc2a\x1ef0\x89;\xbc\x83;\xd0C9\xb4\x03<\xbc\x83<\x84\x03;\xcc\xf0\x14v`\x07{h\x077h\x87rh\x077\x80\x87p\x90\x87p`\x07v(\x07v\xf8\x05vx\x87w\x80\x87_\x08\x87q\x18\x87r\x98\x87y\x98\x81,\xee\xf0\x0e\xee\xe0\x0e\xf5\xc0\x0e\xec0\x03b\xc8\xa1\x1c\xe4\xa1\x1c\xcc\xa1\x1c\xe4\xa1\x1c\xdca\x1c\xca!\x1c\xc4\x81\x1d\xcaa\x06\xd6\x90C9\xc8C9\x98C9\xc8C9\xb8\xc38\x94C8\x88\x03;\x94\xc3/\xbc\x83<\xfc\x82;\xd4\x03;\xb0\xc3\x0c\xc7i\x87pX\x87rp\x83th\x07x`\x87t\x18\x87t\xa0\x87\x19\xceS\x0f\xee\x00\x0f\xf2P\x0e\xe4\x90\x0e\xe3@\x0f\xe1
       \x0e\xecP\x0e3 (\x1d\xdc\xc1\x1e\xc2A\x1e\xd2!\x1c\xdc\x81\x1e\xdc\xe0\x1c\xe4\xe1\x1d\xea\x01\x1ef\x18Q8\xb0C:\x9c\x83;\xccP$v`\x07{h\x077`\x87wx\x07x\x98QL\xf4\x90\x0f\xf0P\x0e3\x1ej\x1e\xcaa\x1c\xe8!\x1d\xde\xc1\x1d~\x01\x1e\xe4\xa1\x1c\xcc!\x1d\xf0a\x06T\x85\x838\xcc\xc3;\xb0C=\xd0C9\xfc\xc2<\xe4C;\x88\xc3;\xb0\xc3\x8c\xc5\n\x87y\x98\x87w\x18\x87t\x08\x07z(\x07r\x98\x81\\\xe3\x10\x0e\xec\xc0\x0e\xe5P\x0e\xf30#\xc1\xd2A\x1e\xe4\xe1\x17\xd8\xe1\x1d\xde\x01\x1efH\x19;\xb0\x83=\xb4\x83\x1b\x84\xc38\x8cC9\xcc\xc3<\xb8\xc19\xc8\xc3;\xd4\x03<\xccH\xb4q\x08\x07v`\x07q\x08\x87qX\x87\x19\xdb\xc6\x0e\xec`\x0f\xed\xe0\x06\xf0
-      \x0f\xe50\x0f\xe5 \x0f\xf6P\x0en\x10\x0e\xe30\x0e\xe50\x0f\xf3\xe0\x06\xe9\xe0\x0e\xe4P\x0e\xf80C\xe1\xda!\x1d\xe6\xa1\x1c\xf0\x01\x1e\xcaa\x1c\xe8aF\xd4\xd9\xc38\x84\x03;\xb0\xc3/\xd8C:\xccC:\x88C:\xb0C:\xd0C>\x00\xa9\x18\x00\x00\x19\x00\x00\x00\x0b\nr(\x87w\x80\x07zXp\x98C=\xb8\xc38\xb0C9\xd0\xc3\x82\xe6\x1c\xc6\xa1\r\xe8A\x1e\xc2\xc1\x1d\xe6!\x1d\xe8!\x1d\xde\xc1\x1d\x164\xe3`\x0e\xe7P\x0f\xe1
-      \x0f\xe4@\x0f\xe1 \x0f\xe7P\x0e\xf4\xb0\x80\x81\x07y(\x87p`\x07vx\x87q\x08\x07z(\x07rXp\x9c\xc38\xb4\x01;\xa4\x83=\x94\x03\x00\x00\x00\xd1\x10\x00\x00\x06\x00\x00\x00\x07\xcc<\xa4\x83;\x9c\x03;\x94\x03=\xa0\x83<\x94C8\x90\xc3\x01\x00\x00\x00a
-      \x00\x00#\x00\x00\x00\x13\x04\xc1\x88\x01\x01\x80 \x18\x14\xc5\x88\x01\x01\x80
-      \x18\x14\xc6\x88\x01\x01\x80 \x18\x14\xc7\x88A\x01\x80 \x18\x1c\xc70bP\x00 \x08\x06\xc7!\x8c\x18\x18\x00\x08\x82Ab\x0c\xc2\x88A\x01\x80
-      \x18\x1c\x850b`\x00 \x08\x06\x891\x08#\x06\x05\x00\x82`p\x10\xc1\x88A\x01\x80
-      \x18\x1c\xc40bP\x00 \x08\x06\x07!h8\x10\x00\x00\x00\x07\x00\x00\x00\x07P\x10\xcd\x14af`@T\x80L\xb4\x1d\x18\x10\x15
-      Sm\x08\x06D\x05\xc8d\x03\x00\x00\x00\x00\x00q \x00\x00\x03\x00\x00\x002\x0e\x10"\x84\x00\x99\x02\x00\x00\x00\x00\x00\x00\x00\x00]\x0c\x00\x003\x00\x00\x00\x12\x03\x94}\x01\x00\x00\x00main__quantum__rt__qubit_allocate__quantum__qis__t__body__quantum__qis__cnot__body__quantum__qis__t__adj__quantum__rt__qubit_release11.1.0
-      1fdec59bffc11ae37eb51a1b9869f0696bfd5312circuit-91\x00\x00\x00\x00\x00\x00\x00'
+      \x0f\xe50\x0f\xe5 \x0f\xf6P\x0en\x10\x0e\xe30\x0e\xe50\x0f\xf3\xe0\x06\xe9\xe0\x0e\xe4P\x0e\xf80#\xe2\xeca\x1c\xc2\x81\x1d\xd8\xe1\x17\xec!\x1d\xe6!\x1d\xc4!\x1d\xd8!\x1d\xe8!\x1ff
+      \x9d;\xbcC=\xb8\x039\x94\x839\xccX\xbcpp\x07wx\x07z\x08\x07zH\x87wp\x07\x00\x00y
+      \x00\x00.\x00\x00\x00r\x1eH C\x88\x0c\x19\tr2H #\x81\x8c\x91\x91\xd1D\xa0\x10(d<12B\x8e\x90!\xa3H\x10\xb7\x00Q\x84e\x00qir_major_versionqir_minor_versiondynamic_qubit_managementdynamic_result_management\x00#\x08\n1\x82\xa0\x14#\x08\x8a1\x82\xb0\x1c3\x0cEP\xcc0\x18\xc21\xc3P\x0c\xc8\x0cCA
+      2\x12\x98\xa0\x8c\xd8\xd8\xec\xda\\\xda\xde\xc8\xea\xd8\xca\\\xcc\xd8\xc2\xce\xe6F!\x90DY\x00\x00\xa9\x18\x00\x00!\x00\x00\x00\x0b\nr(\x87w\x80\x07zXp\x98C=\xb8\xc38\xb0C9\xd0\xc3\x82\xe6\x1c\xc6\xa1\r\xe8A\x1e\xc2\xc1\x1d\xe6!\x1d\xe8!\x1d\xde\xc1\x1d\x164\xe3`\x0e\xe7P\x0f\xe1
+      \x0f\xe4@\x0f\xe1 \x0f\xe7P\x0e\xf4\xb0\x80\x81\x07y(\x87p`\x07vx\x87q\x08\x07z(\x07rXp\x9c\xc38\xb4\x01;\xa4\x83=\x94\xc3\x02k\x1c\xd8!\x1c\xdc\xe1\x1c\xdc
+      \x1c\xe4a\x1c\xdc \x1c\xe8\x81\x1e\xc2a\x1c\xd0\xa1\x1c\xc8a\x1c\xc2\x81\x1d\xd8\x01\xd1\x10\x00\x00\x06\x00\x00\x00\x07\xcc<\xa4\x83;\x9c\x03;\x94\x03=\xa0\x83<\x94C8\x90\xc3\x01\x00\x00\x00a
+      \x00\x00\x16\x00\x00\x00\x13\x04A,\x10\x00\x00\x00\x03\x00\x00\x00\xc4%@d\xca\x08#\x00\x00\x00\x00\x00#\x06\x05\x00\x82`P(\xc1\x88A\x01\x80
+      \x18\x14\x8a0b`\x00 \x08\x06G\x12\x08#\x06\x05\x00\x82`P \xc2\x88\x81\x01\x80
+      \x18\x1cI h8\x10\x02\x00\x00\x00\x07P\x10\xcd\x14a\x00\x00\x00\x00\x00\x00q
+      \x00\x00\x03\x00\x00\x002\x0e\x10"\x84\x00\xf6\x02\x00\x00\x00\x00\x00\x00\x00\x00]\x0c\x00\x00%\x00\x00\x00\x12\x03\x94%\x01\x00\x00\x00circuit-82__quantum__qis__t__body__quantum__qis__cnot__body__quantum__qis__t__adj14.0.6
+      f28c006a5895fc0e329fe15fead81e37457cb1d1batch\x00\x00\x00\x00\x00\x00\x00'''
     headers:
       Accept:
       - application/xml
@@ -288,15 +217,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '4230'
+      - '4898'
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.13.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.14.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 15 Feb 2023 09:40:48 GMT
+      - Tue, 14 Mar 2023 15:05:22 GMT
       x-ms-version:
       - '2021-08-06'
     method: PUT
@@ -313,17 +242,15 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: 'b''{"id": "00000000-0000-0000-0000-000000000000", "name": "circuit-91",
+    body: 'b''{"id": "00000000-0000-0000-0000-000000000000", "name": "circuit-82",
       "containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
       "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData",
-      "inputDataFormat": "qir.v1", "inputParams": {"entryPoint": "main", "arguments":
-      [], "targetCapability": "AdaptiveExecution", "errorBudget": 0.001, "qubitParams":
+      "inputDataFormat": "qir.v1", "inputParams": {"errorBudget": 0.001, "qubitParams":
       {"name": "qubit_gate_ns_e3"}, "qecScheme": {"name": "surface_code"}, "items":
       [{"qubitParams": {"name": "qubit_gate_ns_e3"}, "errorBudget": 0.0001}, {"qubitParams":
       {"name": "qubit_gate_ns_e4"}, "errorBudget": 0.0001}], "count": null, "shots":
       null}, "providerId": "microsoft-qc", "target": "microsoft.estimator", "metadata":
-      {"qiskit": "True", "name": "circuit-91", "num_qubits": "3", "metadata": "null"},
-      "outputDataFormat": "microsoft.resource-estimates.v1"}'''
+      {}, "outputDataFormat": "microsoft.resource-estimates.v1"}'''
     headers:
       Accept:
       - application/json
@@ -332,7 +259,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '971'
+      - '814'
       Content-Type:
       - application/json
       User-Agent:
@@ -343,26 +270,24 @@ interactions:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
         "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=rcw",
-        "inputDataFormat": "qir.v1", "inputParams": {"entryPoint": "main", "arguments":
-        [], "targetCapability": "AdaptiveExecution", "errorBudget": 0.001, "qubitParams":
+        "inputDataFormat": "qir.v1", "inputParams": {"errorBudget": 0.001, "qubitParams":
         {"name": "qubit_gate_ns_e3"}, "qecScheme": {"name": "surface_code"}, "items":
         [{"qubitParams": {"name": "qubit_gate_ns_e3"}, "errorBudget": 0.0001}, {"qubitParams":
         {"name": "qubit_gate_ns_e4"}, "errorBudget": 0.0001}], "count": null, "shots":
-        null}, "metadata": {"qiskit": "True", "name": "circuit-91", "num_qubits":
-        "3", "metadata": "null"}, "sessionId": null, "status": "Waiting", "jobType":
-        "Unknown", "outputDataFormat": "microsoft.resource-estimates.v1", "outputDataUri":
-        "https://mystorage.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        null}, "metadata": {}, "sessionId": null, "status": "Waiting", "jobType":
+        "QuantumComputing", "outputDataFormat": "microsoft.resource-estimates.v1",
+        "outputDataUri": "https://mystorage.blob.core.windows.net:443/job-00000000-0000-0000-0000-000000000000/outputData?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
         "beginExecutionTime": null, "cancellationTime": null, "quantumComputingData":
-        null, "errorData": null, "isCancelling": false, "tags": [], "name": "circuit-91",
+        null, "errorData": null, "isCancelling": false, "tags": [], "name": "circuit-82",
         "id": "00000000-0000-0000-0000-000000000000", "providerId": "microsoft-qc",
-        "target": "microsoft.estimator", "creationTime": "2023-02-15T09:40:48.9771794+00:00",
+        "target": "microsoft.estimator", "creationTime": "2023-03-14T15:05:23.2769743+00:00",
         "endExecutionTime": null, "costEstimate": null, "itemType": "Job", "access_token":
         "fake_token"}'
     headers:
       connection:
       - keep-alive
       content-length:
-      - '1558'
+      - '1410'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -386,27 +311,25 @@ interactions:
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-91-d23f9fde-ad14-11ed-8008-acde48001122.input.json",
-        "inputDataFormat": "qir.v1", "inputParams": {"entryPoint": "main", "arguments":
-        [], "targetCapability": "AdaptiveExecution", "errorBudget": 0.001, "qubitParams":
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-82-a31c49c6-c279-11ed-8d97-acde48001122.input.json",
+        "inputDataFormat": "qir.v1", "inputParams": {"errorBudget": 0.001, "qubitParams":
         {"name": "qubit_gate_ns_e3"}, "qecScheme": {"name": "surface_code"}, "items":
         [{"qubitParams": {"name": "qubit_gate_ns_e3"}, "errorBudget": 0.0001}, {"qubitParams":
         {"name": "qubit_gate_ns_e4"}, "errorBudget": 0.0001}], "count": null, "shots":
-        null}, "metadata": {"qiskit": "True", "name": "circuit-91", "num_qubits":
-        "3", "metadata": "null"}, "sessionId": null, "status": "Succeeded", "jobType":
+        null}, "metadata": {}, "sessionId": null, "status": "Succeeded", "jobType":
         "QuantumComputing", "outputDataFormat": "microsoft.resource-estimates.v1",
-        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-91-d23f9fde-ad14-11ed-8008-acde48001122.output.json",
-        "beginExecutionTime": "2023-02-15T09:40:55.1111742Z", "cancellationTime":
+        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-82-a31c49c6-c279-11ed-8d97-acde48001122.output.json",
+        "beginExecutionTime": "2023-03-14T15:05:23.7468228Z", "cancellationTime":
         null, "quantumComputingData": {"count": 1}, "errorData": null, "isCancelling":
-        false, "tags": [], "name": "circuit-91", "id": "00000000-0000-0000-0000-000000000000",
+        false, "tags": [], "name": "circuit-82", "id": "00000000-0000-0000-0000-000000000000",
         "providerId": "microsoft-qc", "target": "microsoft.estimator", "creationTime":
-        "2023-02-15T09:40:48.9771794+00:00", "endExecutionTime": "2023-02-15T09:41:01.0093432Z",
+        "2023-03-14T15:05:23.2769743+00:00", "endExecutionTime": "2023-03-14T15:05:28.7845169Z",
         "costEstimate": null, "itemType": "Job", "access_token": "fake_token"}'
     headers:
       connection:
       - keep-alive
       content-length:
-      - '1799'
+      - '1642'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -430,27 +353,25 @@ interactions:
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-91-d23f9fde-ad14-11ed-8008-acde48001122.input.json",
-        "inputDataFormat": "qir.v1", "inputParams": {"entryPoint": "main", "arguments":
-        [], "targetCapability": "AdaptiveExecution", "errorBudget": 0.001, "qubitParams":
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-82-a31c49c6-c279-11ed-8d97-acde48001122.input.json",
+        "inputDataFormat": "qir.v1", "inputParams": {"errorBudget": 0.001, "qubitParams":
         {"name": "qubit_gate_ns_e3"}, "qecScheme": {"name": "surface_code"}, "items":
         [{"qubitParams": {"name": "qubit_gate_ns_e3"}, "errorBudget": 0.0001}, {"qubitParams":
         {"name": "qubit_gate_ns_e4"}, "errorBudget": 0.0001}], "count": null, "shots":
-        null}, "metadata": {"qiskit": "True", "name": "circuit-91", "num_qubits":
-        "3", "metadata": "null"}, "sessionId": null, "status": "Succeeded", "jobType":
+        null}, "metadata": {}, "sessionId": null, "status": "Succeeded", "jobType":
         "QuantumComputing", "outputDataFormat": "microsoft.resource-estimates.v1",
-        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-91-d23f9fde-ad14-11ed-8008-acde48001122.output.json",
-        "beginExecutionTime": "2023-02-15T09:40:55.1111742Z", "cancellationTime":
+        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-82-a31c49c6-c279-11ed-8d97-acde48001122.output.json",
+        "beginExecutionTime": "2023-03-14T15:05:23.7468228Z", "cancellationTime":
         null, "quantumComputingData": {"count": 1}, "errorData": null, "isCancelling":
-        false, "tags": [], "name": "circuit-91", "id": "00000000-0000-0000-0000-000000000000",
+        false, "tags": [], "name": "circuit-82", "id": "00000000-0000-0000-0000-000000000000",
         "providerId": "microsoft-qc", "target": "microsoft.estimator", "creationTime":
-        "2023-02-15T09:40:48.9771794+00:00", "endExecutionTime": "2023-02-15T09:41:01.0093432Z",
+        "2023-03-14T15:05:23.2769743+00:00", "endExecutionTime": "2023-03-14T15:05:28.7845169Z",
         "costEstimate": null, "itemType": "Job", "access_token": "fake_token"}'
     headers:
       connection:
       - keep-alive
       content-length:
-      - '1799'
+      - '1642'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -474,27 +395,25 @@ interactions:
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-91-d23f9fde-ad14-11ed-8008-acde48001122.input.json",
-        "inputDataFormat": "qir.v1", "inputParams": {"entryPoint": "main", "arguments":
-        [], "targetCapability": "AdaptiveExecution", "errorBudget": 0.001, "qubitParams":
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-82-a31c49c6-c279-11ed-8d97-acde48001122.input.json",
+        "inputDataFormat": "qir.v1", "inputParams": {"errorBudget": 0.001, "qubitParams":
         {"name": "qubit_gate_ns_e3"}, "qecScheme": {"name": "surface_code"}, "items":
         [{"qubitParams": {"name": "qubit_gate_ns_e3"}, "errorBudget": 0.0001}, {"qubitParams":
         {"name": "qubit_gate_ns_e4"}, "errorBudget": 0.0001}], "count": null, "shots":
-        null}, "metadata": {"qiskit": "True", "name": "circuit-91", "num_qubits":
-        "3", "metadata": "null"}, "sessionId": null, "status": "Succeeded", "jobType":
+        null}, "metadata": {}, "sessionId": null, "status": "Succeeded", "jobType":
         "QuantumComputing", "outputDataFormat": "microsoft.resource-estimates.v1",
-        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-91-d23f9fde-ad14-11ed-8008-acde48001122.output.json",
-        "beginExecutionTime": "2023-02-15T09:40:55.1111742Z", "cancellationTime":
+        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-82-a31c49c6-c279-11ed-8d97-acde48001122.output.json",
+        "beginExecutionTime": "2023-03-14T15:05:23.7468228Z", "cancellationTime":
         null, "quantumComputingData": {"count": 1}, "errorData": null, "isCancelling":
-        false, "tags": [], "name": "circuit-91", "id": "00000000-0000-0000-0000-000000000000",
+        false, "tags": [], "name": "circuit-82", "id": "00000000-0000-0000-0000-000000000000",
         "providerId": "microsoft-qc", "target": "microsoft.estimator", "creationTime":
-        "2023-02-15T09:40:48.9771794+00:00", "endExecutionTime": "2023-02-15T09:41:01.0093432Z",
+        "2023-03-14T15:05:23.2769743+00:00", "endExecutionTime": "2023-03-14T15:05:28.7845169Z",
         "costEstimate": null, "itemType": "Job", "access_token": "fake_token"}'
     headers:
       connection:
       - keep-alive
       content-length:
-      - '1799'
+      - '1642'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -517,83 +436,12 @@ interactions:
     uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/providerStatus
   response:
     body:
-      string: '{"value": [{"id": "ionq", "currentAvailability": "Available", "targets":
-        [{"id": "ionq.qpu", "currentAvailability": "Available", "averageQueueTime":
-        1579, "statusPage": "https://status.ionq.co"}, {"id": "ionq.qpu.aria-1", "currentAvailability":
-        "Available", "averageQueueTime": 354359, "statusPage": "https://status.ionq.co"},
-        {"id": "ionq.simulator", "currentAvailability": "Available", "averageQueueTime":
-        39, "statusPage": "https://status.ionq.co"}, {"id": "ionq.qpu-preview", "currentAvailability":
-        "Available", "averageQueueTime": 1579, "statusPage": "https://status.ionq.co"},
-        {"id": "ionq.qpu.aria-1-preview", "currentAvailability": "Available", "averageQueueTime":
-        354359, "statusPage": "https://status.ionq.co"}, {"id": "ionq.simulator-preview",
-        "currentAvailability": "Available", "averageQueueTime": 39, "statusPage":
-        "https://status.ionq.co"}]}, {"id": "Microsoft.Test", "currentAvailability":
-        "Available", "targets": [{"id": "echo-rigetti", "currentAvailability": "Available",
-        "averageQueueTime": 1, "statusPage": ""}, {"id": "echo-quantinuum", "currentAvailability":
-        "Available", "averageQueueTime": 1, "statusPage": ""}, {"id": "echo-qci",
-        "currentAvailability": "Available", "averageQueueTime": 1, "statusPage": ""},
-        {"id": "echo-ionq", "currentAvailability": "Available", "averageQueueTime":
-        1, "statusPage": ""}, {"id": "sparse-sim-rigetti", "currentAvailability":
-        "Available", "averageQueueTime": 1, "statusPage": ""}, {"id": "sparse-sim-quantinuum",
-        "currentAvailability": "Available", "averageQueueTime": 1, "statusPage": ""},
-        {"id": "sparse-sim-qci", "currentAvailability": "Available", "averageQueueTime":
-        1, "statusPage": ""}, {"id": "sparse-sim-ionq", "currentAvailability": "Available",
-        "averageQueueTime": 1, "statusPage": ""}, {"id": "echo-output", "currentAvailability":
-        "Available", "averageQueueTime": 1, "statusPage": ""}]}, {"id": "rigetti",
-        "currentAvailability": "Degraded", "targets": [{"id": "rigetti.sim.qvm", "currentAvailability":
-        "Available", "averageQueueTime": 5, "statusPage": "https://rigetti.statuspage.io/"},
-        {"id": "rigetti.qpu.aspen-11", "currentAvailability": "Unavailable", "averageQueueTime":
-        0, "statusPage": null}, {"id": "rigetti.qpu.aspen-m-2", "currentAvailability":
-        "Available", "averageQueueTime": 5, "statusPage": "https://rigetti.statuspage.io/"},
-        {"id": "rigetti.qpu.aspen-m-3", "currentAvailability": "Available", "averageQueueTime":
-        5, "statusPage": "https://rigetti.statuspage.io/"}]}, {"id": "microsoft-qc",
-        "currentAvailability": "Available", "targets": [{"id": "microsoft.estimator",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
-        {"id": "quantinuum", "currentAvailability": "Degraded", "targets": [{"id":
-        "quantinuum.hqs-lt-s1", "currentAvailability": "Unavailable", "averageQueueTime":
-        0, "statusPage": "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.hqs-lt-s1-apival",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"},
-        {"id": "quantinuum.hqs-lt-s2", "currentAvailability": "Unavailable", "averageQueueTime":
-        0, "statusPage": "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.hqs-lt-s2-apival",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"},
-        {"id": "quantinuum.hqs-lt-s1-sim", "currentAvailability": "Available", "averageQueueTime":
-        8, "statusPage": "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.hqs-lt-s2-sim",
-        "currentAvailability": "Available", "averageQueueTime": 25, "statusPage":
-        "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.hqs-lt", "currentAvailability":
-        "Unavailable", "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"},
-        {"id": "quantinuum.qpu.h1-1", "currentAvailability": "Unavailable", "averageQueueTime":
-        0, "statusPage": "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.sim.h1-1sc",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"},
-        {"id": "quantinuum.qpu.h1-2", "currentAvailability": "Unavailable", "averageQueueTime":
-        0, "statusPage": "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.sim.h1-2sc",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"},
-        {"id": "quantinuum.sim.h1-1e", "currentAvailability": "Available", "averageQueueTime":
-        8, "statusPage": "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.sim.h1-2e",
-        "currentAvailability": "Available", "averageQueueTime": 25, "statusPage":
-        "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.qpu.h1", "currentAvailability":
-        "Unavailable", "averageQueueTime": 0, "statusPage": null}, {"id": "quantinuum.qpu.h2-1",
-        "currentAvailability": "Unavailable", "averageQueueTime": 38305, "statusPage":
-        "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.sim.h2-1sc",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"},
-        {"id": "quantinuum.sim.h2-1e", "currentAvailability": "Available", "averageQueueTime":
-        217, "statusPage": "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.sim.h1-1sc-preview",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"},
-        {"id": "quantinuum.sim.h1-2sc-preview", "currentAvailability": "Available",
-        "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"},
-        {"id": "quantinuum.sim.h1-1e-preview", "currentAvailability": "Available",
-        "averageQueueTime": 8, "statusPage": "https://www.quantinuum.com/products/h1"},
-        {"id": "quantinuum.sim.h1-2e-preview", "currentAvailability": "Available",
-        "averageQueueTime": 25, "statusPage": "https://www.quantinuum.com/products/h1"},
-        {"id": "quantinuum.qpu.h1-1-preview", "currentAvailability": "Unavailable",
-        "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"},
-        {"id": "quantinuum.qpu.h1-2-preview", "currentAvailability": "Unavailable",
-        "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"}]}],
-        "nextLink": null, "access_token": "fake_token"}'
+      string: '{"value":[{"id":"microsoft-qc","currentAvailability":"Available","targets":[{"id":"microsoft.estimator","currentAvailability":"Available","averageQueueTime":0,"statusPage":null}]}],"nextLink":null,"access_token":"fake_token"}'
     headers:
       connection:
       - keep-alive
       content-length:
-      - '6188'
+      - '226'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -617,27 +465,25 @@ interactions:
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-91-d23f9fde-ad14-11ed-8008-acde48001122.input.json",
-        "inputDataFormat": "qir.v1", "inputParams": {"entryPoint": "main", "arguments":
-        [], "targetCapability": "AdaptiveExecution", "errorBudget": 0.001, "qubitParams":
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-82-a31c49c6-c279-11ed-8d97-acde48001122.input.json",
+        "inputDataFormat": "qir.v1", "inputParams": {"errorBudget": 0.001, "qubitParams":
         {"name": "qubit_gate_ns_e3"}, "qecScheme": {"name": "surface_code"}, "items":
         [{"qubitParams": {"name": "qubit_gate_ns_e3"}, "errorBudget": 0.0001}, {"qubitParams":
         {"name": "qubit_gate_ns_e4"}, "errorBudget": 0.0001}], "count": null, "shots":
-        null}, "metadata": {"qiskit": "True", "name": "circuit-91", "num_qubits":
-        "3", "metadata": "null"}, "sessionId": null, "status": "Succeeded", "jobType":
+        null}, "metadata": {}, "sessionId": null, "status": "Succeeded", "jobType":
         "QuantumComputing", "outputDataFormat": "microsoft.resource-estimates.v1",
-        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-91-d23f9fde-ad14-11ed-8008-acde48001122.output.json",
-        "beginExecutionTime": "2023-02-15T09:40:55.1111742Z", "cancellationTime":
+        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-82-a31c49c6-c279-11ed-8d97-acde48001122.output.json",
+        "beginExecutionTime": "2023-03-14T15:05:23.7468228Z", "cancellationTime":
         null, "quantumComputingData": {"count": 1}, "errorData": null, "isCancelling":
-        false, "tags": [], "name": "circuit-91", "id": "00000000-0000-0000-0000-000000000000",
+        false, "tags": [], "name": "circuit-82", "id": "00000000-0000-0000-0000-000000000000",
         "providerId": "microsoft-qc", "target": "microsoft.estimator", "creationTime":
-        "2023-02-15T09:40:48.9771794+00:00", "endExecutionTime": "2023-02-15T09:41:01.0093432Z",
+        "2023-03-14T15:05:23.2769743+00:00", "endExecutionTime": "2023-03-14T15:05:28.7845169Z",
         "costEstimate": null, "itemType": "Job", "access_token": "fake_token"}'
     headers:
       connection:
       - keep-alive
       content-length:
-      - '1799'
+      - '1642'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -661,27 +507,25 @@ interactions:
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-91-d23f9fde-ad14-11ed-8008-acde48001122.input.json",
-        "inputDataFormat": "qir.v1", "inputParams": {"entryPoint": "main", "arguments":
-        [], "targetCapability": "AdaptiveExecution", "errorBudget": 0.001, "qubitParams":
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-82-a31c49c6-c279-11ed-8d97-acde48001122.input.json",
+        "inputDataFormat": "qir.v1", "inputParams": {"errorBudget": 0.001, "qubitParams":
         {"name": "qubit_gate_ns_e3"}, "qecScheme": {"name": "surface_code"}, "items":
         [{"qubitParams": {"name": "qubit_gate_ns_e3"}, "errorBudget": 0.0001}, {"qubitParams":
         {"name": "qubit_gate_ns_e4"}, "errorBudget": 0.0001}], "count": null, "shots":
-        null}, "metadata": {"qiskit": "True", "name": "circuit-91", "num_qubits":
-        "3", "metadata": "null"}, "sessionId": null, "status": "Succeeded", "jobType":
+        null}, "metadata": {}, "sessionId": null, "status": "Succeeded", "jobType":
         "QuantumComputing", "outputDataFormat": "microsoft.resource-estimates.v1",
-        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-91-d23f9fde-ad14-11ed-8008-acde48001122.output.json",
-        "beginExecutionTime": "2023-02-15T09:40:55.1111742Z", "cancellationTime":
+        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-82-a31c49c6-c279-11ed-8d97-acde48001122.output.json",
+        "beginExecutionTime": "2023-03-14T15:05:23.7468228Z", "cancellationTime":
         null, "quantumComputingData": {"count": 1}, "errorData": null, "isCancelling":
-        false, "tags": [], "name": "circuit-91", "id": "00000000-0000-0000-0000-000000000000",
+        false, "tags": [], "name": "circuit-82", "id": "00000000-0000-0000-0000-000000000000",
         "providerId": "microsoft-qc", "target": "microsoft.estimator", "creationTime":
-        "2023-02-15T09:40:48.9771794+00:00", "endExecutionTime": "2023-02-15T09:41:01.0093432Z",
+        "2023-03-14T15:05:23.2769743+00:00", "endExecutionTime": "2023-03-14T15:05:28.7845169Z",
         "costEstimate": null, "itemType": "Job", "access_token": "fake_token"}'
     headers:
       connection:
       - keep-alive
       content-length:
-      - '1799'
+      - '1642'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -705,27 +549,67 @@ interactions:
   response:
     body:
       string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
-        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-91-d23f9fde-ad14-11ed-8008-acde48001122.input.json",
-        "inputDataFormat": "qir.v1", "inputParams": {"entryPoint": "main", "arguments":
-        [], "targetCapability": "AdaptiveExecution", "errorBudget": 0.001, "qubitParams":
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-82-a31c49c6-c279-11ed-8d97-acde48001122.input.json",
+        "inputDataFormat": "qir.v1", "inputParams": {"errorBudget": 0.001, "qubitParams":
         {"name": "qubit_gate_ns_e3"}, "qecScheme": {"name": "surface_code"}, "items":
         [{"qubitParams": {"name": "qubit_gate_ns_e3"}, "errorBudget": 0.0001}, {"qubitParams":
         {"name": "qubit_gate_ns_e4"}, "errorBudget": 0.0001}], "count": null, "shots":
-        null}, "metadata": {"qiskit": "True", "name": "circuit-91", "num_qubits":
-        "3", "metadata": "null"}, "sessionId": null, "status": "Succeeded", "jobType":
+        null}, "metadata": {}, "sessionId": null, "status": "Succeeded", "jobType":
         "QuantumComputing", "outputDataFormat": "microsoft.resource-estimates.v1",
-        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-91-d23f9fde-ad14-11ed-8008-acde48001122.output.json",
-        "beginExecutionTime": "2023-02-15T09:40:55.1111742Z", "cancellationTime":
+        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-82-a31c49c6-c279-11ed-8d97-acde48001122.output.json",
+        "beginExecutionTime": "2023-03-14T15:05:23.7468228Z", "cancellationTime":
         null, "quantumComputingData": {"count": 1}, "errorData": null, "isCancelling":
-        false, "tags": [], "name": "circuit-91", "id": "00000000-0000-0000-0000-000000000000",
+        false, "tags": [], "name": "circuit-82", "id": "00000000-0000-0000-0000-000000000000",
         "providerId": "microsoft-qc", "target": "microsoft.estimator", "creationTime":
-        "2023-02-15T09:40:48.9771794+00:00", "endExecutionTime": "2023-02-15T09:41:01.0093432Z",
+        "2023-03-14T15:05:23.2769743+00:00", "endExecutionTime": "2023-03-14T15:05:28.7845169Z",
         "costEstimate": null, "itemType": "Job", "access_token": "fake_token"}'
     headers:
       connection:
       - keep-alive
       content-length:
-      - '1799'
+      - '1642'
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - testapp-azure-quantum-qiskit azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
+  response:
+    body:
+      string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-82-a31c49c6-c279-11ed-8d97-acde48001122.input.json",
+        "inputDataFormat": "qir.v1", "inputParams": {"errorBudget": 0.001, "qubitParams":
+        {"name": "qubit_gate_ns_e3"}, "qecScheme": {"name": "surface_code"}, "items":
+        [{"qubitParams": {"name": "qubit_gate_ns_e3"}, "errorBudget": 0.0001}, {"qubitParams":
+        {"name": "qubit_gate_ns_e4"}, "errorBudget": 0.0001}], "count": null, "shots":
+        null}, "metadata": {}, "sessionId": null, "status": "Succeeded", "jobType":
+        "QuantumComputing", "outputDataFormat": "microsoft.resource-estimates.v1",
+        "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-82-a31c49c6-c279-11ed-8d97-acde48001122.output.json",
+        "beginExecutionTime": "2023-03-14T15:05:23.7468228Z", "cancellationTime":
+        null, "quantumComputingData": {"count": 1}, "errorData": null, "isCancelling":
+        false, "tags": [], "name": "circuit-82", "id": "00000000-0000-0000-0000-000000000000",
+        "providerId": "microsoft-qc", "target": "microsoft.estimator", "creationTime":
+        "2023-03-14T15:05:23.2769743+00:00", "endExecutionTime": "2023-03-14T15:05:28.7845169Z",
+        "costEstimate": null, "itemType": "Job", "access_token": "fake_token"}'
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '1642'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -743,15 +627,15 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.13.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
+      - azsdk-python-storage-blob/12.14.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Wed, 15 Feb 2023 09:40:58 GMT
+      - Tue, 14 Mar 2023 15:05:33 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
       - '2021-08-06'
     method: GET
-    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-91-d23f9fde-ad14-11ed-8008-acde48001122.output.json
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dcircuit-82-a31c49c6-c279-11ed-8d97-acde48001122.output.json
   response:
     body:
       string: '[{"errorBudget": {"logical": 5e-05, "rotations": 0.0, "tstates": 5e-05},
@@ -763,20 +647,20 @@ interactions:
         "50 ns", "oneQubitMeasurementErrorRate": 0.001, "oneQubitMeasurementTime":
         "100 ns", "tGateErrorRate": 0.001, "tGateTime": "50 ns", "twoQubitGateErrorRate":
         0.001, "twoQubitGateTime": "50 ns"}}, "logicalCounts": {"ccixCount": 0, "cczCount":
-        0, "measurementCount": 0, "numQubits": 3, "rotationCount": 0, "rotationDepth":
+        0, "measurementCount": 0, "numQubits": 2, "rotationCount": 0, "rotationDepth":
         0, "tCount": 3}, "logicalQubit": {"codeDistance": 9, "logicalCycleTime": 3600.0,
         "logicalErrorRate": 3.0000000000000015e-07, "physicalQubits": 162}, "physicalCounts":
-        {"breakdown": {"algorithmicLogicalDepth": 3, "algorithmicLogicalQubits": 12,
+        {"breakdown": {"algorithmicLogicalDepth": 3, "algorithmicLogicalQubits": 9,
         "cliffordErrorRate": 0.001, "logicalDepth": 13, "numTfactories": 3, "numTfactoryRuns":
         1, "numTsPerRotation": null, "numTstates": 3, "physicalQubitsForAlgorithm":
-        1944, "physicalQubitsForTfactories": 19440, "requiredLogicalQubitErrorRate":
-        3.2051282051282055e-07, "requiredLogicalTstateErrorRate": 1.6666666666666667e-05},
-        "physicalQubits": 21384, "runtime": 46800}, "physicalCountsFormatted": {"codeDistancePerRound":
+        1458, "physicalQubitsForTfactories": 19440, "requiredLogicalQubitErrorRate":
+        4.2735042735042736e-07, "requiredLogicalTstateErrorRate": 1.6666666666666667e-05},
+        "physicalQubits": 20898, "runtime": 46800}, "physicalCountsFormatted": {"codeDistancePerRound":
         "9", "errorBudget": "1.00e-4", "errorBudgetLogical": "5.00e-5", "errorBudgetRotations":
         "0.00e0", "errorBudgetTstates": "5.00e-5", "logicalCycleTime": "3us 600ns",
         "logicalErrorRate": "3.00e-7", "numTsPerRotation": "No rotations in algorithm",
-        "numUnitsPerRound": "2", "physicalQubitsForTfactoriesPercentage": "90.91 %",
-        "physicalQubitsPerRound": "6480", "requiredLogicalQubitErrorRate": "3.21e-7",
+        "numUnitsPerRound": "2", "physicalQubitsForTfactoriesPercentage": "93.02 %",
+        "physicalQubitsPerRound": "6480", "requiredLogicalQubitErrorRate": "4.27e-7",
         "requiredLogicalTstateErrorRate": "1.67e-5", "runtime": "46us 800ns", "tfactoryRuntime":
         "46us 800ns", "tfactoryRuntimePerRound": "46us 800ns", "tstateLogicalErrorRate":
         "2.17e-6", "unitNamePerRound": "15-to-1 space efficient logical"}, "reportData":
@@ -806,7 +690,7 @@ interactions:
         increasing the number of logical time steps for the algorithm."], "groups":
         [{"alwaysVisible": true, "entries": [{"description": "Number of physical qubits",
         "explanation": "This value represents the total number of physical qubits,
-        which is the sum of 1944 physical qubits to implement the algorithm logic,
+        which is the sum of 1458 physical qubits to implement the algorithm logic,
         and 19440 physical qubits to execute the T factories that are responsible
         to produce the T states that are consumed by the algorithm.", "label": "Physical
         qubits", "path": "physicalCounts/physicalQubits"}, {"description": "Total
@@ -821,9 +705,9 @@ interactions:
         [{"description": "Number of logical qubits for the algorithm after layout",
         "explanation": "Laying out the logical qubits in the presence of nearest-neighbor
         constraints requires additional logical qubits.  In particular, to layout
-        the $Q_{\\rm alg} = 3$ logical qubits in the input algorithm, we require in
+        the $Q_{\\rm alg} = 2$ logical qubits in the input algorithm, we require in
         total $2 \\cdot Q_{\\rm alg} + \\lceil \\sqrt{8 \\cdot Q_{\\rm alg}}\\rceil
-        + 1 = 12$ logical qubits.", "label": "Logical algorithmic qubits", "path":
+        + 1 = 9$ logical qubits.", "label": "Logical algorithmic qubits", "path":
         "physicalCounts/breakdown/algorithmicLogicalQubits"}, {"description": "Number
         of logical cycles for the algorithm", "explanation": "To execute the algorithm
         using _Parallel Synthesis Sequential Pauli Computation_ (PSSPC), operations
@@ -855,7 +739,7 @@ interactions:
         "In order to prepare the 3 T states, the 3 copies of the T factory are repeatedly
         invoked 1 times.", "label": "Number of T factory invocations", "path": "physicalCounts/breakdown/numTfactoryRuns"},
         {"description": "Number of physical qubits for the algorithm after layout",
-        "explanation": "The 1944 are the product of the 12 logical qubits after layout
+        "explanation": "The 1458 are the product of the 9 logical qubits after layout
         and the 162 physical qubits that encode a single logical qubit.", "label":
         "Physical algorithmic qubits", "path": "physicalCounts/breakdown/physicalQubitsForAlgorithm"},
         {"description": "Number of physical qubits for the T factories", "explanation":
@@ -865,7 +749,7 @@ interactions:
         "The minimum logical qubit error rate required to run the algorithm within
         the error budget", "explanation": "The minimum logical qubit error rate is
         obtained by dividing the logical error probability 5.00e-5 by the product
-        of 12 logical qubits and the total cycle count 13.", "label": "Required logical
+        of 9 logical qubits and the total cycle count 13.", "label": "Required logical
         qubit error rate", "path": "physicalCountsFormatted/requiredLogicalQubitErrorRate"},
         {"description": "The minimum T state error rate required for distilled T states",
         "explanation": "The minimum T state error rate is obtained by dividing the
@@ -883,7 +767,7 @@ interactions:
         only works with Majorana qubits.", "label": "QEC scheme", "path": "jobParams/qecScheme/name"},
         {"description": "Required code distance for error correction", "explanation":
         "The code distance is the smallest odd integer greater or equal to $\\dfrac{2\\log(0.03
-        / 0.00000032051282051282055)}{\\log(0.01/0.001)} - 1$", "label": "Code distance",
+        / 0.00000042735042735042736)}{\\log(0.01/0.001)} - 1$", "label": "Code distance",
         "path": "logicalQubit/codeDistance"}, {"description": "Number of physical
         qubits per logical qubit", "explanation": "The number of physical qubits per
         logical qubit are evaluated using the formula 2 * codeDistance * codeDistance
@@ -959,7 +843,7 @@ interactions:
         "path": "physicalCountsFormatted/tstateLogicalErrorRate"}], "title": "T factory
         parameters"}, {"alwaysVisible": false, "entries": [{"description": "Number
         of logical qubits in the input quantum program", "explanation": "We determine
-        12 from this number by assuming to align them in a 2D grid.  Auxiliary qubits
+        9 from this number by assuming to align them in a 2D grid.  Auxiliary qubits
         are added to allow for sufficient space to execute multi-qubit Pauli measurements
         on all or a subset of the logical qubits.", "label": "Logical qubits (pre-layout)",
         "path": "logicalCounts/numQubits"}, {"description": "Number of T gates in
@@ -1072,20 +956,20 @@ interactions:
         "50 ns", "oneQubitMeasurementErrorRate": 0.0001, "oneQubitMeasurementTime":
         "100 ns", "tGateErrorRate": 0.0001, "tGateTime": "50 ns", "twoQubitGateErrorRate":
         0.0001, "twoQubitGateTime": "50 ns"}}, "logicalCounts": {"ccixCount": 0, "cczCount":
-        0, "measurementCount": 0, "numQubits": 3, "rotationCount": 0, "rotationDepth":
+        0, "measurementCount": 0, "numQubits": 2, "rotationCount": 0, "rotationDepth":
         0, "tCount": 3}, "logicalQubit": {"codeDistance": 5, "logicalCycleTime": 2000.0,
         "logicalErrorRate": 3.0000000000000004e-08, "physicalQubits": 50}, "physicalCounts":
-        {"breakdown": {"algorithmicLogicalDepth": 3, "algorithmicLogicalQubits": 12,
+        {"breakdown": {"algorithmicLogicalDepth": 3, "algorithmicLogicalQubits": 9,
         "cliffordErrorRate": 0.0001, "logicalDepth": 13, "numTfactories": 3, "numTfactoryRuns":
         1, "numTsPerRotation": null, "numTstates": 3, "physicalQubitsForAlgorithm":
-        600, "physicalQubitsForTfactories": 3000, "requiredLogicalQubitErrorRate":
-        3.2051282051282055e-07, "requiredLogicalTstateErrorRate": 1.6666666666666667e-05},
-        "physicalQubits": 3600, "runtime": 26000}, "physicalCountsFormatted": {"codeDistancePerRound":
+        450, "physicalQubitsForTfactories": 3000, "requiredLogicalQubitErrorRate":
+        4.2735042735042736e-07, "requiredLogicalTstateErrorRate": 1.6666666666666667e-05},
+        "physicalQubits": 3450, "runtime": 26000}, "physicalCountsFormatted": {"codeDistancePerRound":
         "5", "errorBudget": "1.00e-4", "errorBudgetLogical": "5.00e-5", "errorBudgetRotations":
         "0.00e0", "errorBudgetTstates": "5.00e-5", "logicalCycleTime": "2us", "logicalErrorRate":
         "3.00e-8", "numTsPerRotation": "No rotations in algorithm", "numUnitsPerRound":
-        "1", "physicalQubitsForTfactoriesPercentage": "83.33 %", "physicalQubitsPerRound":
-        "1000", "requiredLogicalQubitErrorRate": "3.21e-7", "requiredLogicalTstateErrorRate":
+        "1", "physicalQubitsForTfactoriesPercentage": "86.96 %", "physicalQubitsPerRound":
+        "1000", "requiredLogicalQubitErrorRate": "4.27e-7", "requiredLogicalTstateErrorRate":
         "1.67e-5", "runtime": "26us", "tfactoryRuntime": "26us", "tfactoryRuntimePerRound":
         "26us", "tstateLogicalErrorRate": "2.13e-7", "unitNamePerRound": "15-to-1
         space efficient logical"}, "reportData": {"assumptions": ["_More details on
@@ -1114,7 +998,7 @@ interactions:
         without significantly increasing the number of logical time steps for the
         algorithm."], "groups": [{"alwaysVisible": true, "entries": [{"description":
         "Number of physical qubits", "explanation": "This value represents the total
-        number of physical qubits, which is the sum of 600 physical qubits to implement
+        number of physical qubits, which is the sum of 450 physical qubits to implement
         the algorithm logic, and 3000 physical qubits to execute the T factories that
         are responsible to produce the T states that are consumed by the algorithm.",
         "label": "Physical qubits", "path": "physicalCounts/physicalQubits"}, {"description":
@@ -1129,9 +1013,9 @@ interactions:
         [{"description": "Number of logical qubits for the algorithm after layout",
         "explanation": "Laying out the logical qubits in the presence of nearest-neighbor
         constraints requires additional logical qubits.  In particular, to layout
-        the $Q_{\\rm alg} = 3$ logical qubits in the input algorithm, we require in
+        the $Q_{\\rm alg} = 2$ logical qubits in the input algorithm, we require in
         total $2 \\cdot Q_{\\rm alg} + \\lceil \\sqrt{8 \\cdot Q_{\\rm alg}}\\rceil
-        + 1 = 12$ logical qubits.", "label": "Logical algorithmic qubits", "path":
+        + 1 = 9$ logical qubits.", "label": "Logical algorithmic qubits", "path":
         "physicalCounts/breakdown/algorithmicLogicalQubits"}, {"description": "Number
         of logical cycles for the algorithm", "explanation": "To execute the algorithm
         using _Parallel Synthesis Sequential Pauli Computation_ (PSSPC), operations
@@ -1163,7 +1047,7 @@ interactions:
         "In order to prepare the 3 T states, the 3 copies of the T factory are repeatedly
         invoked 1 times.", "label": "Number of T factory invocations", "path": "physicalCounts/breakdown/numTfactoryRuns"},
         {"description": "Number of physical qubits for the algorithm after layout",
-        "explanation": "The 600 are the product of the 12 logical qubits after layout
+        "explanation": "The 450 are the product of the 9 logical qubits after layout
         and the 50 physical qubits that encode a single logical qubit.", "label":
         "Physical algorithmic qubits", "path": "physicalCounts/breakdown/physicalQubitsForAlgorithm"},
         {"description": "Number of physical qubits for the T factories", "explanation":
@@ -1173,7 +1057,7 @@ interactions:
         "The minimum logical qubit error rate required to run the algorithm within
         the error budget", "explanation": "The minimum logical qubit error rate is
         obtained by dividing the logical error probability 5.00e-5 by the product
-        of 12 logical qubits and the total cycle count 13.", "label": "Required logical
+        of 9 logical qubits and the total cycle count 13.", "label": "Required logical
         qubit error rate", "path": "physicalCountsFormatted/requiredLogicalQubitErrorRate"},
         {"description": "The minimum T state error rate required for distilled T states",
         "explanation": "The minimum T state error rate is obtained by dividing the
@@ -1191,7 +1075,7 @@ interactions:
         only works with Majorana qubits.", "label": "QEC scheme", "path": "jobParams/qecScheme/name"},
         {"description": "Required code distance for error correction", "explanation":
         "The code distance is the smallest odd integer greater or equal to $\\dfrac{2\\log(0.03
-        / 0.00000032051282051282055)}{\\log(0.01/0.0001)} - 1$", "label": "Code distance",
+        / 0.00000042735042735042736)}{\\log(0.01/0.0001)} - 1$", "label": "Code distance",
         "path": "logicalQubit/codeDistance"}, {"description": "Number of physical
         qubits per logical qubit", "explanation": "The number of physical qubits per
         logical qubit are evaluated using the formula 2 * codeDistance * codeDistance
@@ -1267,7 +1151,7 @@ interactions:
         "path": "physicalCountsFormatted/tstateLogicalErrorRate"}], "title": "T factory
         parameters"}, {"alwaysVisible": false, "entries": [{"description": "Number
         of logical qubits in the input quantum program", "explanation": "We determine
-        12 from this number by assuming to align them in a 2D grid.  Auxiliary qubits
+        9 from this number by assuming to align them in a 2D grid.  Auxiliary qubits
         are added to allow for sufficient space to execute multi-qubit Pauli measurements
         on all or a subset of the logical qubits.", "label": "Logical qubits (pre-layout)",
         "path": "logicalCounts/numQubits"}, {"description": "Number of T gates in
@@ -1376,17 +1260,17 @@ interactions:
       accept-ranges:
       - bytes
       content-length:
-      - '49699'
+      - '49689'
       content-range:
-      - bytes 0-48418/48419
+      - bytes 0-48408/48409
       content-type:
       - application/json
       x-ms-blob-content-md5:
-      - bLCz6gS/tNgqF0Ro0phqRQ==
+      - P6csN/1bedmGrxmgG5EywQ==
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 15 Feb 2023 09:40:49 GMT
+      - Tue, 14 Mar 2023 15:05:23 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:

--- a/azure-quantum/tests/unit/test_qiskit.py
+++ b/azure-quantum/tests/unit/test_qiskit.py
@@ -102,7 +102,7 @@ class TestQiskit(QuantumTestBase):
             circuit.metadata = { "some": "data" }
 
             qiskit_job = backend.run(
-                circuit=circuit,
+                circuit,
                 shots=num_shots
             )
 
@@ -162,13 +162,13 @@ class TestQiskit(QuantumTestBase):
     @pytest.mark.live_test
     def test_plugins_submit_qiskit_to_ionq(self):
         circuit = self._3_qubit_ghz()
-        self._test_qiskit_submit_ionq(circuit=circuit)
+        self._test_qiskit_submit_ionq(circuit)
 
     @pytest.mark.ionq
     @pytest.mark.live_test
     def test_plugins_submit_qiskit_circuit_as_list_to_ionq(self):
         circuit = self._3_qubit_ghz()
-        self._test_qiskit_submit_ionq(circuit=[circuit])
+        self._test_qiskit_submit_ionq([circuit])
 
     @pytest.mark.ionq
     @pytest.mark.live_test
@@ -231,7 +231,7 @@ class TestQiskit(QuantumTestBase):
             shots = kwargs.get("shots", backend.options.shots)
 
             qiskit_job = backend.run(
-                circuit=circuit,
+                circuit,
                 **kwargs
             )
 
@@ -369,7 +369,7 @@ class TestQiskit(QuantumTestBase):
             backend = provider.get_backend("ionq.simulator")
             circuit = self._3_qubit_ghz()
             qiskit_job = backend.run(
-                circuit=circuit,
+                circuit,
                 shots=100
             )
 
@@ -413,13 +413,13 @@ class TestQiskit(QuantumTestBase):
     @pytest.mark.live_test
     def test_plugins_submit_qiskit_to_quantinuum(self):
         circuit = self._3_qubit_ghz()
-        self._test_qiskit_submit_quantinuum(circuit=circuit)
+        self._test_qiskit_submit_quantinuum(circuit)
 
     @pytest.mark.quantinuum
     @pytest.mark.live_test
     def test_plugins_submit_qiskit_circuit_as_list_to_quantinuum(self):
         circuit = self._3_qubit_ghz()
-        self._test_qiskit_submit_quantinuum(circuit=[circuit])
+        self._test_qiskit_submit_quantinuum([circuit])
 
     @pytest.mark.quantinuum
     @pytest.mark.live_test
@@ -461,7 +461,7 @@ class TestQiskit(QuantumTestBase):
                 circuit.metadata = { "some": "data" }
 
             qiskit_job = backend.run(
-                circuit=circuit,
+                circuit,
                 **kwargs
             )
 
@@ -559,7 +559,7 @@ class TestQiskit(QuantumTestBase):
             circuit.metadata = { "some": "data" }
 
             qiskit_job = backend.run(
-                circuit=circuit,
+                circuit,
                 count=shots
             )
 
@@ -639,7 +639,7 @@ class TestQiskit(QuantumTestBase):
             circuit.metadata = { "some": "data" }
 
             qiskit_job = backend.run(
-                circuit=circuit,
+                circuit,
                 shots=shots
             )
 
@@ -710,7 +710,7 @@ class TestQiskit(QuantumTestBase):
             circuit.metadata = { "some": "data" }
 
             qiskit_job = backend.run(
-                circuit=circuit,
+                circuit,
                 shots=shots
             )
             assert qiskit_job._azure_job.details.metadata["num_qubits"] == '3'
@@ -738,7 +738,7 @@ class TestQiskit(QuantumTestBase):
 
             circuit = self._controlled_s()
 
-            qiskit_job = backend.run(circuit=circuit)
+            qiskit_job = backend.run(circuit)
             assert qiskit_job._azure_job.details.metadata["num_qubits"] == '3'
 
             # Make sure the job is completed before fetching results
@@ -766,7 +766,7 @@ class TestQiskit(QuantumTestBase):
 
             circuit = self._controlled_s()
 
-            qiskit_job = backend.run(circuit=circuit, qubitParams={"name": "qubit_gate_ns_e4"}, errorBudget=0.0001)
+            qiskit_job = backend.run(circuit, qubitParams={"name": "qubit_gate_ns_e4"}, errorBudget=0.0001)
             assert qiskit_job._azure_job.details.metadata["num_qubits"] == '3'
 
             # Make sure the job is completed before fetching results
@@ -796,7 +796,7 @@ class TestQiskit(QuantumTestBase):
 
             item1 = {"qubitParams": {"name": "qubit_gate_ns_e3"}, "errorBudget": 1e-4}
             item2 = {"qubitParams": {"name": "qubit_gate_ns_e4"}, "errorBudget": 1e-4}
-            qiskit_job = backend.run(circuit=circuit, items=[item1, item2])
+            qiskit_job = backend.run(circuit, items=[item1, item2])
             assert qiskit_job._azure_job.details.metadata["num_qubits"] == '3'
 
             # Make sure the job is completed before fetching results

--- a/azure-quantum/tests/unit/test_qiskit.py
+++ b/azure-quantum/tests/unit/test_qiskit.py
@@ -1175,5 +1175,7 @@ class TestQiskit(QuantumTestBase):
             None, "AzureQuantumProvider", output_data_format=azure_congfig_value
         )
         expected = "test_format_v2"
-        actual = backend._get_output_data_format(**{"output_data_format": expected})
+        options = {"output_data_format": expected}
+        actual = backend._get_output_data_format(options)
+        assert "output_data_format" not in options
         assert expected == actual

--- a/azure-quantum/tests/unit/test_qiskit.py
+++ b/azure-quantum/tests/unit/test_qiskit.py
@@ -261,72 +261,84 @@ class TestQiskit(QuantumTestBase):
                 assert hasattr(result.results[0].header, "metadata")
 
     @pytest.mark.ionq
+    @pytest.mark.live_test
     def test_ionq_simulator_has_default(self):
         workspace = self.create_workspace()
         provider = AzureQuantumProvider(workspace=workspace)
         provider.get_backend("ionq.simulator")
 
     @pytest.mark.ionq
+    @pytest.mark.live_test
     def test_ionq_simulator_has_qir_target(self):
         workspace = self.create_workspace()
         provider = AzureQuantumProvider(workspace=workspace)
         provider.get_backend("ionq.simulator", input_data_format="qir.v1")
 
     @pytest.mark.ionq
+    @pytest.mark.live_test
     def test_ionq_simulator_has_native_gateset_target(self):
         workspace = self.create_workspace()
         provider = AzureQuantumProvider(workspace=workspace)
         provider.get_backend("ionq.simulator", gateset="native")
 
     @pytest.mark.ionq
+    @pytest.mark.live_test
     def test_ionq_simulator_has_qis_gateset_target(self):
         workspace = self.create_workspace()
         provider = AzureQuantumProvider(workspace=workspace)
         provider.get_backend("ionq.simulator", gateset="qis")
 
     @pytest.mark.ionq
+    @pytest.mark.live_test
     def test_ionq_qpu_has_default(self):
         workspace = self.create_workspace()
         provider = AzureQuantumProvider(workspace=workspace)
         provider.get_backend("ionq.qpu")
 
     @pytest.mark.ionq
+    @pytest.mark.live_test
     def test_ionq_qpu_has_qir_target(self):
         workspace = self.create_workspace()
         provider = AzureQuantumProvider(workspace=workspace)
         provider.get_backend("ionq.qpu", input_data_format="qir.v1")
 
     @pytest.mark.ionq
+    @pytest.mark.live_test
     def test_ionq_qpu_has_native_gateset_target(self):
         workspace = self.create_workspace()
         provider = AzureQuantumProvider(workspace=workspace)
         provider.get_backend("ionq.qpu", gateset="native")
 
     @pytest.mark.ionq
+    @pytest.mark.live_test
     def test_ionq_qpu_has_qis_gateset_target(self):
         workspace = self.create_workspace()
         provider = AzureQuantumProvider(workspace=workspace)
         provider.get_backend("ionq.qpu", gateset="qis")
 
     @pytest.mark.ionq
+    @pytest.mark.live_test
     def test_ionq_aria_has_default(self):
         workspace = self.create_workspace()
         provider = AzureQuantumProvider(workspace=workspace)
         provider.get_backend("ionq.qpu.aria-1")
 
     @pytest.mark.ionq
+    @pytest.mark.live_test
     def test_ionq_aria_has_qir_target(self):
         workspace = self.create_workspace()
         provider = AzureQuantumProvider(workspace=workspace)
         provider.get_backend("ionq.qpu.aria-1", input_data_format="qir.v1")
 
     @pytest.mark.ionq
+    @pytest.mark.live_test
     def test_ionq_aria_has_native_gateset_target(self):
         workspace = self.create_workspace()
         provider = AzureQuantumProvider(workspace=workspace)
         provider.get_backend("ionq.qpu.aria-1", gateset="native")
 
     @pytest.mark.ionq
+    @pytest.mark.live_test
     def test_ionq_aria_has_qis_gateset_target(self):
         workspace = self.create_workspace()
         provider = AzureQuantumProvider(workspace=workspace)
@@ -622,7 +634,7 @@ class TestQiskit(QuantumTestBase):
             assert "qir.v1" == config.azure["content_type"]
             assert "rigetti" == config.azure["provider_id"]
             assert "qir.v1" == config.azure["input_data_format"]
-            assert "microsoft.quantum-results.v1" == config.azure["output_data_format"]
+            assert "microsoft.quantum-results.v1" == backend._get_output_data_format()
             shots = 100
 
             circuit = self._3_qubit_ghz()
@@ -680,7 +692,7 @@ class TestQiskit(QuantumTestBase):
         assert "qir.v1" == config.azure["content_type"]
         assert "rigetti" == config.azure["provider_id"]
         assert "qir.v1" == config.azure["input_data_format"]
-        assert "microsoft.quantum-results.v1" == config.azure["output_data_format"]
+        assert "microsoft.quantum-results.v1" == backend._get_output_data_format()
 
     @pytest.mark.qci
     @pytest.mark.live_test
@@ -702,7 +714,7 @@ class TestQiskit(QuantumTestBase):
             assert "qir.v1" == config.azure["content_type"]
             assert "qci" == config.azure["provider_id"]
             assert "qir.v1" == config.azure["input_data_format"]
-            assert "microsoft.quantum-results.v1" == config.azure["output_data_format"]
+            assert "microsoft.quantum-results.v1" == backend._get_output_data_format()
             shots = 100
 
             circuit = self._3_qubit_ghz()
@@ -758,7 +770,7 @@ class TestQiskit(QuantumTestBase):
         assert "qir.v1" == config.azure["content_type"]
         assert "qci" == config.azure["provider_id"]
         assert "qir.v1" == config.azure["input_data_format"]
-        assert "microsoft.quantum-results.v1" == config.azure["output_data_format"]
+        assert "microsoft.quantum-results.v1" == backend._get_output_data_format()
 
     # @pytest.mark.parametrize("endian_pos, expectation",
     #     [(0,"000 000 001"), (1,"000 010 000"), (2,"100 000 000")]

--- a/azure-quantum/tests/unit/test_qiskit.py
+++ b/azure-quantum/tests/unit/test_qiskit.py
@@ -551,7 +551,7 @@ class TestQiskit(QuantumTestBase):
         workspace = self.create_workspace()
         provider = AzureQuantumProvider(workspace=workspace)
         backend = IonQSimulatorQirBackend("ionq.simulator", provider)
-        input_params = backend._get_input_params()
+        input_params = backend._get_input_params({})
 
         payload = backend._translate_input(circuit, input_params)
         config = backend.configuration()

--- a/azure-quantum/tests/unit/test_qiskit.py
+++ b/azure-quantum/tests/unit/test_qiskit.py
@@ -22,9 +22,9 @@ from qiskit_ionq import GPIGate, GPI2Gate, MSGate
 
 from azure.quantum.job.job import Job
 from azure.quantum.qiskit import AzureQuantumProvider
-from azure.quantum.qiskit.job import AzureQuantumJob
+from azure.quantum.qiskit.job import MICROSOFT_OUTPUT_DATA_FORMAT, AzureQuantumJob
 from azure.quantum.qiskit.backends import QuantinuumEmulatorBackend
-from azure.quantum.qiskit.backends import IonQSimulatorBackend
+from azure.quantum.qiskit.backends.ionq import IonQSimulatorQirBackend
 
 from common import QuantumTestBase, ZERO_UID
 
@@ -260,26 +260,96 @@ class TestQiskit(QuantumTestBase):
                 assert hasattr(result.results[0].header, "num_qubits")
                 assert hasattr(result.results[0].header, "metadata")
 
+    @pytest.mark.ionq
+    def test_ionq_simulator_has_default(self):
+        workspace = self.create_workspace()
+        provider = AzureQuantumProvider(workspace=workspace)
+        provider.get_backend("ionq.simulator")
+
+    @pytest.mark.ionq
+    def test_ionq_simulator_has_qir_target(self):
+        workspace = self.create_workspace()
+        provider = AzureQuantumProvider(workspace=workspace)
+        provider.get_backend("ionq.simulator", input_data_format="qir.v1")
+
+    @pytest.mark.ionq
+    def test_ionq_simulator_has_native_gateset_target(self):
+        workspace = self.create_workspace()
+        provider = AzureQuantumProvider(workspace=workspace)
+        provider.get_backend("ionq.simulator", gateset="native")
+
+    @pytest.mark.ionq
+    def test_ionq_simulator_has_qis_gateset_target(self):
+        workspace = self.create_workspace()
+        provider = AzureQuantumProvider(workspace=workspace)
+        provider.get_backend("ionq.simulator", gateset="qis")
+
+    @pytest.mark.ionq
+    def test_ionq_qpu_has_default(self):
+        workspace = self.create_workspace()
+        provider = AzureQuantumProvider(workspace=workspace)
+        provider.get_backend("ionq.qpu")
+
+    @pytest.mark.ionq
+    def test_ionq_qpu_has_qir_target(self):
+        workspace = self.create_workspace()
+        provider = AzureQuantumProvider(workspace=workspace)
+        provider.get_backend("ionq.qpu", input_data_format="qir.v1")
+
+    @pytest.mark.ionq
+    def test_ionq_qpu_has_native_gateset_target(self):
+        workspace = self.create_workspace()
+        provider = AzureQuantumProvider(workspace=workspace)
+        provider.get_backend("ionq.qpu", gateset="native")
+
+    @pytest.mark.ionq
+    def test_ionq_qpu_has_qis_gateset_target(self):
+        workspace = self.create_workspace()
+        provider = AzureQuantumProvider(workspace=workspace)
+        provider.get_backend("ionq.qpu", gateset="qis")
+
+    @pytest.mark.ionq
+    def test_ionq_aria_has_default(self):
+        workspace = self.create_workspace()
+        provider = AzureQuantumProvider(workspace=workspace)
+        provider.get_backend("ionq.qpu.aria-1")
+
+    @pytest.mark.ionq
+    def test_ionq_aria_has_qir_target(self):
+        workspace = self.create_workspace()
+        provider = AzureQuantumProvider(workspace=workspace)
+        provider.get_backend("ionq.qpu.aria-1", input_data_format="qir.v1")
+
+    @pytest.mark.ionq
+    def test_ionq_aria_has_native_gateset_target(self):
+        workspace = self.create_workspace()
+        provider = AzureQuantumProvider(workspace=workspace)
+        provider.get_backend("ionq.qpu.aria-1", gateset="native")
+
+    @pytest.mark.ionq
+    def test_ionq_aria_has_qis_gateset_target(self):
+        workspace = self.create_workspace()
+        provider = AzureQuantumProvider(workspace=workspace)
+        provider.get_backend("ionq.qpu.aria-1", gateset="qis")
     
     @pytest.mark.ionq
     def test_translate_ionq_qir(self):
         circuit = self._3_qubit_ghz()
         workspace = self.create_workspace()
         provider = AzureQuantumProvider(workspace=workspace)
-        backend = IonQSimulatorBackend("ionq.simulator", provider)
+        backend = IonQSimulatorQirBackend("ionq.simulator", provider)
+        input_params = backend._get_input_params()
 
-        input_format = backend.configuration().azure["input_data_format"]
-        input_params = {
-            "targetCapability": "BasicExecution"
-        }
-
-        (payload, dataformat, params) = backend._translate_input(circuit, input_format, input_params)
+        payload = backend._translate_input(circuit, input_params)
+        config = backend.configuration()
+        input_data_format = config.azure["input_data_format"]
+        output_data_format = backend._get_output_data_format()
 
         assert isinstance(payload, bytes)
-        assert dataformat == "qir.v1"
-        assert "entryPoint" in params
-        assert "arguments" in params
-        assert "targetCapability" in params
+        assert input_data_format == "qir.v1"
+        assert output_data_format == MICROSOFT_OUTPUT_DATA_FORMAT
+        assert "entryPoint" in input_params
+        assert "arguments" in input_params
                 
 
     @pytest.mark.ionq

--- a/azure-quantum/tests/unit/test_qiskit.py
+++ b/azure-quantum/tests/unit/test_qiskit.py
@@ -1055,15 +1055,13 @@ class TestQiskit(QuantumTestBase):
             circuit = self._controlled_s()
 
             qiskit_job = backend.run(circuit)
-            assert qiskit_job._azure_job.details.metadata["num_qubits"] == "3"
 
             # Make sure the job is completed before fetching results
             self._qiskit_wait_to_complete(qiskit_job, provider)
 
             if JobStatus.DONE == qiskit_job.status():
                 result = qiskit_job.result()
-                assert result.data()["physicalCounts"]["physicalQubits"] == 12936
-                assert result.data()["physicalCounts"]["runtime"] == 36400
+                assert result.data()["logicalCounts"]["numQubits"] == 2
                 assert (
                     result.data()["jobParams"]["qubitParams"]["name"]
                     == "qubit_gate_ns_e3"
@@ -1088,15 +1086,13 @@ class TestQiskit(QuantumTestBase):
             qiskit_job = backend.run(
                 circuit, qubitParams={"name": "qubit_gate_ns_e4"}, errorBudget=0.0001
             )
-            assert qiskit_job._azure_job.details.metadata["num_qubits"] == "3"
 
             # Make sure the job is completed before fetching results
             self._qiskit_wait_to_complete(qiskit_job, provider)
 
             if JobStatus.DONE == qiskit_job.status():
                 result = qiskit_job.result()
-                assert result.data()["physicalCounts"]["physicalQubits"] == 3600
-                assert result.data()["physicalCounts"]["runtime"] == 26000
+                assert result.data()["logicalCounts"]["numQubits"] == 2
                 assert (
                     result.data()["jobParams"]["qubitParams"]["name"]
                     == "qubit_gate_ns_e4"
@@ -1118,10 +1114,11 @@ class TestQiskit(QuantumTestBase):
 
             circuit = self._controlled_s()
 
-            item1 = {"qubitParams": {"name": "qubit_gate_ns_e3"}, "errorBudget": 1e-4}
-            item2 = {"qubitParams": {"name": "qubit_gate_ns_e4"}, "errorBudget": 1e-4}
+            # TODO: explicit entryPoint specification can be removed after
+            #       change in microsoft.estimator target.
+            item1 = {"entryPoint": "circuit-0", "qubitParams": {"name": "qubit_gate_ns_e3"}, "errorBudget": 1e-4}
+            item2 = {"entryPoint": "circuit-0", "qubitParams": {"name": "qubit_gate_ns_e4"}, "errorBudget": 1e-4}
             qiskit_job = backend.run(circuit, items=[item1, item2])
-            assert qiskit_job._azure_job.details.metadata["num_qubits"] == "3"
 
             # Make sure the job is completed before fetching results
             self._qiskit_wait_to_complete(qiskit_job, provider)
@@ -1132,8 +1129,7 @@ class TestQiskit(QuantumTestBase):
             if JobStatus.DONE == qiskit_job.status():
                 result = qiskit_job.result()
 
-                assert result.data(0)["physicalCounts"]["physicalQubits"] == 21384
-                assert result.data(0)["physicalCounts"]["runtime"] == 46800
+                assert result.data(0)["logicalCounts"]["numQubits"] == 2
                 assert (
                     result.data(0)["jobParams"]["qubitParams"]["name"]
                     == "qubit_gate_ns_e3"
@@ -1143,8 +1139,7 @@ class TestQiskit(QuantumTestBase):
                 )
                 assert result.data(0)["jobParams"]["errorBudget"] == 0.0001
 
-                assert result.data(1)["physicalCounts"]["physicalQubits"] == 3600
-                assert result.data(1)["physicalCounts"]["runtime"] == 26000
+                assert result.data(1)["logicalCounts"]["numQubits"] == 2
                 assert (
                     result.data(1)["jobParams"]["qubitParams"]["name"]
                     == "qubit_gate_ns_e4"

--- a/azure-quantum/tests/unit/test_qiskit.py
+++ b/azure-quantum/tests/unit/test_qiskit.py
@@ -800,7 +800,7 @@ class TestQiskit(QuantumTestBase):
             "quantinuum.sim.h1-2sc-preview", provider
         )
 
-        input_params = backend._get_input_params()
+        input_params = backend._get_input_params({})
         payload = backend._translate_input(circuit, input_params)
 
         config = backend.configuration()

--- a/azure-quantum/tests/unit/test_qiskit.py
+++ b/azure-quantum/tests/unit/test_qiskit.py
@@ -65,7 +65,7 @@ class NoopQirBackend(AzureQirBackend):
     ):
         return self._normalize_run_input_params(run_input, **options)
     
-    def _azure_config(self, output_data_format = None) -> dict[str, str]:
+    def _azure_config(self, output_data_format = None) -> Dict[str, str]:
         values = {
             "blob_name": "inputData",
             "content_type": "qir.v1",
@@ -112,7 +112,7 @@ class NoopPassThruBackend(AzureBackend):
     def run(self, run_input = None, **kwargs):
         return self._normalize_run_input_params(run_input, **kwargs)
 
-    def _azure_config(self, fields) -> dict[str, str]:
+    def _azure_config(self, fields) -> Dict[str, str]:
         return fields
     
     def _default_options(cls):

--- a/azure-quantum/tests/unit/test_qiskit.py
+++ b/azure-quantum/tests/unit/test_qiskit.py
@@ -1059,6 +1059,7 @@ class TestQiskit(QuantumTestBase):
             # Make sure the job is completed before fetching results
             self._qiskit_wait_to_complete(qiskit_job, provider)
 
+            assert qiskit_job.status() == JobStatus.DONE
             if JobStatus.DONE == qiskit_job.status():
                 result = qiskit_job.result()
                 assert result.data()["logicalCounts"]["numQubits"] == 2
@@ -1083,22 +1084,24 @@ class TestQiskit(QuantumTestBase):
 
             circuit = self._controlled_s()
 
+            # TODO: change this back to not use items explicitly
             qiskit_job = backend.run(
-                circuit, qubitParams={"name": "qubit_gate_ns_e4"}, errorBudget=0.0001
+                circuit, items=[{"entryPoint": circuit.name, "qubitParams": {"name": "qubit_gate_ns_e4"}, "errorBudget": 0.0001}]
             )
 
             # Make sure the job is completed before fetching results
             self._qiskit_wait_to_complete(qiskit_job, provider)
 
+            assert qiskit_job.status() == JobStatus.DONE
             if JobStatus.DONE == qiskit_job.status():
                 result = qiskit_job.result()
-                assert result.data()["logicalCounts"]["numQubits"] == 2
+                assert result.data(0)["logicalCounts"]["numQubits"] == 2
                 assert (
                     result.data()["jobParams"]["qubitParams"]["name"]
                     == "qubit_gate_ns_e4"
                 )
-                assert result.data()["jobParams"]["qecScheme"]["name"] == "surface_code"
-                assert result.data()["jobParams"]["errorBudget"] == 0.0001
+                assert result.data(0)["jobParams"]["qecScheme"]["name"] == "surface_code"
+                assert result.data(0)["jobParams"]["errorBudget"] == 0.0001
 
     @pytest.mark.microsoft_qc
     @pytest.mark.live_test
@@ -1116,16 +1119,14 @@ class TestQiskit(QuantumTestBase):
 
             # TODO: explicit entryPoint specification can be removed after
             #       change in microsoft.estimator target.
-            item1 = {"entryPoint": "circuit-0", "qubitParams": {"name": "qubit_gate_ns_e3"}, "errorBudget": 1e-4}
-            item2 = {"entryPoint": "circuit-0", "qubitParams": {"name": "qubit_gate_ns_e4"}, "errorBudget": 1e-4}
+            item1 = {"entryPoint": circuit.name, "qubitParams": {"name": "qubit_gate_ns_e3"}, "errorBudget": 1e-4}
+            item2 = {"entryPoint": circuit.name, "qubitParams": {"name": "qubit_gate_ns_e4"}, "errorBudget": 1e-4}
             qiskit_job = backend.run(circuit, items=[item1, item2])
 
             # Make sure the job is completed before fetching results
             self._qiskit_wait_to_complete(qiskit_job, provider)
 
-            print(qiskit_job)
-            print(dir(qiskit_job))
-
+            assert qiskit_job.status() == JobStatus.DONE
             if JobStatus.DONE == qiskit_job.status():
                 result = qiskit_job.result()
 

--- a/azure-quantum/tests/unit/test_qiskit.py
+++ b/azure-quantum/tests/unit/test_qiskit.py
@@ -272,21 +272,37 @@ class TestQiskit(QuantumTestBase):
     def test_ionq_simulator_has_qir_target(self):
         workspace = self.create_workspace()
         provider = AzureQuantumProvider(workspace=workspace)
-        provider.get_backend("ionq.simulator", input_data_format="qir.v1")
+        backend = provider.get_backend("ionq.simulator", input_data_format="qir.v1")
+        config = backend.configuration()
+        input_data_format = config.azure["input_data_format"]
+        assert input_data_format == "qir.v1"
 
     @pytest.mark.ionq
     @pytest.mark.live_test
     def test_ionq_simulator_has_native_gateset_target(self):
         workspace = self.create_workspace()
         provider = AzureQuantumProvider(workspace=workspace)
-        provider.get_backend("ionq.simulator", gateset="native")
+        backend = provider.get_backend("ionq.simulator", gateset="native")
+        config = backend.configuration()
+        assert config.gateset == "native"
 
     @pytest.mark.ionq
     @pytest.mark.live_test
     def test_ionq_simulator_has_qis_gateset_target(self):
         workspace = self.create_workspace()
         provider = AzureQuantumProvider(workspace=workspace)
-        provider.get_backend("ionq.simulator", gateset="qis")
+        backend = provider.get_backend("ionq.simulator", gateset="qis")
+        config = backend.configuration()
+        assert config.gateset == "qis"
+
+    @pytest.mark.ionq
+    @pytest.mark.live_test
+    def test_ionq_simulator_default_target_has_qis_gateset(self):
+        workspace = self.create_workspace()
+        provider = AzureQuantumProvider(workspace=workspace)
+        backend = provider.get_backend("ionq.simulator")
+        config = backend.configuration()
+        assert config.gateset == "qis"
 
     @pytest.mark.ionq
     @pytest.mark.live_test
@@ -300,22 +316,38 @@ class TestQiskit(QuantumTestBase):
     def test_ionq_qpu_has_qir_target(self):
         workspace = self.create_workspace()
         provider = AzureQuantumProvider(workspace=workspace)
-        provider.get_backend("ionq.qpu", input_data_format="qir.v1")
+        backend = provider.get_backend("ionq.qpu", input_data_format="qir.v1")
+        config = backend.configuration()
+        input_data_format = config.azure["input_data_format"]
+        assert input_data_format == "qir.v1"
 
     @pytest.mark.ionq
     @pytest.mark.live_test
     def test_ionq_qpu_has_native_gateset_target(self):
         workspace = self.create_workspace()
         provider = AzureQuantumProvider(workspace=workspace)
-        provider.get_backend("ionq.qpu", gateset="native")
+        backend = provider.get_backend("ionq.qpu", gateset="native")
+        config = backend.configuration()
+        assert config.gateset == "native"
 
     @pytest.mark.ionq
     @pytest.mark.live_test
     def test_ionq_qpu_has_qis_gateset_target(self):
         workspace = self.create_workspace()
         provider = AzureQuantumProvider(workspace=workspace)
-        provider.get_backend("ionq.qpu", gateset="qis")
+        backend = provider.get_backend("ionq.qpu", gateset="qis")
+        config = backend.configuration()
+        assert config.gateset == "qis"
     
+    @pytest.mark.ionq
+    @pytest.mark.live_test
+    def test_ionq_qpu_default_target_has_qis_gateset(self):
+        workspace = self.create_workspace()
+        provider = AzureQuantumProvider(workspace=workspace)
+        backend = provider.get_backend("ionq.qpu")
+        config = backend.configuration()
+        assert config.gateset == "qis"
+
     @pytest.mark.ionq
     def test_translate_ionq_qir(self):
         circuit = self._3_qubit_ghz()


### PR DESCRIPTION
# Overview
- Adding unique backends for QIR and pass through.
- Backend filtering now works.
- TargetFactory no longer does double duty for Backend creation.
- Support for output results format v2

# Questions
 - The signature for `BackendV1.run` is `def run(self, run_input, **options)` in the Qiskit API. Our current implementation uses `def run(self, circuit, **kwargs)` which is focused on a single circuit while other values can be passed. This PR updates the def of run to match the original API. This will effect anyone that tries to explicitly specify the circuit param as seen in our tests. AFAICT we don't use that syntax in our samples. Are we ok with this change?

# Examples
## Backend filtering
Filtering of backends from the provider now works according to the Qisksit backend definition. In addition to the backend name, `**kwargs` can now be passed that will return backends that match all criteria specified that are both available locally via implementations and available in the workspace:
```python
for backend in provider.backends(provider_id="quantinuum", n_qubits=20):
    print("- " + backend.name())
```
```shell
- quantinuum.hqs-lt-s1-apival
- quantinuum.hqs-lt-s1-apival
- quantinuum.sim.h1-1sc
- quantinuum.sim.h1-1sc
...
```

This looks like duplicates, however they are distinct backends for QIR and pass through. 

## Getting a specific backend
Calling `backends` will always return a list of all available backends.

```python
for backend in provider.backends("ionq.simulator"):
    print("- " + backend.name() + ", " + backend.configuration().azure["input_data_format"])
```
```shell
- ionq.simulator, ionq.circuit.v1
- ionq.simulator, qir.v1
```

This works normally for `provider.get_backend` as it always expects to return a single backend, and will throw an error if 0 or > 1 are returned.  To handle multiple backends with the same target name, one implementation is marked as default. If the filtered backends all have the same name, it applies an additional filter to include only the default backend for that name. As providers move to QIR as the default, we can change this configuration to switch which backend is returned.

```python
backend = provider.get_backend("ionq.simulator")
print(backend.name() + ", " + backend.configuration().azure["input_data_format"])
```
```log
ionq.simulator, ionq.circuit.v1
```
```python
backend = provider.get_backend("ionq.simulator", input_data_format="qir.v1")
print(backend.name() + ", " + backend.configuration().azure["input_data_format"])
```
```log
ionq.simulator, qir.v1
```