### PR TITLE
Fixing CI

### DIFF
--- a/qdk/environment.yml
+++ b/qdk/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - ipywidgets==8.0.4 # version 8.0.5 causes JsmolView to break. See: https://github.com/fekad/jupyter-jsmol/issues/58
   - ruamel.yaml
   - varname
+  - notebook=6.5.4   # TODO(kuzminrobin, #485): Eventually this line needs to be removed and code adapted to the change.
   - pip:
     - basis_set_exchange
     - jupyter_jsmol


### PR DESCRIPTION
Freezing as notebook=6.5.4 to work around the 7.0.0 build break. Details: #485

Group PR.

QDK (368)
* [IQ#](https://github.com/microsoft/iqsharp/pull/800)
* [Q# Compiler](https://github.com/microsoft/qsharp-compiler/pull/1621)
* [qsharp-runtime](https://github.com/microsoft/qsharp-runtime/pull/1148)
* [Quantum](https://github.com/microsoft/Quantum/pull/815)
* [Quantum-NC](https://github.com/microsoft/Quantum-NC/pull/91)
* [QuantumKatas](https://github.com/microsoft/QuantumKatas/pull/888)
* [QuantumLibraries](https://github.com/microsoft/QuantumLibraries/pull/679)
* private repo (19643)
* [qdk-python](https://github.com/microsoft/qdk-python/pull/488)