### PR TITLE
Make Workspace.get_job target aware

### DIFF
--- a/azure-quantum/azure/quantum/target/microsoft/target.py
+++ b/azure-quantum/azure/quantum/target/microsoft/target.py
@@ -26,6 +26,9 @@ class MicrosoftEstimator(Target):
         # There is only a single target name for this target
         assert name == self.target_names[0]
 
+        # make sure to not pass argument twice
+        kwargs.pop("provider_id", None)
+
         super().__init__(
             workspace=workspace,
             name=name,

--- a/azure-quantum/azure/quantum/target/microsoft/target.py
+++ b/azure-quantum/azure/quantum/target/microsoft/target.py
@@ -2,6 +2,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 ##
+from typing import Type
+from ...job import Job
 from ...job.base_job import ContentType
 from ...workspace import Workspace
 from ..target import Target
@@ -36,6 +38,9 @@ class MicrosoftEstimator(Target):
             output_data_format="microsoft.resource-estimates.v1",
             provider_id="microsoft-qc",
             content_type=ContentType.json,
-            job_cls=MicrosoftEstimatorJob,
             **kwargs
         )
+
+    @classmethod
+    def _get_job_class(cls) -> Type[Job]:
+        return MicrosoftEstimatorJob

--- a/azure-quantum/azure/quantum/target/target.py
+++ b/azure-quantum/azure/quantum/target/target.py
@@ -165,15 +165,6 @@ target '{self.name}' of provider '{self.provider_id}' not found."
             input_params=input_params,
             **kwargs
         )
-    
-    def get_job(self, job_id: str) -> Job:
-        """Returns the job corresponding to the given id.
-        
-        :param job_id: Job id
-        """
-        client = self.workspace._get_jobs_client()
-        details = client.get(job_id)
-        return self._job_cls(self.workspace, details)
 
     def supports_protobuf(self):
         """

--- a/azure-quantum/azure/quantum/target/target.py
+++ b/azure-quantum/azure/quantum/target/target.py
@@ -37,15 +37,10 @@ class Target:
         content_type: ContentType = ContentType.json,
         encoding: str = "",
         average_queue_time: Union[float, None] = None,
-        current_availability: str = "",
-        job_cls: Type[Job] = Job
+        current_availability: str = ""
     ):
         """
         Initializes a new target.
-
-        :param job_cls: The job class used by submit and get_job.  The default
-            is Job.
-        :type job_cls: Type[Job]
         """
         if not provider_id and "." in name:
             provider_id = name.split(".")[0]
@@ -58,7 +53,6 @@ class Target:
         self.encoding = encoding
         self._average_queue_time = average_queue_time
         self._current_availability = current_availability
-        self._job_cls = job_cls
 
     def __repr__(self):
         return f"<Target name=\"{self.name}\", \
@@ -84,7 +78,16 @@ avg. queue time={self._average_queue_time} s, {self._current_availability}>"
             current_availability=status.current_availability,
             **kwargs
         )
-    
+
+    @classmethod
+    def _get_job_class(cls) -> Type[Job]:
+        """
+        Returns the job class associated to this target.
+
+        The job class used by submit and get_job.  The default is Job.
+        """
+        return Job
+
     def refresh(self):
         """Update the target availability and queue time"""
         targets = self.workspace._get_target_status(self.name, self.provider_id)
@@ -152,7 +155,8 @@ target '{self.name}' of provider '{self.provider_id}' not found."
         content_type = kwargs.pop("content_type", self.content_type)
         encoding = kwargs.pop("encoding", self.encoding)
         blob = self._encode_input_data(data=input_data)
-        return self._job_cls.from_input_data(
+        job_cls = type(self)._get_job_class()
+        return job_cls.from_input_data(
             workspace=self.workspace,
             name=name,
             target=self.name,

--- a/azure-quantum/azure/quantum/target/target_factory.py
+++ b/azure-quantum/azure/quantum/target/target_factory.py
@@ -4,7 +4,7 @@
 ##
 import warnings
 import asyncio
-from typing import Any, Dict, List, TYPE_CHECKING, Union
+from typing import Any, Dict, List, TYPE_CHECKING, Union, Type
 from azure.quantum.target import *
 
 if TYPE_CHECKING:
@@ -29,7 +29,7 @@ class TargetFactory:
 
     def __init__(
         self,
-        base_cls: Target,
+        base_cls: Type[Target],
         workspace: "Workspace",
         default_targets: Dict[str, Any] = DEFAULT_TARGETS,
         all_targets: Dict[str, Any] = None

--- a/azure-quantum/azure/quantum/workspace.py
+++ b/azure-quantum/azure/quantum/workspace.py
@@ -275,9 +275,16 @@ class Workspace:
 
     def get_job(self, job_id: str) -> Job:
         """Returns the job corresponding to the given id."""
+        from azure.quantum.target.target_factory import TargetFactory
+        from azure.quantum.target import Target
+
         client = self._get_jobs_client()
         details = client.get(job_id)
-        return Job(self, details)
+        target_factory = TargetFactory(base_cls=Target, workspace=self)
+        target = target_factory.create_target(
+            details.provider_id,
+            details.target)
+        return target._job_cls(self, details)
 
     def list_jobs(
         self,

--- a/azure-quantum/azure/quantum/workspace.py
+++ b/azure-quantum/azure/quantum/workspace.py
@@ -281,10 +281,11 @@ class Workspace:
         client = self._get_jobs_client()
         details = client.get(job_id)
         target_factory = TargetFactory(base_cls=Target, workspace=self)
-        target = target_factory.create_target(
+        target_cls = target_factory._target_cls(
             details.provider_id,
             details.target)
-        return target._job_cls(self, details)
+        job_cls = target_cls._get_job_class()
+        return job_cls(self, details)
 
     def list_jobs(
         self,

--- a/azure-quantum/tests/unit/recordings/test_estimator_non_batching_job.yaml
+++ b/azure-quantum/tests/unit/recordings/test_estimator_non_batching_job.yaml
@@ -55,13 +55,13 @@ interactions:
     body:
       string: '{"value": [{"id": "ionq", "currentAvailability": "Available", "targets":
         [{"id": "ionq.qpu", "currentAvailability": "Available", "averageQueueTime":
-        19618, "statusPage": "https://status.ionq.co"}, {"id": "ionq.qpu.aria-1",
-        "currentAvailability": "Available", "averageQueueTime": 698092, "statusPage":
+        68528, "statusPage": "https://status.ionq.co"}, {"id": "ionq.qpu.aria-1",
+        "currentAvailability": "Available", "averageQueueTime": 448177, "statusPage":
         "https://status.ionq.co"}, {"id": "ionq.simulator", "currentAvailability":
         "Available", "averageQueueTime": 2, "statusPage": "https://status.ionq.co"},
         {"id": "ionq.qpu-preview", "currentAvailability": "Available", "averageQueueTime":
-        19618, "statusPage": "https://status.ionq.co"}, {"id": "ionq.qpu.aria-1-preview",
-        "currentAvailability": "Available", "averageQueueTime": 698092, "statusPage":
+        68528, "statusPage": "https://status.ionq.co"}, {"id": "ionq.qpu.aria-1-preview",
+        "currentAvailability": "Available", "averageQueueTime": 448177, "statusPage":
         "https://status.ionq.co"}, {"id": "ionq.simulator-preview", "currentAvailability":
         "Available", "averageQueueTime": 2, "statusPage": "https://status.ionq.co"}]},
         {"id": "Microsoft.Test", "currentAvailability": "Available", "targets": [{"id":
@@ -77,50 +77,49 @@ interactions:
         {"id": "sparse-sim-ionq", "currentAvailability": "Available", "averageQueueTime":
         1, "statusPage": ""}, {"id": "echo-output", "currentAvailability": "Available",
         "averageQueueTime": 1, "statusPage": ""}]}, {"id": "rigetti", "currentAvailability":
-        "Degraded", "targets": [{"id": "rigetti.sim.qvm", "currentAvailability": "Available",
-        "averageQueueTime": 5, "statusPage": "https://rigetti.statuspage.io/"}, {"id":
-        "rigetti.qpu.aspen-11", "currentAvailability": "Unavailable", "averageQueueTime":
-        0, "statusPage": null}, {"id": "rigetti.qpu.aspen-m-2", "currentAvailability":
+        "Available", "targets": [{"id": "rigetti.sim.qvm", "currentAvailability":
         "Available", "averageQueueTime": 5, "statusPage": "https://rigetti.statuspage.io/"},
-        {"id": "rigetti.qpu.aspen-m-3", "currentAvailability": "Available", "averageQueueTime":
-        5, "statusPage": "https://rigetti.statuspage.io/"}]}, {"id": "microsoft-qc",
-        "currentAvailability": "Available", "targets": [{"id": "microsoft.estimator",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": null}]},
-        {"id": "quantinuum", "currentAvailability": "Degraded", "targets": [{"id":
-        "quantinuum.hqs-lt-s1", "currentAvailability": "Unavailable", "averageQueueTime":
-        0, "statusPage": "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.hqs-lt-s1-apival",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"},
+        {"id": "rigetti.qpu.aspen-m-2", "currentAvailability": "Available", "averageQueueTime":
+        5, "statusPage": "https://rigetti.statuspage.io/"}, {"id": "rigetti.qpu.aspen-m-3",
+        "currentAvailability": "Available", "averageQueueTime": 5, "statusPage": "https://rigetti.statuspage.io/"}]},
+        {"id": "microsoft-qc", "currentAvailability": "Available", "targets": [{"id":
+        "microsoft.estimator", "currentAvailability": "Available", "averageQueueTime":
+        0, "statusPage": null}]}, {"id": "quantinuum", "currentAvailability": "Degraded",
+        "targets": [{"id": "quantinuum.hqs-lt-s1", "currentAvailability": "Unavailable",
+        "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"},
+        {"id": "quantinuum.hqs-lt-s1-apival", "currentAvailability": "Available",
+        "averageQueueTime": 1, "statusPage": "https://www.quantinuum.com/products/h1"},
         {"id": "quantinuum.hqs-lt-s2", "currentAvailability": "Unavailable", "averageQueueTime":
         0, "statusPage": "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.hqs-lt-s2-apival",
         "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"},
         {"id": "quantinuum.hqs-lt-s1-sim", "currentAvailability": "Available", "averageQueueTime":
-        7, "statusPage": "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.hqs-lt-s2-sim",
-        "currentAvailability": "Available", "averageQueueTime": 10, "statusPage":
+        8, "statusPage": "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.hqs-lt-s2-sim",
+        "currentAvailability": "Available", "averageQueueTime": 12, "statusPage":
         "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.hqs-lt", "currentAvailability":
         "Unavailable", "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"},
         {"id": "quantinuum.qpu.h1-1", "currentAvailability": "Unavailable", "averageQueueTime":
         0, "statusPage": "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.sim.h1-1sc",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"},
+        "currentAvailability": "Available", "averageQueueTime": 1, "statusPage": "https://www.quantinuum.com/products/h1"},
         {"id": "quantinuum.qpu.h1-2", "currentAvailability": "Unavailable", "averageQueueTime":
         0, "statusPage": "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.sim.h1-2sc",
         "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"},
         {"id": "quantinuum.sim.h1-1e", "currentAvailability": "Available", "averageQueueTime":
-        7, "statusPage": "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.sim.h1-2e",
-        "currentAvailability": "Available", "averageQueueTime": 10, "statusPage":
+        8, "statusPage": "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.sim.h1-2e",
+        "currentAvailability": "Available", "averageQueueTime": 12, "statusPage":
         "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.qpu.h1", "currentAvailability":
         "Unavailable", "averageQueueTime": 0, "statusPage": null}, {"id": "quantinuum.qpu.h2-1",
-        "currentAvailability": "Unavailable", "averageQueueTime": 0, "statusPage":
+        "currentAvailability": "Unavailable", "averageQueueTime": 8918, "statusPage":
         "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.sim.h2-1sc",
         "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"},
         {"id": "quantinuum.sim.h2-1e", "currentAvailability": "Available", "averageQueueTime":
-        109991, "statusPage": "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.sim.h1-1sc-preview",
-        "currentAvailability": "Available", "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"},
+        5138, "statusPage": "https://www.quantinuum.com/products/h1"}, {"id": "quantinuum.sim.h1-1sc-preview",
+        "currentAvailability": "Available", "averageQueueTime": 1, "statusPage": "https://www.quantinuum.com/products/h1"},
         {"id": "quantinuum.sim.h1-2sc-preview", "currentAvailability": "Available",
         "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"},
         {"id": "quantinuum.sim.h1-1e-preview", "currentAvailability": "Available",
-        "averageQueueTime": 7, "statusPage": "https://www.quantinuum.com/products/h1"},
+        "averageQueueTime": 8, "statusPage": "https://www.quantinuum.com/products/h1"},
         {"id": "quantinuum.sim.h1-2e-preview", "currentAvailability": "Available",
-        "averageQueueTime": 10, "statusPage": "https://www.quantinuum.com/products/h1"},
+        "averageQueueTime": 12, "statusPage": "https://www.quantinuum.com/products/h1"},
         {"id": "quantinuum.qpu.h1-1-preview", "currentAvailability": "Unavailable",
         "averageQueueTime": 0, "statusPage": "https://www.quantinuum.com/products/h1"},
         {"id": "quantinuum.qpu.h1-2-preview", "currentAvailability": "Unavailable",
@@ -130,7 +129,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '6187'
+      - '6076'
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -183,7 +182,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-blob/12.14.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Fri, 03 Mar 2023 09:32:23 GMT
+      - Thu, 09 Mar 2023 08:31:02 GMT
       x-ms-version:
       - '2021-08-06'
     method: GET
@@ -191,7 +190,7 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
-        specified container does not exist.\nRequestId:776f8e19-b01e-00e2-0ab3-4da7a0000000\nTime:2023-03-03T09:32:23.9243487Z</Message></Error>"
+        specified container does not exist.\nRequestId:9a841619-901e-0063-4261-52077a000000\nTime:2023-03-09T08:31:03.2349586Z</Message></Error>"
     headers:
       content-length:
       - '223'
@@ -216,7 +215,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-blob/12.14.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Fri, 03 Mar 2023 09:32:23 GMT
+      - Thu, 09 Mar 2023 08:31:03 GMT
       x-ms-version:
       - '2021-08-06'
     method: PUT
@@ -244,7 +243,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-blob/12.14.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Fri, 03 Mar 2023 09:32:24 GMT
+      - Thu, 09 Mar 2023 08:31:03 GMT
       x-ms-version:
       - '2021-08-06'
     method: GET
@@ -337,7 +336,7 @@ interactions:
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Fri, 03 Mar 2023 09:32:24 GMT
+      - Thu, 09 Mar 2023 08:31:04 GMT
       x-ms-version:
       - '2021-08-06'
     method: PUT
@@ -384,7 +383,7 @@ interactions:
         "beginExecutionTime": null, "cancellationTime": null, "quantumComputingData":
         null, "errorData": null, "isCancelling": false, "tags": [], "name": "azure-quantum-job",
         "id": "00000000-0000-0000-0000-000000000000", "providerId": "microsoft-qc",
-        "target": "microsoft.estimator", "creationTime": "2023-03-03T09:32:25.2049077+00:00",
+        "target": "microsoft.estimator", "creationTime": "2023-03-09T08:31:04.5478272+00:00",
         "endExecutionTime": null, "costEstimate": null, "itemType": "Job", "access_token":
         "fake_token"}'
     headers:
@@ -419,11 +418,11 @@ interactions:
         "inputDataFormat": "qir.v1", "inputParams": {}, "metadata": null, "sessionId":
         null, "status": "Succeeded", "jobType": "QuantumComputing", "outputDataFormat":
         "microsoft.resource-estimates.v1", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dazure-quantum-job-00000000-0000-0000-0000-000000000000.output.json",
-        "beginExecutionTime": "2023-03-03T09:32:25.3841631Z", "cancellationTime":
+        "beginExecutionTime": "2023-03-09T08:30:59.6053258Z", "cancellationTime":
         null, "quantumComputingData": {"count": 1}, "errorData": null, "isCancelling":
         false, "tags": [], "name": "azure-quantum-job", "id": "00000000-0000-0000-0000-000000000000",
         "providerId": "microsoft-qc", "target": "microsoft.estimator", "creationTime":
-        "2023-03-03T09:32:25.2049077+00:00", "endExecutionTime": "2023-03-03T09:32:31.4677805Z",
+        "2023-03-09T08:31:04.5478272+00:00", "endExecutionTime": "2023-03-09T08:31:04.0837134Z",
         "costEstimate": null, "itemType": "Job", "access_token": "fake_token"}'
     headers:
       connection:
@@ -449,7 +448,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-blob/12.14.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
       x-ms-date:
-      - Fri, 03 Mar 2023 09:32:37 GMT
+      - Thu, 09 Mar 2023 08:31:12 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
@@ -782,7 +781,402 @@ interactions:
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Fri, 03 Mar 2023 09:32:26 GMT
+      - Thu, 09 Mar 2023 08:31:05 GMT
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2021-08-06'
+    status:
+      code: 206
+      message: Partial Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - testapp azsdk-python-quantum/0.0.0.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://eastus.quantum.azure.com/v1.0/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Quantum/workspaces/myworkspace/jobs/00000000-0000-0000-0000-000000000000
+  response:
+    body:
+      string: '{"containerUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000?sv=PLACEHOLDER&sig=PLACEHOLDER&se=PLACEHOLDER&srt=co&ss=b&sp=racw",
+        "inputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/inputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dazure-quantum-job-00000000-0000-0000-0000-000000000000.input.json",
+        "inputDataFormat": "qir.v1", "inputParams": {}, "metadata": null, "sessionId":
+        null, "status": "Succeeded", "jobType": "QuantumComputing", "outputDataFormat":
+        "microsoft.resource-estimates.v1", "outputDataUri": "https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dazure-quantum-job-00000000-0000-0000-0000-000000000000.output.json",
+        "beginExecutionTime": "2023-03-09T08:30:59.6053258Z", "cancellationTime":
+        null, "quantumComputingData": {"count": 1}, "errorData": null, "isCancelling":
+        false, "tags": [], "name": "azure-quantum-job", "id": "00000000-0000-0000-0000-000000000000",
+        "providerId": "microsoft-qc", "target": "microsoft.estimator", "creationTime":
+        "2023-03-09T08:31:04.5478272+00:00", "endExecutionTime": "2023-03-09T08:31:04.0837134Z",
+        "costEstimate": null, "itemType": "Job", "access_token": "fake_token"}'
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '1380'
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-storage-blob/12.14.1 Python/3.7.13 (Darwin-22.3.0-x86_64-i386-64bit)
+      x-ms-date:
+      - Thu, 09 Mar 2023 08:31:13 GMT
+      x-ms-range:
+      - bytes=0-33554431
+      x-ms-version:
+      - '2021-08-06'
+    method: GET
+    uri: https://mystorage.blob.core.windows.net/job-00000000-0000-0000-0000-000000000000/rawOutputData?sv=PLACEHOLDER&sr=b&sig=PLACEHOLDER&se=PLACEHOLDER&sp=r&rscd=attachment%3B%20filename%3Dazure-quantum-job-00000000-0000-0000-0000-000000000000.output.json
+  response:
+    body:
+      string: '{"errorBudget": {"logical": 0.0005, "rotations": 0.0, "tstates": 0.0005},
+        "jobParams": {"errorBudget": 0.001, "qecScheme": {"crossingPrefactor": 0.03,
+        "errorCorrectionThreshold": 0.01, "logicalCycleTime": "(4 * twoQubitGateTime
+        + 2 * oneQubitMeasurementTime) * codeDistance", "name": "surface_code", "physicalQubitsPerLogicalQubit":
+        "2 * codeDistance * codeDistance"}, "qubitParams": {"instructionSet": "GateBased",
+        "name": "qubit_gate_ns_e3", "oneQubitGateErrorRate": 0.001, "oneQubitGateTime":
+        "50 ns", "oneQubitMeasurementErrorRate": 0.001, "oneQubitMeasurementTime":
+        "100 ns", "tGateErrorRate": 0.001, "tGateTime": "50 ns", "twoQubitGateErrorRate":
+        0.001, "twoQubitGateTime": "50 ns"}}, "logicalCounts": {"ccixCount": 0, "cczCount":
+        1, "measurementCount": 3, "numQubits": 3, "rotationCount": 0, "rotationDepth":
+        0, "tCount": 0}, "logicalQubit": {"codeDistance": 7, "logicalCycleTime": 2800.0,
+        "logicalErrorRate": 3.0000000000000013e-06, "physicalQubits": 98}, "physicalCounts":
+        {"breakdown": {"algorithmicLogicalDepth": 6, "algorithmicLogicalQubits": 12,
+        "cliffordErrorRate": 0.001, "logicalDepth": 13, "numTfactories": 4, "numTfactoryRuns":
+        1, "numTsPerRotation": null, "numTstates": 4, "physicalQubitsForAlgorithm":
+        1176, "physicalQubitsForTfactories": 15680, "requiredLogicalQubitErrorRate":
+        3.2051282051282054e-06, "requiredLogicalTstateErrorRate": 0.000125}, "physicalQubits":
+        16856, "runtime": 36400}, "physicalCountsFormatted": {"codeDistancePerRound":
+        "7", "errorBudget": "1.00e-3", "errorBudgetLogical": "5.00e-4", "errorBudgetRotations":
+        "0.00e0", "errorBudgetTstates": "5.00e-4", "logicalCycleTime": "2us 800ns",
+        "logicalErrorRate": "3.00e-6", "numTsPerRotation": "No rotations in algorithm",
+        "numUnitsPerRound": "2", "physicalQubitsForTfactoriesPercentage": "93.02 %",
+        "physicalQubitsPerRound": "3920", "requiredLogicalQubitErrorRate": "3.21e-6",
+        "requiredLogicalTstateErrorRate": "1.25e-4", "runtime": "36us 400ns", "tfactoryRuntime":
+        "36us 400ns", "tfactoryRuntimePerRound": "36us 400ns", "tstateLogicalErrorRate":
+        "2.13e-5", "unitNamePerRound": "15-to-1 space efficient logical"}, "reportData":
+        {"assumptions": ["_More details on the following lists of assumptions can
+        be found in the paper [Accessing requirements for scaling quantum computers
+        and their applications](https://aka.ms/AQ/RE/Paper)._", "**Uniform independent
+        physical noise.** We assume that the noise on physical qubits and physical
+        qubit operations is the standard circuit noise model. In particular we assume
+        error events at different space-time locations are independent and that error
+        rates are uniform across the system in time and space.", "**Efficient classical
+        computation.** We assume that classical overhead (compilation, control, feedback,
+        readout, decoding, etc.) does not dominate the overall cost of implementing
+        the full quantum algorithm.", "**Extraction circuits for planar quantum ISA.**
+        We assume that stabilizer extraction circuits with similar depth and error
+        correction performance to those for standard surface and Hastings-Haah code
+        patches can be constructed to implement all operations of the planar quantum
+        ISA (instruction set architecture).", "**Uniform independent logical noise.**
+        We assume that the error rate of a logical operation is approximately equal
+        to its space-time volume (the number of tiles multiplied by the number of
+        logical time steps) multiplied by the error rate of a logical qubit in a standard
+        one-tile patch in one logical time step.", "**Negligible Clifford costs for
+        synthesis.** We assume that the space overhead for synthesis and space and
+        time overhead for transport of magic states within magic state factories and
+        to synthesis qubits are all negligible.", "**Smooth magic state consumption
+        rate.** We assume that the rate of T state consumption throughout the compiled
+        algorithm is almost constant, or can be made almost constant without significantly
+        increasing the number of logical time steps for the algorithm."], "groups":
+        [{"alwaysVisible": true, "entries": [{"description": "Number of physical qubits",
+        "explanation": "This value represents the total number of physical qubits,
+        which is the sum of 1176 physical qubits to implement the algorithm logic,
+        and 15680 physical qubits to execute the T factories that are responsible
+        to produce the T states that are consumed by the algorithm.", "label": "Physical
+        qubits", "path": "physicalCounts/physicalQubits"}, {"description": "Total
+        runtime", "explanation": "This is a runtime estimate (in nanosecond precision)
+        for the execution time of the algorithm.  In general, the execution time corresponds
+        to the duration of one logical cycle (2us 800ns) multiplied by the 6 logical
+        cycles to run the algorithm.  If however the duration of a single T factory
+        (here: 36us 400ns) is larger than the algorithm runtime, we extend the number
+        of logical cycles artificially in order to exceed the runtime of a single
+        T factory.", "label": "Runtime", "path": "physicalCountsFormatted/runtime"}],
+        "title": "Physical resource estimates"}, {"alwaysVisible": false, "entries":
+        [{"description": "Number of logical qubits for the algorithm after layout",
+        "explanation": "Laying out the logical qubits in the presence of nearest-neighbor
+        constraints requires additional logical qubits.  In particular, to layout
+        the $Q_{\\rm alg} = 3$ logical qubits in the input algorithm, we require in
+        total $2 \\cdot Q_{\\rm alg} + \\lceil \\sqrt{8 \\cdot Q_{\\rm alg}}\\rceil
+        + 1 = 12$ logical qubits.", "label": "Logical algorithmic qubits", "path":
+        "physicalCounts/breakdown/algorithmicLogicalQubits"}, {"description": "Number
+        of logical cycles for the algorithm", "explanation": "To execute the algorithm
+        using _Parallel Synthesis Sequential Pauli Computation_ (PSSPC), operations
+        are scheduled in terms of multi-qubit Pauli measurements, for which assume
+        an execution time of one logical cycle.  Based on the input algorithm, we
+        require one multi-qubit measurement for the 3 single-qubit measurements, the
+        0 arbitrary single-qubit rotations, and the 0 T gates, three multi-qubit measurements
+        for each of the 1 CCZ and 0 CCiX gates in the input program, as well as No
+        rotations in algorithm multi-qubit measurements for each of the 0 non-Clifford
+        layers in which there is at least one single-qubit rotation with an arbitrary
+        angle rotation.", "label": "Algorithmic depth", "path": "physicalCounts/breakdown/algorithmicLogicalDepth"},
+        {"description": "Number of logical cycles performed", "explanation": "This
+        number is usually equal to the logical depth of the algorithm, which is 6.  However,
+        in the case in which a single T factory is slower than the execution time
+        of the algorithm, we adjust the logical cycle depth to exceed the T factory''s
+        execution time.", "label": "Logical depth", "path": "physicalCounts/breakdown/logicalDepth"},
+        {"description": "Number of T states consumed by the algorithm", "explanation":
+        "To execute the algorithm, we require one T state for each of the 0 T gates,
+        four T states for each of the 1 CCZ and 0 CCiX gates, as well as No rotations
+        in algorithm for each of the 0 single-qubit rotation gates with arbitrary
+        angle rotation.", "label": "Number of T states", "path": "physicalCounts/breakdown/numTstates"},
+        {"description": "Number of T factories capable of producing the demanded 4
+        T states during the algorithm''s runtime", "explanation": "The total number
+        of T factories 4 that are executed in parallel is computed as $\\left\\lceil\\dfrac{4\\;\\text{T
+        states} \\cdot 36us 400ns\\;\\text{T factory duration}}{1\\;\\text{T states
+        per T factory} \\cdot 36us 400ns\\;\\text{algorithm runtime}}\\right\\rceil$",
+        "label": "Number of T factories", "path": "physicalCounts/breakdown/numTfactories"},
+        {"description": "Number of times all T factories are invoked", "explanation":
+        "In order to prepare the 4 T states, the 4 copies of the T factory are repeatedly
+        invoked 1 times.", "label": "Number of T factory invocations", "path": "physicalCounts/breakdown/numTfactoryRuns"},
+        {"description": "Number of physical qubits for the algorithm after layout",
+        "explanation": "The 1176 are the product of the 12 logical qubits after layout
+        and the 98 physical qubits that encode a single logical qubit.", "label":
+        "Physical algorithmic qubits", "path": "physicalCounts/breakdown/physicalQubitsForAlgorithm"},
+        {"description": "Number of physical qubits for the T factories", "explanation":
+        "Each T factory requires 3920 physical qubits and we run 4 in parallel, therefore
+        we need $15680 = 3920 \\cdot 4$ qubits.", "label": "Physical T factory qubits",
+        "path": "physicalCounts/breakdown/physicalQubitsForTfactories"}, {"description":
+        "The minimum logical qubit error rate required to run the algorithm within
+        the error budget", "explanation": "The minimum logical qubit error rate is
+        obtained by dividing the logical error probability 5.00e-4 by the product
+        of 12 logical qubits and the total cycle count 13.", "label": "Required logical
+        qubit error rate", "path": "physicalCountsFormatted/requiredLogicalQubitErrorRate"},
+        {"description": "The minimum T state error rate required for distilled T states",
+        "explanation": "The minimum T state error rate is obtained by dividing the
+        T distillation error probability 5.00e-4 by the total number of T states 4.",
+        "label": "Required logical T state error rate", "path": "physicalCountsFormatted/requiredLogicalTstateErrorRate"},
+        {"description": "Number of T states to implement a rotation with an arbitrary
+        angle", "explanation": "The number of T states to implement a rotation with
+        an arbitrary angle is $\\lceil 0.53 \\log_2(0 / 0) + 5.3\\rceil$ [[arXiv:2203.10064](https://arxiv.org/abs/2203.10064)].  For
+        simplicity, we use this formula for all single-qubit arbitrary angle rotations,
+        and do not distinguish between best, worst, and average cases.", "label":
+        "Number of T states per rotation", "path": "physicalCountsFormatted/numTsPerRotation"}],
+        "title": "Resource estimates breakdown"}, {"alwaysVisible": false, "entries":
+        [{"description": "Name of QEC scheme", "explanation": "You can load pre-defined
+        QEC schemes by using the name `surface_code` or `floquet_code`. The latter
+        only works with Majorana qubits.", "label": "QEC scheme", "path": "jobParams/qecScheme/name"},
+        {"description": "Required code distance for error correction", "explanation":
+        "The code distance is the smallest odd integer greater or equal to $\\dfrac{2\\log(0.03
+        / 0.0000032051282051282054)}{\\log(0.01/0.001)} - 1$", "label": "Code distance",
+        "path": "logicalQubit/codeDistance"}, {"description": "Number of physical
+        qubits per logical qubit", "explanation": "The number of physical qubits per
+        logical qubit are evaluated using the formula 2 * codeDistance * codeDistance
+        that can be user-specified.", "label": "Physical qubits", "path": "logicalQubit/physicalQubits"},
+        {"description": "Duration of a logical cycle in nanoseconds", "explanation":
+        "The runtime of one logical cycle in nanoseconds is evaluated using the formula
+        (4 * twoQubitGateTime + 2 * oneQubitMeasurementTime) * codeDistance that can
+        be user-specified.", "label": "Logical cycle time", "path": "physicalCountsFormatted/logicalCycleTime"},
+        {"description": "Logical qubit error rate", "explanation": "The logical qubit
+        error rate is computed as $0.03 \\cdot \\left(\\dfrac{0.001}{0.01}\\right)^\\frac{7
+        + 1}{2}$", "label": "Logical qubit error rate", "path": "physicalCountsFormatted/logicalErrorRate"},
+        {"description": "Crossing prefactor used in QEC scheme", "explanation": "The
+        crossing prefactor is usually extracted numerically from simulations when
+        fitting an exponential curve to model the relationship between logical and
+        physical error rate.", "label": "Crossing prefactor", "path": "jobParams/qecScheme/crossingPrefactor"},
+        {"description": "Error correction threshold used in QEC scheme", "explanation":
+        "The error correction threshold is the physical error rate below which the
+        error rate of the logical qubit is less than the error rate of the physical
+        qubit that constitute it.  This value is usually extracted numerically from
+        simulations of the logical error rate.", "label": "Error correction threshold",
+        "path": "jobParams/qecScheme/errorCorrectionThreshold"}, {"description": "QEC
+        scheme formula used to compute logical cycle time", "explanation": "This is
+        the formula that is used to compute the logical cycle time 2us 800ns.", "label":
+        "Logical cycle time formula", "path": "jobParams/qecScheme/logicalCycleTime"},
+        {"description": "QEC scheme formula used to compute number of physical qubits
+        per logical qubit", "explanation": "This is the formula that is used to compute
+        the number of physical qubits per logical qubits 98.", "label": "Physical
+        qubits formula", "path": "jobParams/qecScheme/physicalQubitsPerLogicalQubit"}],
+        "title": "Logical qubit parameters"}, {"alwaysVisible": false, "entries":
+        [{"description": "Number of physical qubits for a single T factory", "explanation":
+        "This corresponds to the maximum number of physical qubits over all rounds
+        of T distillation units in a T factory.  A round of distillation contains
+        of multiple copies of distillation units to achieve the required success probability
+        of producing a T state with the expected logical T state error rate.", "label":
+        "Physical qubits", "path": "tfactory/physicalQubits"}, {"description": "Runtime
+        of a single T factory", "explanation": "The runtime of a single T factory
+        is the accumulated runtime of executing each round in a T factory.", "label":
+        "Runtime", "path": "physicalCountsFormatted/tfactoryRuntime"}, {"description":
+        "Number of output T states produced in a single run of T factory", "explanation":
+        "The T factory takes as input 30 noisy physical T states with an error rate
+        of 0.001 and produces 1 T states with an error rate of 2.13e-5.", "label":
+        "Number of output T states per run", "path": "tfactory/numTstates"}, {"description":
+        "Number of physical input T states consumed in a single run of a T factory",
+        "explanation": "This value includes the physical input T states of all copies
+        of the distillation unit in the first round.", "label": "Number of input T
+        states per run", "path": "tfactory/numInputTstates"}, {"description": "The
+        number of distillation rounds", "explanation": "This is the number of distillation
+        rounds.  In each round one or multiple copies of some distillation unit is
+        executed.", "label": "Distillation rounds", "path": "tfactory/numRounds"},
+        {"description": "The number of units in each round of distillation", "explanation":
+        "This is the number of copies for the distillation units per round.", "label":
+        "Distillation units per round", "path": "physicalCountsFormatted/numUnitsPerRound"},
+        {"description": "The types of distillation units", "explanation": "These are
+        the types of distillation units that are executed in each round.  The units
+        can be either physical or logical, depending on what type of qubit they are
+        operating.  Space-efficient units require fewer qubits for the cost of longer
+        runtime compared to Reed-Muller preparation units.", "label": "Distillation
+        units", "path": "physicalCountsFormatted/unitNamePerRound"}, {"description":
+        "The code distance in each round of distillation", "explanation": "This is
+        the code distance used for the units in each round.  If the code distance
+        is 1, then the distillation unit operates on physical qubits instead of error-corrected
+        logical qubits.", "label": "Distillation code distances", "path": "physicalCountsFormatted/codeDistancePerRound"},
+        {"description": "The number of physical qubits used in each round of distillation",
+        "explanation": "The maximum number of physical qubits over all rounds is the
+        number of physical qubits for the T factory, since qubits are reused by different
+        rounds.", "label": "Number of physical qubits per round", "path": "physicalCountsFormatted/physicalQubitsPerRound"},
+        {"description": "The runtime of each distillation round", "explanation": "The
+        runtime of the T factory is the sum of the runtimes in all rounds.", "label":
+        "Runtime per round", "path": "physicalCountsFormatted/tfactoryRuntimePerRound"},
+        {"description": "Logical T state error rate", "explanation": "This is the
+        logical T state error rate achieved by the T factory which is equal or smaller
+        than the required error rate 1.25e-4.", "label": "Logical T state error rate",
+        "path": "physicalCountsFormatted/tstateLogicalErrorRate"}], "title": "T factory
+        parameters"}, {"alwaysVisible": false, "entries": [{"description": "Number
+        of logical qubits in the input quantum program", "explanation": "We determine
+        12 from this number by assuming to align them in a 2D grid.  Auxiliary qubits
+        are added to allow for sufficient space to execute multi-qubit Pauli measurements
+        on all or a subset of the logical qubits.", "label": "Logical qubits (pre-layout)",
+        "path": "logicalCounts/numQubits"}, {"description": "Number of T gates in
+        the input quantum program", "explanation": "This includes all T gates and
+        adjoint T gates, but not T gates used to implement rotation gates with arbitrary
+        angle, CCZ gates, or CCiX gates.", "label": "T gates", "path": "logicalCounts/tCount"},
+        {"description": "Number of rotation gates in the input quantum program", "explanation":
+        "This is the number of all rotation gates. If an angle corresponds to a Pauli,
+        Clifford, or T gate, it is not accounted for in this number.", "label": "Rotation
+        gates", "path": "logicalCounts/rotationCount"}, {"description": "Depth of
+        rotation gates in the input quantum program", "explanation": "This is the
+        number of all non-Clifford layers that include at least one single-qubit rotation
+        gate with an arbitrary angle.", "label": "Rotation depth", "path": "logicalCounts/rotationDepth"},
+        {"description": "Number of CCZ-gates in the input quantum program", "explanation":
+        "This is the number of CCZ gates.", "label": "CCZ gates", "path": "logicalCounts/cczCount"},
+        {"description": "Number of CCiX-gates in the input quantum program", "explanation":
+        "This is the number of CCiX gates, which applies $-iX$ controlled on two control
+        qubits [[1212.5069](https://arxiv.org/abs/1212.5069)].", "label": "CCiX gates",
+        "path": "logicalCounts/ccixCount"}, {"description": "Number of single qubit
+        measurements in the input quantum program", "explanation": "This is the number
+        of single qubit measurements in Pauli basis that are used in the input program.  Note
+        that all measurements are counted, however, the measurement result is is determined
+        randomly (with a fixed seed) to be 0 or 1 with a probability of 50%.", "label":
+        "Measurement operations", "path": "logicalCounts/measurementCount"}], "title":
+        "Pre-layout logical resources"}, {"alwaysVisible": false, "entries": [{"description":
+        "Total error budget for the algorithm", "explanation": "The total error budget
+        sets the overall allowed error for the algorithm, i.e., the number of times
+        it is allowed to fail.  Its value must be between 0 and 1 and the default
+        value is 0.001, which corresponds to 0.1%, and means that the algorithm is
+        allowed to fail once in 1000 executions.  This parameter is highly application
+        specific. For example, if one is running Shor''s algorithm for factoring integers,
+        a large value for the error budget may be tolerated as one can check that
+        the output are indeed the prime factors of the input.  On the other hand,
+        a much smaller error budget may be needed for an algorithm solving a problem
+        with a solution which cannot be efficiently verified.  This budget $\\epsilon
+        = \\epsilon_{\\log} + \\epsilon_{\\rm dis} + \\epsilon_{\\rm syn}$ is uniformly
+        distributed and applies to errors $\\epsilon_{\\log}$ to implement logical
+        qubits, an error budget $\\epsilon_{\\rm dis}$ to produce T states through
+        distillation, and an error budget $\\epsilon_{\\rm syn}$ to synthesize rotation
+        gates with arbitrary angles.  Note that for distillation and rotation synthesis,
+        the respective error budgets $\\epsilon_{\\rm dis}$ and $\\epsilon_{\\rm syn}$
+        are uniformly distributed among all T states and all rotation gates, respectively.
+        If there are no rotation gates in the input algorithm, the error budget is
+        uniformly distributed to logical errors and T state errors.", "label": "Total
+        error budget", "path": "physicalCountsFormatted/errorBudget"}, {"description":
+        "Probability of at least one logical error", "explanation": "This is one third
+        of the total error budget 1.00e-3 if the input algorithm contains rotation
+        with gates with arbitrary angles, or one half of it, otherwise.", "label":
+        "Logical error probability", "path": "physicalCountsFormatted/errorBudgetLogical"},
+        {"description": "Probability of at least one faulty T distillation", "explanation":
+        "This is one third of the total error budget 1.00e-3 if the input algorithm
+        contains rotation with gates with arbitrary angles, or one half of it, otherwise.",
+        "label": "T distillation error probability", "path": "physicalCountsFormatted/errorBudgetTstates"},
+        {"description": "Probability of at least one failed rotation synthesis", "explanation":
+        "This is one third of the total error budget 1.00e-3.", "label": "Rotation
+        synthesis error probability", "path": "physicalCountsFormatted/errorBudgetRotations"}],
+        "title": "Assumed error budget"}, {"alwaysVisible": false, "entries": [{"description":
+        "Some descriptive name for the qubit model", "explanation": "You can load
+        pre-defined qubit parameters by using the names `qubit_gate_ns_e3`, `qubit_gate_ns_e4`,
+        `qubit_gate_us_e3`, `qubit_gate_us_e4`, `qubit_maj_ns_e4`, or `qubit_maj_ns_e6`.  The
+        names of these pre-defined qubit parameters indicate the instruction set (gate-based
+        or Majorana), the operation speed (ns or \u00ac\u00b5s regime), as well as
+        the fidelity (e.g., e3 for $10^{-3}$ gate error rates).", "label": "Qubit
+        name", "path": "jobParams/qubitParams/name"}, {"description": "Underlying
+        qubit technology (gate-based or Majorana)", "explanation": "When modeling
+        the physical qubit abstractions, we distinguish between two different physical
+        instruction sets that are used to operate the qubits.  The physical instruction
+        set can be either *gate-based* or *Majorana*.  A gate-based instruction set
+        provides single-qubit measurement, single-qubit gates (incl. T gates), and
+        two-qubit gates.  A Majorana instruction set provides a physical T gate, single-qubit
+        measurement and two-qubit joint measurement operations.", "label": "Instruction
+        set", "path": "jobParams/qubitParams/instructionSet"}, {"description": "Operation
+        time for single-qubit measurement (t_meas) in ns", "explanation": "This is
+        the operation time in nanoseconds to perform a single-qubit measurement in
+        the Pauli basis.", "label": "Single-qubit measurement time", "path": "jobParams/qubitParams/oneQubitMeasurementTime"},
+        {"description": "Operation time for single-qubit gate (t_gate) in ns", "explanation":
+        "This is the operation time in nanoseconds to perform a single-qubit Clifford
+        operation, e.g., Hadamard or Phase gates.", "label": "Single-qubit gate time",
+        "path": "jobParams/qubitParams/oneQubitGateTime"}, {"description": "Operation
+        time for two-qubit gate in ns", "explanation": "This is the operation time
+        in nanoseconds to perform a two-qubit Clifford operation, e.g., a CNOT or
+        CZ gate.", "label": "Two-qubit gate time", "path": "jobParams/qubitParams/twoQubitGateTime"},
+        {"description": "Operation time for a T gate", "explanation": "This is the
+        operation time in nanoseconds to execute a T gate.", "label": "T gate time",
+        "path": "jobParams/qubitParams/tGateTime"}, {"description": "Error rate for
+        single-qubit measurement", "explanation": "This is the probability in which
+        a single-qubit measurement in the Pauli basis may fail.", "label": "Single-qubit
+        measurement error rate", "path": "jobParams/qubitParams/oneQubitMeasurementErrorRate"},
+        {"description": "Error rate for single-qubit Clifford gate (p)", "explanation":
+        "This is the probability in which a single-qubit Clifford operation, e.g.,
+        Hadamard or Phase gates, may fail.", "label": "Single-qubit error rate", "path":
+        "jobParams/qubitParams/oneQubitGateErrorRate"}, {"description": "Error rate
+        for two-qubit Clifford gate", "explanation": "This is the probability in which
+        a two-qubit Clifford operation, e.g., CNOT or CZ gates, may fail.", "label":
+        "Two-qubit error rate", "path": "jobParams/qubitParams/twoQubitGateErrorRate"},
+        {"description": "Error rate to prepare single-qubit T state or apply a T gate
+        (p_T)", "explanation": "This is the probability in which executing a single
+        T gate may fail.", "label": "T gate error rate", "path": "jobParams/qubitParams/tGateErrorRate"}],
+        "title": "Physical qubit parameters"}]}, "status": "success", "tfactory":
+        {"codeDistancePerRound": [7], "logicalErrorRate": 2.133500000000001e-05, "numInputTstates":
+        30, "numRounds": 1, "numTstates": 1, "numUnitsPerRound": [2], "physicalQubits":
+        3920, "physicalQubitsPerRound": [3920], "runtime": 36400.0, "runtimePerRound":
+        [36400.0], "unitNamePerRound": ["15-to-1 space efficient logical"]}, "access_token":
+        "fake_token"}'
+    headers:
+      accept-ranges:
+      - bytes
+      content-length:
+      - '24888'
+      content-range:
+      - bytes 0-24215/24216
+      content-type:
+      - application/json
+      x-ms-blob-content-md5:
+      - NRwDssw6Ljw/QFnjlWs26w==
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-creation-time:
+      - Thu, 09 Mar 2023 08:31:05 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:

--- a/azure-quantum/tests/unit/test_microsoft_qc.py
+++ b/azure-quantum/tests/unit/test_microsoft_qc.py
@@ -70,5 +70,11 @@ class TestMicrosoftQC(QuantumTestBase):
                     raise Exception(f"Job {job.id} not succeeded in "
                                     "test_estimator_non_batching_job")
                 result = job.get_results()
-
                 assert type(result) == dict
+
+                # Retrieve job by ID
+                job2 = ws.get_job(job.id)
+                assert type(job2) == type(job)
+                result2 = job2.get_results()
+                assert type(result2) == type(result)
+


### PR DESCRIPTION
This removes `Target.get_job` and implements `Workspace.get_job` in a way that it uses the target specific `Job` class if it exists.