### PR TITLE
Fixed relative links

### DIFF
--- a/azure-quantum/README.md
+++ b/azure-quantum/README.md
@@ -78,7 +78,7 @@ result = job.get_results()
 
 ## Examples ##
 
-You can find example Python scripts that use the Azure Quantum Python API in the [examples](./examples/) directory.
+You can find example Python scripts that use the Azure Quantum Python API in the [examples](https://github.com/microsoft/qdk-python/tree/main/azure-quantum/examples) directory.
 
 ## Contributing ##
 

--- a/azure-quantum/examples/README.md
+++ b/azure-quantum/examples/README.md
@@ -1,3 +1,3 @@
 # Azure Quantum Python API examples
 
-* [Resource estimator examples](./resource_estimation/)
+* [Resource estimator examples](https://github.com/microsoft/qdk-python/tree/main/azure-quantum/examples/resource_estimation)

--- a/azure-quantum/examples/resource_estimation/README.md
+++ b/azure-quantum/examples/resource_estimation/README.md
@@ -8,7 +8,7 @@ Quantum Resource Estimator through the `azure_quantum` Python API.
 Some of the scripts require a resource id and a location, which can be obtained
 from the _Overview_ page of your _Azure Quantum workspace_.
 
-* **[cli.py](./cli.py): A resource estimation CLI that can execute resource
+* **[cli.py](https://github.com/microsoft/qdk-python/blob/main/azure-quantum/examples/resource_estimation/cli.py): A resource estimation CLI that can execute resource
   estimation jobs from various input formats and generate JSON output.**
 
   The input type is determined by file extension:


### PR DESCRIPTION
Replaced relative links with absolute links.
Relative links are not allowed. This breaks SDL.vnex pipeline.