### PR TITLE
Use AzureArtifacts feed instead of directly PyPi feed

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -42,6 +42,8 @@ variables:
     value: none # Disable usage telemetry for internal test pipelines
   - name: PYTEST_MAX_PARALLEL_TESTS
     value: "auto"
+  - name: PipFeed
+    value: "AzureQuantum/azure-quantum"
 
 resources:
   repositories:
@@ -76,6 +78,12 @@ extends:
                   versionSpec: "3.11"
                 displayName: Set Python version
 
+              - task: PipAuthenticate@1
+                displayName: Authenticate pip to Azure Artifacts feed
+                inputs:
+                  artifactFeeds: $(PipFeed)
+                  onlyAddExtraIndex: false
+
               - script: |
                   pip install wheel
                 displayName: Install wheel
@@ -108,6 +116,12 @@ extends:
                 inputs:
                   versionSpec: "3.11"
                 displayName: Set Python version
+
+              - task: PipAuthenticate@1
+                displayName: Authenticate pip to Azure Artifacts feed
+                inputs:
+                  artifactFeeds: $(PipFeed)
+                  onlyAddExtraIndex: false
 
               - script: |
                   python -m pip install --upgrade pip
@@ -169,6 +183,12 @@ extends:
                 inputs:
                   versionSpec: "3.11"
                 displayName: Set Python version
+
+              - task: PipAuthenticate@1
+                displayName: Authenticate pip to Azure Artifacts feed
+                inputs:
+                  artifactFeeds: $(PipFeed)
+                  onlyAddExtraIndex: false
 
               - script: |
                   python $(Pipeline.Workspace)/azure-quantum-wheels/set_version.py

--- a/azure-quantum/tox.ini
+++ b/azure-quantum/tox.ini
@@ -8,6 +8,11 @@ basepython =
     py311: python3.11
     py312: python3.12
     py313: python3.13
+# Forward the pip index/auth configured by PipAuthenticate@1 into tox's isolated
+# environments so package restores go through the Azure Artifacts feed (CFS policy).
+passenv =
+    PIP_INDEX_URL
+    PIP_EXTRA_INDEX_URL
 allowlist_externals = pytest
 deps =
     qiskit1: qiskit<2


### PR DESCRIPTION
Changes the publish pipeline to use the AzureArtifacts feed instead of directly pulling from the PyPi feed.