### PR TITLE
Add json property to RE result

### DIFF
--- a/azure-quantum/azure/quantum/target/microsoft/result.py
+++ b/azure-quantum/azure/quantum/target/microsoft/result.py
@@ -154,6 +154,17 @@ class MicrosoftEstimatorResult(dict):
         plt.legend(loc="upper left")
         plt.show()
 
+    @property
+    def json(self):
+        """
+        Returns a JSON representation of the resource estimation result data.
+        """
+        if not hasattr(self, "_json"):
+            import json
+            self._json = json.dumps(self._data)
+
+        return self._json
+
     def _summary_data_frame(self, **kwargs):
         try:
             import pandas as pd

--- a/azure-quantum/tests/unit/test_microsoft_qc.py
+++ b/azure-quantum/tests/unit/test_microsoft_qc.py
@@ -29,6 +29,19 @@ class TestMicrosoftQC(QuantumTestBase):
         bitcode_filename = path.join(path.dirname(__file__), "qir", "ccnot.bc")
         with open(bitcode_filename, "rb") as f:
             return f.read()
+        
+    def _mock_result_data(self) -> dict:
+        """
+        A small result data for tests.
+        """
+        return {
+            "physicalCounts": {
+                "physicalQubits": 655321,
+                "runtime": 1729,
+                "rqops": 314
+            },
+            "reportData": {"groups": [], "assumptions": []}
+        }
 
     @pytest.mark.microsoft_qc
     @pytest.mark.live_test
@@ -423,3 +436,17 @@ class TestMicrosoftQC(QuantumTestBase):
         assert specification.as_dict() == {
             "numUnitQubits": 1, "durationInQubitCycleTime": 2
         }
+
+    def test_simple_result_as_json(self):
+        data = self._mock_result_data()
+        result = MicrosoftEstimatorResult(data)
+
+        import json
+        assert json.loads(result.json) == data
+
+    def test_batch_result_as_json(self):
+        data = [self._mock_result_data(), self._mock_result_data()]
+        result = MicrosoftEstimatorResult(data)
+
+        import json
+        assert json.loads(result.json) == data


### PR DESCRIPTION
Allows you to call `result.json` where `result` is a resource estimation result to get the JSON representation of its data.