### PR TITLE
Fixing CI

### DIFF
--- a/qdk/environment.yml
+++ b/qdk/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - ipywidgets==8.0.4 # version 8.0.5 causes JsmolView to break. See: https://github.com/fekad/jupyter-jsmol/issues/58
   - ruamel.yaml
   - varname
+  - notebook=6.5.4   # TODO(kuzminrobin, #485): Eventually this line needs to be removed and code adapted to the change.
   - pip:
     - basis_set_exchange
     - jupyter_jsmol


### PR DESCRIPTION
Freezing as notebook=6.5.4 to work around the 7.0.0 build break. Details: #485