### PR TITLE
Install latest released IQ# for E2E tests

### DIFF
--- a/build/install-iqsharp.ps1
+++ b/build/install-iqsharp.ps1
@@ -24,7 +24,7 @@ $iqsharpNugetPackagePath = !($Env:NUGET_OUTDIR) ? $iqsharpNugetPackage : (Join-P
 
 # PICK_QDK_VERSION="auto" is used by the E2E Live test pipeline by default
 if ($Env:PICK_QDK_VERSION -eq "auto") {    
-    Write-Host "Installing the $nugetVersion published IQ# dotnet tool"
+    Write-Host "Installing the latest published IQ# dotnet tool"
     dotnet tool install Microsoft.Quantum.IQSharp --tool-path $Env:TOOLS_DIR | Write-Host
 }
 elseif (Test-Path $iqsharpNugetPackagePath -PathType Leaf) {
@@ -77,7 +77,12 @@ try {
 # Install the qsharp Python wheel
 $qsharpPythonWheel = "qsharp-$pythonVersion-py3-none-any.whl"
 $qsharpPythonWheelPath = !($Env:PYTHON_OUTDIR) ? $qsharpPythonWheel : (Join-Path $Env:PYTHON_OUTDIR $qsharpPythonWheel)
-if (Test-Path $qsharpPythonWheelPath -PathType Leaf) {
+
+# PICK_QDK_VERSION="auto" is used by the E2E Live test pipeline by default
+if ($Env:PICK_QDK_VERSION -eq "auto") {    
+    Write-Host "Installing the latest published qsharp Python package"
+    pip install --user --verbose qsharp | Write-Host
+} elseif (Test-Path $qsharpPythonWheelPath -PathType Leaf) {
     Write-Host "Installing the qsharp Python wheel from the build drop folder."
     Write-Host "  Wheel: $qsharpPythonWheelPath"
     Write-Host "  Source: $Env:PYTHON_OUTDIR"


### PR DESCRIPTION
Fixes and complements #471 letting the E2E test pipeline to use the latest released IQ# instead of installing from the build artifacts.