### PR TITLE
Constants for default qubit params and QEC schemes

### DIFF
--- a/azure-quantum/azure/quantum/target/microsoft/__init__.py
+++ b/azure-quantum/azure/quantum/target/microsoft/__init__.py
@@ -12,8 +12,10 @@ from .qio import (
 )
 
 __all__ = ["MicrosoftEstimator", "MicrosoftEstimatorJob",
-           "MicrosoftEstimatorResult", "MicrosoftEstimatorParams"]
+           "MicrosoftEstimatorResult", "MicrosoftEstimatorParams",
+           "QECScheme", "QubitParams"]
 
 from .job import MicrosoftEstimatorJob
 from .result import MicrosoftEstimatorResult
-from .target import MicrosoftEstimator, MicrosoftEstimatorParams
+from .target import MicrosoftEstimator, MicrosoftEstimatorParams, QECScheme, \
+    QubitParams

--- a/azure-quantum/azure/quantum/target/microsoft/target.py
+++ b/azure-quantum/azure/quantum/target/microsoft/target.py
@@ -14,6 +14,20 @@ from ..target import Target
 from . import MicrosoftEstimatorJob
 
 
+class QubitParams:
+    GATE_US_E3 = "qubit_gate_us_e3"
+    GATE_US_E4 = "qubit_gate_us_e4"
+    GATE_NS_E3 = "qubit_gate_ns_e3"
+    GATE_NS_E4 = "qubit_gate_ns_e4"
+    MAJ_NS_E4 = "qubit_maj_ns_e4"
+    MAJ_NS_E6 = "qubit_maj_ns_e6"
+
+
+class QECScheme:
+    SURFACE_CODE = "surface_code"
+    FLOQUET_CODE = "floquet_code"
+
+
 @dataclass
 class MicrosoftEstimatorQubitParams(AutoValidatingParams):
     @staticmethod
@@ -52,9 +66,9 @@ class MicrosoftEstimatorQubitParams(AutoValidatingParams):
         validating_field(check_error_rate)
     t_gate_error_rate: Optional[float] = validating_field(check_error_rate)
 
-    _default_models = ["qubit_gate_us_e3", "qubit_gate_us_e4",
-                       "qubit_gate_ns_e3", "qubit_gate_ns_e4",
-                       "qubit_maj_ns_e4", "qubit_maj_ns_e6"]
+    _default_models = [QubitParams.GATE_US_E3, QubitParams.GATE_US_E4,
+                       QubitParams.GATE_NS_E3, QubitParams.GATE_NS_E4,
+                       QubitParams.MAJ_NS_E4, QubitParams.MAJ_NS_E6]
     _gate_based = ["gate-based", "gate_based", "GateBased", "gateBased"]
     _maj_based = ["Majorana", "majorana"]
 

--- a/azure-quantum/tests/unit/test_microsoft_qc.py
+++ b/azure-quantum/tests/unit/test_microsoft_qc.py
@@ -17,7 +17,8 @@ from common import QuantumTestBase, ZERO_UID
 
 from azure.quantum.job.job import Job
 from azure.quantum.target.microsoft import MicrosoftEstimator, \
-    MicrosoftEstimatorJob, MicrosoftEstimatorResult, MicrosoftEstimatorParams
+    MicrosoftEstimatorJob, MicrosoftEstimatorResult, \
+    MicrosoftEstimatorParams, QubitParams
 
 
 class TestMicrosoftQC(QuantumTestBase):
@@ -147,7 +148,7 @@ class TestMicrosoftQC(QuantumTestBase):
         params = MicrosoftEstimatorParams()
 
         params.error_budget = 0.1
-        params.qubit_params.name = "qubit_gate_ns_e3"
+        params.qubit_params.name = QubitParams.GATE_NS_E3
         params.qubit_params.instruction_set = "gate_based"
         params.qubit_params.t_gate_error_rate = 0.03
         params.qubit_params.t_gate_time = "10 ns"


### PR DESCRIPTION
To avoid typos for the default parameters, I added constants for default qubit parameter models and QEC schemes.