### PR TITLE
Pin urllib3 for E2E tests

### DIFF
--- a/azure-quantum/tests.live/Run.ps1
+++ b/azure-quantum/tests.live/Run.ps1
@@ -105,6 +105,9 @@ if ($PackageDir -Match "azure-quantum") {
     Copy-Item -Path (Join-Path $PackageDir "tests" "unit" "*.qs") -Destination $PSScriptRoot
 }
 
+# Pin urllib3 for compatibility with vcrpy
+pip install urllib3==1.26.15
+
 python -m pytest -v `
     --junitxml=junit/test-results.xml `
     --log-level=INFO `

--- a/azure-quantum/tests.live/Run.ps1
+++ b/azure-quantum/tests.live/Run.ps1
@@ -106,6 +106,7 @@ if ($PackageDir -Match "azure-quantum") {
 }
 
 # Pin urllib3 for compatibility with vcrpy
+Write-Host "##[info]Install version of urllib3 that is compatible with vcrpy"
 pip install urllib3==1.26.15
 
 python -m pytest -v `

--- a/build/set-env.ps1
+++ b/build/set-env.ps1
@@ -23,3 +23,6 @@ $RequirementsTxt = Join-Path $PSScriptRoot "../azure-quantum/requirements.txt"
 (Get-Content $RequirementsTxt) `
     -replace 'azure-core>=1.21.1', 'azure-core>=1.19.1' |
   Out-File $RequirementsTxt
+
+# Pin urllib3 for compatibility with vcrpy
+Add-Content $RequirementsTxt "`nurllib3==1.26.15"

--- a/build/set-env.ps1
+++ b/build/set-env.ps1
@@ -23,6 +23,3 @@ $RequirementsTxt = Join-Path $PSScriptRoot "../azure-quantum/requirements.txt"
 (Get-Content $RequirementsTxt) `
     -replace 'azure-core>=1.21.1', 'azure-core>=1.19.1' |
   Out-File $RequirementsTxt
-
-# Pin urllib3 for compatibility with vcrpy
-Add-Content $RequirementsTxt "`nurllib3==1.26.15"

--- a/build/test.ps1
+++ b/build/test.ps1
@@ -17,12 +17,6 @@ param (
 
 Import-Module (Join-Path $PSScriptRoot "package-utils.psm1");
 
-
-
-# Pin urllib3 for compatibility with vcrpy
-Write-Host "##[info]Install version of urllib3 that is compatible with vcrpy"
-pip install urllib3==1.26.15
-
 if ($Env:ENABLE_PYTHON -eq "false") {
   Write-Host "##vso[task.logissue type=warning;]Skipping testing Python packages. Env:ENABLE_PYTHON was set to 'false'."
 } else {

--- a/build/test.ps1
+++ b/build/test.ps1
@@ -17,6 +17,12 @@ param (
 
 Import-Module (Join-Path $PSScriptRoot "package-utils.psm1");
 
+
+
+# Pin urllib3 for compatibility with vcrpy
+Write-Host "##[info]Install version of urllib3 that is compatible with vcrpy"
+pip install urllib3==1.26.15
+
 if ($Env:ENABLE_PYTHON -eq "false") {
   Write-Host "##vso[task.logissue type=warning;]Skipping testing Python packages. Env:ENABLE_PYTHON was set to 'false'."
 } else {
@@ -32,10 +38,6 @@ if ($Env:ENABLE_PYTHON -eq "false") {
         Write-Host "##vso[task.logissue type=error;]Tests for package $PackageName failed."
       }
     }
-
-    # Pin urllib3 for compatibility with vcrpy
-    Write-Host "##[info]Install version of urllib3 that is compatible with vcrpy"
-    pip install urllib3==1.26.15
 
     "Returning: $ExitCode" | Write-Host
     exit $ExitCode;

--- a/build/test.ps1
+++ b/build/test.ps1
@@ -32,6 +32,11 @@ if ($Env:ENABLE_PYTHON -eq "false") {
         Write-Host "##vso[task.logissue type=error;]Tests for package $PackageName failed."
       }
     }
+
+    # Pin urllib3 for compatibility with vcrpy
+    Write-Host "##[info]Install version of urllib3 that is compatible with vcrpy"
+    pip install urllib3==1.26.15
+
     "Returning: $ExitCode" | Write-Host
     exit $ExitCode;
 }

--- a/build/test.ps1
+++ b/build/test.ps1
@@ -20,6 +20,11 @@ Import-Module (Join-Path $PSScriptRoot "package-utils.psm1");
 if ($Env:ENABLE_PYTHON -eq "false") {
   Write-Host "##vso[task.logissue type=warning;]Skipping testing Python packages. Env:ENABLE_PYTHON was set to 'false'."
 } else {
+
+  # Pin urllib3 for compatibility
+  $EnvironmentFile = Join-Path $PSScriptRoot "../azure-quantum/environment.yml"
+  Add-Content $EnvironmentFile "`n    - urllib3=1.26.15"
+
   $PackageNames = PackagesList -PackageName $PackageName
   $ExitCode = 0;
   foreach ($PackageName in $PackageNames) {


### PR DESCRIPTION
vcrpy is incompatible with urllib3 2.0.2, so this pins urllib3 to an older version.