### PR TITLE
Pin urllib3 to fix issue with vcrpy

### DIFF
--- a/azure-quantum/requirements-dev.txt
+++ b/azure-quantum/requirements-dev.txt
@@ -1,2 +1,9 @@
-azure-devtools>=1.2.0,<2.0
+# The following lines are to be removed 
+# after https://github.com/kevin1024/vcrpy/issues/688 is fixed
+# and azure-devtools adopts the fix from vcrpy.
+urllib3==1.26.14
+vcrpy==4.2.1
+azure-devtools==1.2.0
+# And uncomment the following line
+# azure-devtools>1.2.0,<2.0
 asyncmock>=0.4.0,<1.0


### PR DESCRIPTION
Replaces (and based on) #464.

`vcrpy` is incompatible with the latest `urllib3` `2.0.2` (https://github.com/kevin1024/vcrpy/issues/688).

This PR is a temporary workaround to pin some older versions of the dependencies to unblock our test pipelines.

We take an indirect dependency on `vcrpy` and `urllib3` from the `azure-devtool` package, which contains the Azure SDK test infrastructure.
Once `vcrpy` is fixed and `azure-devtool` picks the fix, we can undo this workaround.