### PR TITLE
Let E2E tests use the latest released package

### DIFF
--- a/azure-quantum/tests.live/Install-Artifacts.ps1
+++ b/azure-quantum/tests.live/Install-Artifacts.ps1
@@ -23,7 +23,7 @@ if (-not $Env:PYTHON_OUTDIR) {
     "== We will install $PackageName from source." | Write-Host
     "" | Write-Host
 
-    Install-PackageInEnv -PackageName $PackageName -FromSource $True
+    Install-PackageInEnv -PackageName "$PackageName[all]" -FromSource $True
 
     "" | Write-Host
     "== $PackageName installed from source. ==" | Write-Host
@@ -43,9 +43,9 @@ elseif (($Env:PICK_QDK_VERSION -eq "auto") -and ([string]::IsNullOrEmpty($Packag
     "== Preparing environment to use artifacts with version '$Env:PYTHON_VERSION' " | Write-Host
     "== from '$Env:PYTHON_OUTDIR'" | Write-Host
     if ($Env:PYTHON_VERSION) {
-        $NameAndVersion = "$PackageName==$($Env:PYTHON_VERSION)"
+        $NameAndVersion = "$PackageName[all]==$($Env:PYTHON_VERSION)"
     } else {
-        $NameAndVersion = $PackageName
+        $NameAndVersion = "$PackageName[all]"
     }
     
     Install-PackageInEnv -PackageName $NameAndVersion -FromSource $False -BuildArtifactPath $Env:PYTHON_OUTDIR

--- a/azure-quantum/tests.live/Install-Artifacts.ps1
+++ b/azure-quantum/tests.live/Install-Artifacts.ps1
@@ -34,6 +34,11 @@ if (-not $Env:PYTHON_OUTDIR) {
     "== To use build artifacts, download the artifacts locally and point the variable to this folder." | Write-Warning
     "" | Write-Warning
     Exit 1
+} 
+# this condition is used by the E2E Live test pipeline
+elseif (($Env:PICK_QDK_VERSION -eq "auto") -and ([string]::IsNullOrEmpty($PackageName) -or ($PackageName -eq "azure-quantum"))) {
+    "== Installing latest published azure-quantum package from PyPI..." | Write-Host
+    Install-PackageInEnv -PackageName $PackageName -FromSource $False
 } else {
     "== Preparing environment to use artifacts with version '$Env:PYTHON_VERSION' " | Write-Host
     "== from '$Env:PYTHON_OUTDIR'" | Write-Host

--- a/azure-quantum/tests.live/Install-Artifacts.ps1
+++ b/azure-quantum/tests.live/Install-Artifacts.ps1
@@ -36,8 +36,8 @@ if (-not $Env:PYTHON_OUTDIR) {
     Exit 1
 } 
 # this condition is used by the E2E Live test pipeline
-elseif (($Env:PICK_QDK_VERSION -eq "auto") -and ([string]::IsNullOrEmpty($PackageName) -or ($PackageName -eq "azure-quantum"))) {
-    "== Installing latest published azure-quantum package from PyPI..." | Write-Host
+elseif ($Env:PICK_QDK_VERSION -eq "auto") {
+    "== Installing latest published $PackageName package from PyPI..." | Write-Host
     Install-PackageInEnv -PackageName $PackageName -FromSource $False
 } else {
     "== Preparing environment to use artifacts with version '$Env:PYTHON_VERSION' " | Write-Host

--- a/azure-quantum/tests/README.md
+++ b/azure-quantum/tests/README.md
@@ -114,3 +114,30 @@ Example:
 ```bash
 pytest -k test_job_refresh
 ```
+
+## E2E Live Test Pipeline
+
+We have a private E2E test pipeline that run all the tests against
+a live environment on a regular basis.
+
+By default that pipeline will use the latest tests from the `main` branch
+of this repository, but will install the latest released `azure-quantum` package from PyPI.
+
+That can create an issue if you add tests for a new feature that has not been
+released/published yet, since the tests will expect that feature but the current released
+package does not have it.
+
+To mitigate this issue you can add a `pytest.mark.skipif` mark to those new tests if the version
+if less or equal to the latest published version.
+
+For example:
+
+```python
+import pytest
+from azure.quantum.version import __version__
+skip_older_version = pytest.mark.skipif(__version__ != "0.0.1" and __version__ <= "0.28.263081", reason="Test requires the version to be > 0.28.263081.")
+
+@skip_older_version
+def test_my_test(self):
+    pass
+```

--- a/build/install-iqsharp.ps1
+++ b/build/install-iqsharp.ps1
@@ -22,7 +22,8 @@ pip install --user `
 $iqsharpNugetPackage = "Microsoft.Quantum.IQSharp.$nugetVersion.nupkg"
 $iqsharpNugetPackagePath = !($Env:NUGET_OUTDIR) ? $iqsharpNugetPackage : (Join-Path $Env:NUGET_OUTDIR $iqsharpNugetPackage)
 
-if (Test-Path $iqsharpNugetPackagePath -PathType Leaf) {
+# PICK_QDK_VERSION="auto" is used by the E2E Live test pipeline by default
+if ((Test-Path $iqsharpNugetPackagePath -PathType Leaf) -and ($Env:PICK_QDK_VERSION -ne "auto")) {
     # Uninstall if different version is already installed
     try {
         $currentInstalledVersion = dotnet tool list --tool-path $Env:TOOLS_DIR | Select-String -Pattern "microsoft.quantum.iqsharp\s+(.*)\s+" | foreach { $matches[1] }

--- a/build/install-iqsharp.ps1
+++ b/build/install-iqsharp.ps1
@@ -23,7 +23,11 @@ $iqsharpNugetPackage = "Microsoft.Quantum.IQSharp.$nugetVersion.nupkg"
 $iqsharpNugetPackagePath = !($Env:NUGET_OUTDIR) ? $iqsharpNugetPackage : (Join-Path $Env:NUGET_OUTDIR $iqsharpNugetPackage)
 
 # PICK_QDK_VERSION="auto" is used by the E2E Live test pipeline by default
-if ((Test-Path $iqsharpNugetPackagePath -PathType Leaf) -and ($Env:PICK_QDK_VERSION -ne "auto")) {
+if ($Env:PICK_QDK_VERSION -eq "auto") {    
+    Write-Host "Installing the $nugetVersion published IQ# dotnet tool"
+    dotnet tool install Microsoft.Quantum.IQSharp --tool-path $Env:TOOLS_DIR | Write-Host
+}
+elseif (Test-Path $iqsharpNugetPackagePath -PathType Leaf) {
     # Uninstall if different version is already installed
     try {
         $currentInstalledVersion = dotnet tool list --tool-path $Env:TOOLS_DIR | Select-String -Pattern "microsoft.quantum.iqsharp\s+(.*)\s+" | foreach { $matches[1] }

--- a/build/package-utils.psm1
+++ b/build/package-utils.psm1
@@ -32,16 +32,16 @@ function Install-Package() {
         $ParentPath = Split-Path -parent $PSScriptRoot
         $AbsPackageName = Join-Path $ParentPath $PackageName
         Write-Host "##[info]Install package $AbsPackageName in development mode for env $EnvName"
-        pip install -e $AbsPackageName
+        pip install -e "$AbsPackageName[all]"
     } elseif ("" -ne $BuildArtifactPath) {
         Write-Host "##[info]Installing $PackageName from $BuildArtifactPath"
         Push-Location $BuildArtifactPath
-            pip install $PackageName --pre --find-links $BuildArtifactPath
+            pip install "$PackageName[all]" --pre --find-links $BuildArtifactPath
             if ($LASTEXITCODE -ne 0) { throw "Error installing qsharp-core wheel" }
         Pop-Location
     } else {
-        Write-Host "##[info]Install package $PackageName for env $EnvName"
-        pip install $PackageName
+        Write-Host "##[info]Install package $PackageName for env $EnvName from PyPI"
+        pip install "$PackageName[all]"
     }
 }
 

--- a/build/package-utils.psm1
+++ b/build/package-utils.psm1
@@ -32,16 +32,16 @@ function Install-Package() {
         $ParentPath = Split-Path -parent $PSScriptRoot
         $AbsPackageName = Join-Path $ParentPath $PackageName
         Write-Host "##[info]Install package $AbsPackageName in development mode for env $EnvName"
-        pip install -e "$AbsPackageName[all]"
+        pip install -e $AbsPackageName
     } elseif ("" -ne $BuildArtifactPath) {
         Write-Host "##[info]Installing $PackageName from $BuildArtifactPath"
         Push-Location $BuildArtifactPath
-            pip install "$PackageName[all]" --pre --find-links $BuildArtifactPath
+            pip install $PackageName --pre --find-links $BuildArtifactPath
             if ($LASTEXITCODE -ne 0) { throw "Error installing qsharp-core wheel" }
         Pop-Location
     } else {
-        Write-Host "##[info]Install package $PackageName for env $EnvName from PyPI"
-        pip install "$PackageName[all]"
+        Write-Host "##[info]Install latest package $PackageName for env $EnvName from PyPI"
+        pip install $PackageName
     }
 }
 

--- a/build/package-utils.psm1
+++ b/build/package-utils.psm1
@@ -55,7 +55,7 @@ function GetEnvName {
     #   2. add conda env suffix
     #   3. remove "-" since its invalid
     #   4. remove ".aio" and use the same environment as the non-async version
-    return ($PackageName.Split("=")[0] + $CondaEnvironmentSuffix).replace("-", "").replace(".aio", "")
+    return ($PackageName.Split("[")[0].Split("=")[0] + $CondaEnvironmentSuffix).replace("-", "").replace(".aio", "")
 }
 
 function Install-PackageInEnv {


### PR DESCRIPTION
This PR checks for the environment variable `PICK_QDK_VERSION` that is used by the E2E live test pipeline and when it's set to "auto" (which is the default mode), it will install the latest published `azure-quantum` package from PyPI instead of using the build artifact.

This allows the E2E test pipeline to use the latest test code from the QDK-Python `main` branch while testing against the latest released `azure-quantum` package.