### PR TITLE
Bump vcrpy and fix issues with urllib3

### DIFF
--- a/azure-quantum/requirements-dev.txt
+++ b/azure-quantum/requirements-dev.txt
@@ -1,9 +1,2 @@
-# The following lines are to be removed 
-# after https://github.com/kevin1024/vcrpy/issues/688 is fixed
-# and azure-devtools adopts the fix from vcrpy.
-urllib3==1.26.14
-vcrpy==4.2.1
-azure-devtools==1.2.0
-# And uncomment the following line
-# azure-devtools>1.2.0,<2.0
-asyncmock>=0.4.0,<1.0
+vcrpy>=4.3.1 # fixes https://github.com/kevin1024/vcrpy/issues/688
+azure-devtools>=1.2.0,<2.0


### PR DESCRIPTION
This PR reverts #468 (mitigation for https://github.com/kevin1024/vcrpy/issues/688) and bump vcrpy to a version `>=4.3.1` which includes the fix.

We can merge after our internal pipelines (QDK Release and E2E tests) succeed on this branch.