### PR TITLE
Reverted the temporary workaround of pull/468.

### DIFF
--- a/azure-quantum/requirements-dev.txt
+++ b/azure-quantum/requirements-dev.txt
@@ -1,9 +1,2 @@
-# The following lines are to be removed 
-# after https://github.com/kevin1024/vcrpy/issues/688 is fixed
-# and azure-devtools adopts the fix from vcrpy.
-urllib3==1.26.14
-vcrpy==4.2.1
-azure-devtools==1.2.0
-# And uncomment the following line
-# azure-devtools>1.2.0,<2.0
+azure-devtools>1.2.0,<2.0
 asyncmock>=0.4.0,<1.0


### PR DESCRIPTION
Get back to this PR once the [azure-devtools](https://pypi.org/project/azure-devtools/#history) gets a version above 1.2.0.