### PR TITLE
Update `tox` Environments to Explicitly Use Azure Feed

### DIFF
--- a/.ado/ci.yml
+++ b/.ado/ci.yml
@@ -17,6 +17,14 @@ variables:
     value: none # Disable usage telemetry for internal test pipelines
   - name: PYTEST_MAX_PARALLEL_TESTS
     value: "auto"
+  # Azure Artifacts feed (with a PyPI upstream source) that pip restores from, so the
+  # build does not connect directly to public pypi.org / files.pythonhosted.org (CFS).
+  # Project-scoped: "<Project>/<FeedName>".
+  - name: PipFeed
+    value: "AzureQuantum/azure-quantum"
+  # Stop pip from contacting pypi.org for its "is there a newer pip?" self-check.
+  - name: PIP_DISABLE_PIP_VERSION_CHECK
+    value: "1"
 
 jobs:
   - job: "Build_Azure_Quantum_Python"
@@ -29,6 +37,12 @@ jobs:
         inputs:
           versionSpec: "3.11"
         displayName: Set Python version
+
+      - task: PipAuthenticate@1
+        displayName: Authenticate pip to Azure Artifacts feed
+        inputs:
+          artifactFeeds: $(PipFeed)
+          onlyAddExtraIndex: false
 
       - script: |
           pip install wheel
@@ -58,6 +72,12 @@ jobs:
         inputs:
           versionSpec: "3.11"
         displayName: Set Python version
+
+      - task: PipAuthenticate@1
+        displayName: Authenticate pip to Azure Artifacts feed
+        inputs:
+          artifactFeeds: $(PipFeed)
+          onlyAddExtraIndex: false
 
       - script: |
           python -m pip install --upgrade pip

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -42,6 +42,8 @@ variables:
     value: none # Disable usage telemetry for internal test pipelines
   - name: PYTEST_MAX_PARALLEL_TESTS
     value: "auto"
+  - name: PipFeed
+    value: "AzureQuantum/azure-quantum"
 
 resources:
   repositories:
@@ -76,6 +78,12 @@ extends:
                   versionSpec: "3.11"
                 displayName: Set Python version
 
+              - task: PipAuthenticate@1
+                displayName: Authenticate pip to Azure Artifacts feed
+                inputs:
+                  artifactFeeds: $(PipFeed)
+                  onlyAddExtraIndex: false
+
               - script: |
                   pip install wheel
                 displayName: Install wheel
@@ -108,6 +116,12 @@ extends:
                 inputs:
                   versionSpec: "3.11"
                 displayName: Set Python version
+
+              - task: PipAuthenticate@1
+                displayName: Authenticate pip to Azure Artifacts feed
+                inputs:
+                  artifactFeeds: $(PipFeed)
+                  onlyAddExtraIndex: false
 
               - script: |
                   python -m pip install --upgrade pip
@@ -169,6 +183,12 @@ extends:
                 inputs:
                   versionSpec: "3.11"
                 displayName: Set Python version
+
+              - task: PipAuthenticate@1
+                displayName: Authenticate pip to Azure Artifacts feed
+                inputs:
+                  artifactFeeds: $(PipFeed)
+                  onlyAddExtraIndex: false
 
               - script: |
                   python $(Pipeline.Workspace)/azure-quantum-wheels/set_version.py

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -144,8 +144,8 @@ extends:
 
               - script: |
                   cd $(Build.SourcesDirectory)/azure-quantum
-                  if defined PIP_INDEX_URL (echo PIP_INDEX_URL is set) else (echo PIP_INDEX_URL is NOT set)
-                  tox -e py311-qiskit1,py311-qiskit2 -v
+                  python -c "import os, urllib.parse as u; h = u.urlsplit(os.environ.get('PIP_INDEX_URL', '')).hostname or '(unset -> default pypi.org)'; print('pip index host:', h)"
+                  tox -e py311-qiskit1,py311-qiskit2
                 displayName: Run Qiskit matrix tests
 
               - task: PublishTestResults@2

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -44,6 +44,10 @@ variables:
     value: "auto"
   - name: PipFeed
     value: "AzureQuantum/azure-quantum"
+  # Stop pip from contacting pypi.org for its "is there a newer pip?" self-check.
+  # This version check ignores PIP_INDEX_URL and is a common lingering CFS offender.
+  - name: PIP_DISABLE_PIP_VERSION_CHECK
+    value: "1"
 
 resources:
   repositories:
@@ -140,7 +144,8 @@ extends:
 
               - script: |
                   cd $(Build.SourcesDirectory)/azure-quantum
-                  tox -e py311-qiskit1,py311-qiskit2
+                  if defined PIP_INDEX_URL (echo PIP_INDEX_URL is set) else (echo PIP_INDEX_URL is NOT set)
+                  tox -e py311-qiskit1,py311-qiskit2 -v
                 displayName: Run Qiskit matrix tests
 
               - task: PublishTestResults@2

--- a/azure-quantum/tox.ini
+++ b/azure-quantum/tox.ini
@@ -8,6 +8,11 @@ basepython =
     py311: python3.11
     py312: python3.12
     py313: python3.13
+# Forward the pip index/auth configured by PipAuthenticate@1 into tox's isolated
+# environments so package restores go through the Azure Artifacts feed (CFS policy).
+passenv =
+    PIP_INDEX_URL
+    PIP_EXTRA_INDEX_URL
 allowlist_externals = pytest
 deps =
     qiskit1: qiskit<2

--- a/azure-quantum/tox.ini
+++ b/azure-quantum/tox.ini
@@ -13,6 +13,13 @@ basepython =
 passenv =
     PIP_INDEX_URL
     PIP_EXTRA_INDEX_URL
+# Explicitly re-assert the feed index inside each isolated environment. Relying on
+# passenv alone proved unreliable (tox's inner pip fell back to pypi.org). The
+# fallback keeps local dev working when PIP_INDEX_URL is unset. Also disable pip's
+# pypi.org version self-check, which ignores the index URL.
+setenv =
+    PIP_INDEX_URL = {env:PIP_INDEX_URL:https://pypi.org/simple}
+    PIP_DISABLE_PIP_VERSION_CHECK = 1
 allowlist_externals = pytest
 deps =
     qiskit1: qiskit<2


### PR DESCRIPTION
Sets up the `tox` environment to use the passed in environment variables to make sure the `tox` environments are using the Azure feed instead of PyPi.