### PR TITLE
Avoid mutating input parameters during target submission

### DIFF
--- a/azure-quantum/azure/quantum/target/target.py
+++ b/azure-quantum/azure/quantum/target/target.py
@@ -238,7 +238,7 @@ target '{self.name}' of provider '{self.provider_id}' not found."
         if isinstance(input_params, InputParams):
             input_params = input_params.as_dict()
         else:
-            input_params = input_params or {}
+            input_params = dict(input_params) if input_params is not None else {}
         input_data_format = None
         output_data_format = None
         content_type = None

--- a/azure-quantum/azure/quantum/target/target.py
+++ b/azure-quantum/azure/quantum/target/target.py
@@ -8,6 +8,7 @@ import io
 import json
 import abc
 import warnings
+import copy
 
 from azure.quantum._client.models import TargetStatus
 from azure.quantum.job.job import Job
@@ -238,7 +239,7 @@ target '{self.name}' of provider '{self.provider_id}' not found."
         if isinstance(input_params, InputParams):
             input_params = input_params.as_dict()
         else:
-            input_params = dict(input_params) if input_params is not None else {}
+            input_params = copy.deepcopy(input_params or {})
         input_data_format = None
         output_data_format = None
         content_type = None

--- a/azure-quantum/tests/test_target.py
+++ b/azure-quantum/tests/test_target.py
@@ -1,0 +1,53 @@
+##
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+##
+
+import copy
+from unittest import mock
+from azure.quantum.target.target import Target
+
+from mock_client import WorkspaceMock
+from common import (
+    SUBSCRIPTION_ID,
+    RESOURCE_GROUP,
+    WORKSPACE,
+)
+
+def test_target_submit_does_not_mutate_input_params():
+    ws = WorkspaceMock(
+        subscription_id=SUBSCRIPTION_ID,
+        resource_group=RESOURCE_GROUP,
+        name=WORKSPACE,
+    )
+    target = Target(
+        workspace=ws,
+        name="fake.target",
+        provider_id="fake-provider",
+        input_data_format="fake-input-format",
+        output_data_format="fake-output-format",
+    )
+    input_params = {
+        "someOption": "someValue",
+        "nested": {
+            "innerOption": "innerValue",
+            "list": [1, 2, 3],
+        },
+    }
+    original = copy.deepcopy(input_params)
+
+    with mock.patch(
+        "azure.quantum.job.base_job.BaseJob.upload_input_data",
+        return_value="https://example.com/blob",
+    ):
+        target.submit(
+            name="test-job",
+            shots=10,
+            input_data=b"fake-ir",
+            input_params=input_params,
+        )
+
+    assert input_params == original
+    assert "shots" not in input_params
+    assert input_params["nested"]["innerOption"] == "innerValue"
+    assert input_params["nested"]["list"] == [1, 2, 3]

--- a/azure-quantum/tests/test_workspace.py
+++ b/azure-quantum/tests/test_workspace.py
@@ -400,7 +400,13 @@ def test_target_submit_does_not_mutate_input_params():
         input_data_format="fake-input-format",
         output_data_format="fake-output-format",
     )
-    input_params = {"someOption": "someValue"}
+    input_params = {
+        "someOption": "someValue",
+        "nested": {
+            "innerOption": "innerValue",
+            "list": [1, 2, 3],
+        },
+    }
     original = copy.deepcopy(input_params)
 
     with mock.patch(
@@ -416,6 +422,8 @@ def test_target_submit_does_not_mutate_input_params():
 
     assert input_params == original
     assert "shots" not in input_params
+    assert input_params["nested"]["innerOption"] == "innerValue"
+    assert input_params["nested"]["list"] == [1, 2, 3]
 
 
 def test_workspace_user_agent_appid():

--- a/azure-quantum/tests/test_workspace.py
+++ b/azure-quantum/tests/test_workspace.py
@@ -3,9 +3,11 @@
 # Licensed under the MIT License.
 ##
 
+import copy
 import os
 from unittest import mock
 from azure.quantum.job.job import Job
+from azure.quantum.target.target import Target
 from azure.quantum._client.models import JobDetails
 from azure.quantum._constants import EnvironmentVariables, ConnectionConstants
 from azure.core.credentials import AzureKeyCredential
@@ -383,6 +385,37 @@ def test_workspace_cancel_job_success():
 
     assert result.details.status == "Cancelled"
     assert result.id == job_id
+
+
+def test_target_submit_does_not_mutate_input_params():
+    ws = WorkspaceMock(
+        subscription_id=SUBSCRIPTION_ID,
+        resource_group=RESOURCE_GROUP,
+        name=WORKSPACE,
+    )
+    target = Target(
+        workspace=ws,
+        name="fake.target",
+        provider_id="fake-provider",
+        input_data_format="fake-input-format",
+        output_data_format="fake-output-format",
+    )
+    input_params = {"someOption": "someValue"}
+    original = copy.deepcopy(input_params)
+
+    with mock.patch(
+        "azure.quantum.job.base_job.BaseJob.upload_input_data",
+        return_value="https://example.com/blob",
+    ):
+        target.submit(
+            name="test-job",
+            shots=10,
+            input_data=b"fake-ir",
+            input_params=input_params,
+        )
+
+    assert input_params == original
+    assert "shots" not in input_params
 
 
 def test_workspace_user_agent_appid():

--- a/azure-quantum/tests/test_workspace.py
+++ b/azure-quantum/tests/test_workspace.py
@@ -3,11 +3,9 @@
 # Licensed under the MIT License.
 ##
 
-import copy
 import os
 from unittest import mock
 from azure.quantum.job.job import Job
-from azure.quantum.target.target import Target
 from azure.quantum._client.models import JobDetails
 from azure.quantum._constants import EnvironmentVariables, ConnectionConstants
 from azure.core.credentials import AzureKeyCredential
@@ -385,45 +383,6 @@ def test_workspace_cancel_job_success():
 
     assert result.details.status == "Cancelled"
     assert result.id == job_id
-
-
-def test_target_submit_does_not_mutate_input_params():
-    ws = WorkspaceMock(
-        subscription_id=SUBSCRIPTION_ID,
-        resource_group=RESOURCE_GROUP,
-        name=WORKSPACE,
-    )
-    target = Target(
-        workspace=ws,
-        name="fake.target",
-        provider_id="fake-provider",
-        input_data_format="fake-input-format",
-        output_data_format="fake-output-format",
-    )
-    input_params = {
-        "someOption": "someValue",
-        "nested": {
-            "innerOption": "innerValue",
-            "list": [1, 2, 3],
-        },
-    }
-    original = copy.deepcopy(input_params)
-
-    with mock.patch(
-        "azure.quantum.job.base_job.BaseJob.upload_input_data",
-        return_value="https://example.com/blob",
-    ):
-        target.submit(
-            name="test-job",
-            shots=10,
-            input_data=b"fake-ir",
-            input_params=input_params,
-        )
-
-    assert input_params == original
-    assert "shots" not in input_params
-    assert input_params["nested"]["innerOption"] == "innerValue"
-    assert input_params["nested"]["list"] == [1, 2, 3]
 
 
 def test_workspace_user_agent_appid():


### PR DESCRIPTION
Avoid mutating input parameters during target submission

### Summary

This PR updates target job submission so that default or provider-specific parameters are added to a copied input parameter dictionary instead of mutating the caller-provided dictionary directly.

### Motivation

Currently, submitting a job can modify the original `input_params` dictionary passed by the caller. This can cause unexpected behavior when the same dictionary is reused for a later submission, because parameters added during the first submission remain present for the second one.

This is especially confusing when default parameters are meant to apply only to the outgoing job payload, not to the user's original Python object.

Some providers require shots to be passed separately while others take it as part of input_params so functionality could not simply be removed 

### Changes

- Create a deep copy of `input_params` before adding submission-specific/default parameters.
- Preserve the original caller-provided dictionary and any nested structures passed in it.
- Prevent reused `input_params` dictionaries from retaining parameters added during a previous submission.

### Testing

- [ ] Verified `Target.submit` does not mutate a caller-provided `input_params` dictionary when `shots` is passed separately.
- [ ] Verified the same `input_params` dictionary can be reused across submissions without retaining SDK-added parameters.
- [ ] Verified nested/inherited `input_params` structures remain unchanged.
- [ ] Ran targeted real-job validation against `quantinuum.sim.h2-1sc`.

- [ ] Simple mock target Unit test added for regression testing
- [ ] Added new test file test_target.py 
